### PR TITLE
vmm_tests: fix serial hangup race in the IOAPIC interrupt-remapping check

### DIFF
--- a/vmm_tests/vmm_tests/tests/tests/multiarch/pcie.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch/pcie.rs
@@ -930,35 +930,13 @@ async fn verify_ioapic_interrupt_remapping(
         "interrupt remapping dmesg lines"
     );
 
-    // `/dev/ttyS0` is the system console, and on a systemd guest there is a
-    // getty on it. `serial-getty@.service` is `Type=idle` with
-    // `TTYVHangup=yes`, so agetty is not actually exec'd until the boot job
-    // queue drains, and when it runs it vhangups the tty. A vhangup marks
-    // every open file for that tty as hung up, so a `write()` that is in
-    // flight fails with `EIO`. Pipette connects before the guest has finished
-    // booting, so the writes below can land in that window. Stop the getty
-    // first (this blocks until any pending start job is cancelled and any
-    // running agetty is reaped) so nothing else owns the tty while the test
-    // drives it.
-    let systemd = cmd!(sh, "test -d /run/systemd/system")
-        .ignore_status()
-        .output()
-        .await?
-        .status
-        .success();
-    if systemd {
-        cmd!(sh, "systemctl stop serial-getty@ttyS0.service")
-            .run()
-            .await?;
-    }
-
     let interrupts = cmd!(sh, "cat /proc/interrupts").read().await?;
     tracing::info!(%interrupts, "/proc/interrupts");
 
     let serial_irq = interrupts
         .lines()
-        .find(|l| l.contains("ttyS0"))
-        .context("serial port IRQ (ttyS0) not present in /proc/interrupts")?;
+        .find(|l| l.contains("ttyS1"))
+        .context("serial port IRQ (ttyS1) not present in /proc/interrupts")?;
     assert!(
         serial_irq.contains("IR-IO-APIC"),
         "serial IRQ should route through the IR-IO-APIC chip once interrupt \
@@ -970,15 +948,15 @@ async fn verify_ioapic_interrupt_remapping(
     // without it a failed write anywhere but the final one is silently ignored.
     cmd!(
         sh,
-        "sh -c 'set -e; for i in $(seq 1 100); do echo ir-remap-test > /dev/ttyS0; done'"
+        "sh -c 'set -e; for i in $(seq 1 100); do echo ir-remap-test > /dev/ttyS1; done'"
     )
     .run()
     .await?;
     let interrupts_after = cmd!(sh, "cat /proc/interrupts").read().await?;
     let serial_irq_after = interrupts_after
         .lines()
-        .find(|l| l.contains("ttyS0"))
-        .context("serial port IRQ (ttyS0) disappeared from /proc/interrupts")?;
+        .find(|l| l.contains("ttyS1"))
+        .context("serial port IRQ (ttyS1) disappeared from /proc/interrupts")?;
     let count_after = sum_irq_count(serial_irq_after);
     tracing::info!(count_before, count_after, "serial IOAPIC interrupt counts");
     assert!(
@@ -993,7 +971,7 @@ async fn verify_ioapic_interrupt_remapping(
 
 /// Sum the per-CPU interrupt counts from a `/proc/interrupts` line.
 ///
-/// A line looks like `" 4:   42    0   IR-IO-APIC   4-edge   ttyS0"`: the
+/// A line looks like `" 4:   42    0   IR-IO-APIC   4-edge   ttyS1"`: the
 /// leading token is the IRQ label and the trailing tokens are the chip and
 /// device name, so only the numeric per-CPU columns in between are summed.
 fn sum_irq_count(line: &str) -> u64 {

--- a/vmm_tests/vmm_tests/tests/tests/multiarch/pcie.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch/pcie.rs
@@ -930,6 +930,28 @@ async fn verify_ioapic_interrupt_remapping(
         "interrupt remapping dmesg lines"
     );
 
+    // `/dev/ttyS0` is the system console, and on a systemd guest there is a
+    // getty on it. `serial-getty@.service` is `Type=idle` with
+    // `TTYVHangup=yes`, so agetty is not actually exec'd until the boot job
+    // queue drains, and when it runs it vhangups the tty. A vhangup marks
+    // every open file for that tty as hung up, so a `write()` that is in
+    // flight fails with `EIO`. Pipette connects before the guest has finished
+    // booting, so the writes below can land in that window. Stop the getty
+    // first (this blocks until any pending start job is cancelled and any
+    // running agetty is reaped) so nothing else owns the tty while the test
+    // drives it.
+    let systemd = cmd!(sh, "test -d /run/systemd/system")
+        .ignore_status()
+        .output()
+        .await?
+        .status
+        .success();
+    if systemd {
+        cmd!(sh, "systemctl stop serial-getty@ttyS0.service")
+            .run()
+            .await?;
+    }
+
     let interrupts = cmd!(sh, "cat /proc/interrupts").read().await?;
     tracing::info!(%interrupts, "/proc/interrupts");
 
@@ -944,9 +966,11 @@ async fn verify_ioapic_interrupt_remapping(
     );
 
     let count_before = sum_irq_count(serial_irq);
+    // `set -e` matters: a `for` loop's status is just its last iteration's, so
+    // without it a failed write anywhere but the final one is silently ignored.
     cmd!(
         sh,
-        "sh -c 'for i in $(seq 1 100); do echo ir-remap-test > /dev/ttyS0; done'"
+        "sh -c 'set -e; for i in $(seq 1 100); do echo ir-remap-test > /dev/ttyS0; done'"
     )
     .run()
     .await?;

--- a/vmm_tests/vmm_tests/tests/tests/multiarch/pcie.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch/pcie.rs
@@ -930,8 +930,23 @@ async fn verify_ioapic_interrupt_remapping(
         "interrupt remapping dmesg lines"
     );
 
-    let interrupts = cmd!(sh, "cat /proc/interrupts").read().await?;
-    tracing::info!(%interrupts, "/proc/interrupts");
+    // `/dev/ttyS1` is used rather than the console `/dev/ttyS0` so nothing else
+    // (kernel console, getty) owns the tty while the test drives it. The 8250
+    // driver only requests the port's IRQ while the port is open, so `ttyS1`
+    // has no `/proc/interrupts` line until then — both snapshots have to be
+    // taken from a shell that is holding the port open. `set -e` matters
+    // because a `for` loop's status is just its last iteration's, so without it
+    // a failed write anywhere but the final one is silently ignored.
+    const SNAPSHOT_SEPARATOR: &str = "===petri-after===";
+    let script = format!(
+        "set -e; exec 3>/dev/ttyS1; cat /proc/interrupts; echo {SNAPSHOT_SEPARATOR}; \
+         for i in $(seq 1 100); do echo ir-remap-test >&3; done; cat /proc/interrupts"
+    );
+    let snapshots = cmd!(sh, "sh -c {script}").read().await?;
+    let (interrupts, interrupts_after) = snapshots
+        .split_once(SNAPSHOT_SEPARATOR)
+        .context("serial IRQ snapshot separator missing")?;
+    tracing::info!(%interrupts, %interrupts_after, "/proc/interrupts");
 
     let serial_irq = interrupts
         .lines()
@@ -944,15 +959,6 @@ async fn verify_ioapic_interrupt_remapping(
     );
 
     let count_before = sum_irq_count(serial_irq);
-    // `set -e` matters: a `for` loop's status is just its last iteration's, so
-    // without it a failed write anywhere but the final one is silently ignored.
-    cmd!(
-        sh,
-        "sh -c 'set -e; for i in $(seq 1 100); do echo ir-remap-test > /dev/ttyS1; done'"
-    )
-    .run()
-    .await?;
-    let interrupts_after = cmd!(sh, "cat /proc/interrupts").read().await?;
     let serial_irq_after = interrupts_after
         .lines()
         .find(|l| l.contains("ttyS1"))
@@ -971,7 +977,7 @@ async fn verify_ioapic_interrupt_remapping(
 
 /// Sum the per-CPU interrupt counts from a `/proc/interrupts` line.
 ///
-/// A line looks like `" 4:   42    0   IR-IO-APIC   4-edge   ttyS1"`: the
+/// A line looks like `" 3:   42    0   IR-IO-APIC   3-edge   ttyS1"`: the
 /// leading token is the IRQ label and the trailing tokens are the chip and
 /// device name, so only the numeric per-CPU columns in between are summed.
 fn sum_irq_count(line: &str) -> u64 {


### PR DESCRIPTION
[amd_iommu_mixed_topology](vscode-file://vscode-app/c:/Users/stevenmalis/AppData/Local/Programs/Microsoft%20VS%20Code/e4c7e7b1d6/resources/app/out/vs/code/electron-browser/workbench/workbench.html) / [intel_vtd_multi_segment](vscode-file://vscode-app/c:/Users/stevenmalis/AppData/Local/Programs/Microsoft%20VS%20Code/e4c7e7b1d6/resources/app/out/vs/code/electron-browser/workbench/workbench.html) intermittently fail with [sh: 1: echo: echo: I/O error](vscode-file://vscode-app/c:/Users/stevenmalis/AppData/Local/Programs/Microsoft%20VS%20Code/e4c7e7b1d6/resources/app/out/vs/code/electron-browser/workbench/workbench.html).

Root cause. The test generates serial IRQs by writing to [ttyS0](vscode-file://vscode-app/c:/Users/stevenmalis/AppData/Local/Programs/Microsoft%20VS%20Code/e4c7e7b1d6/resources/app/out/vs/code/electron-browser/workbench/workbench.html), which is the guest console with [serial-getty@ttyS0.service](vscode-file://vscode-app/c:/Users/stevenmalis/AppData/Local/Programs/Microsoft%20VS%20Code/e4c7e7b1d6/resources/app/out/vs/code/electron-browser/workbench/workbench.html) on it. That unit is [Type=idle](vscode-file://vscode-app/c:/Users/stevenmalis/AppData/Local/Programs/Microsoft%20VS%20Code/e4c7e7b1d6/resources/app/out/vs/code/electron-browser/workbench/workbench.html) + TTYVHangup=yes, so agetty isn't exec'd until systemd's boot job queue drains — and when it runs it vhangups the tty, failing any in-flight [write()](vscode-file://vscode-app/c:/Users/stevenmalis/AppData/Local/Programs/Microsoft%20VS%20Code/e4c7e7b1d6/resources/app/out/vs/code/electron-browser/workbench/workbench.html) with EIO. Pipette starts before boot finishes, so the test can land in that window. In run 30466090198 the EIO hit 4 ms after [Finished cloud-final.service](vscode-file://vscode-app/c:/Users/stevenmalis/AppData/Local/Programs/Microsoft%20VS%20Code/e4c7e7b1d6/resources/app/out/vs/code/electron-browser/workbench/workbench.html).

Fix. Use ttyS1 instead, as there's no getty attached to it.

Also adds [set -e](vscode-file://vscode-app/c:/Users/stevenmalis/AppData/Local/Programs/Microsoft%20VS%20Code/e4c7e7b1d6/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to the write loop — a for loop's status is only its last iteration's, so failed writes were being silently discarded. Only safe with the fix, as it makes the test ~32x more sensitive.