### PR TITLE
Add support for creating virtual addresses via the API in consommé

### DIFF
--- a/vm/devices/net/net_consomme/consomme/src/lib.rs
+++ b/vm/devices/net/net_consomme/consomme/src/lib.rs
@@ -858,7 +858,7 @@ impl Consomme {
     }
 
     /// Allocates a virtual address within this endpoint's subnet and routes
-    ///
+    /// guest traffic sent to it to `destination` on the host.
     /// Returns `None` if the subnet's virtual address pool is exhausted.
     pub fn create_virtual_address(&mut self, destination: IpAddr) -> Option<IpAddr> {
         match destination {

--- a/vm/devices/net/net_consomme/consomme/src/lib.rs
+++ b/vm/devices/net/net_consomme/consomme/src/lib.rs
@@ -60,6 +60,7 @@ use smoltcp::wire::Ipv4Address;
 use smoltcp::wire::Ipv4Packet;
 use smoltcp::wire::Ipv6Address;
 use smoltcp::wire::Ipv6Packet;
+use std::net::IpAddr;
 use std::net::Ipv4Addr;
 use std::net::SocketAddr;
 use std::net::SocketAddrV4;
@@ -854,6 +855,33 @@ impl Consomme {
     /// acceptable.
     pub fn clear_local_addr_map(&mut self) {
         self.state.local_addr_map.clear();
+    }
+
+    /// Allocates a virtual address within this endpoint's subnet and routes
+    ///
+    /// Returns `None` if the subnet's virtual address pool is exhausted.
+    pub fn create_virtual_address(&mut self, destination: IpAddr) -> Option<IpAddr> {
+        match destination {
+            IpAddr::V4(destination) => {
+                let net_mask = self.state.params.net_mask;
+                let gateway_ip = self.state.params.gateway_ip;
+                let client_ip = self.state.params.client_ip;
+                let subnet_base = Ipv4Addr::from(u32::from(gateway_ip) & u32::from(net_mask));
+                self.state
+                    .local_addr_map
+                    .get_or_allocate_v4(destination, subnet_base, net_mask, gateway_ip, client_ip)
+                    .map(IpAddr::V4)
+            }
+            IpAddr::V6(destination) => {
+                let gateway_ll = self.state.params.gateway_link_local_ipv6;
+                let client_ll = self.state.params.client_ip_ipv6;
+                let client_routable = self.state.params.client_ip_ipv6_routable;
+                self.state
+                    .local_addr_map
+                    .get_or_allocate_v6(destination, gateway_ll, client_ll, client_routable)
+                    .map(IpAddr::V6)
+            }
+        }
     }
 
     /// Pairs the client with this instance to operate on the consomme instance.

--- a/vm/devices/net/net_consomme/consomme/src/tests.rs
+++ b/vm/devices/net/net_consomme/consomme/src/tests.rs
@@ -473,3 +473,43 @@ fn handle_ipv6_updates_link_local_from_traffic() {
 
     assert_eq!(params.client_ip_ipv6, Some(second_address));
 }
+
+#[test]
+fn create_virtual_address_allocates_subnet_address() {
+    let mut consomme = Consomme::new(ConsommeParams::new().unwrap());
+
+    // Expect 10.0.0.254 since the default subnet is 10.0.0/24.
+    let addr = consomme
+        .create_virtual_address(IpAddr::V4(Ipv4Addr::LOCALHOST))
+        .unwrap();
+    assert_eq!(addr, IpAddr::V4(Ipv4Addr::new(10, 0, 0, 254)));
+
+    // Requesting a virtual address for the same destination returns the same
+    // address.
+    let addr_again = consomme
+        .create_virtual_address(IpAddr::V4(Ipv4Addr::LOCALHOST))
+        .unwrap();
+    assert_eq!(addr, addr_again);
+
+    // Validate that a different destination gets a different address.
+    let other = consomme
+        .create_virtual_address(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 5)))
+        .unwrap();
+    assert_eq!(other, IpAddr::V4(Ipv4Addr::new(10, 0, 0, 253)));
+}
+
+#[test]
+fn create_virtual_address_allocates_ipv6_link_local() {
+    let mut consomme = Consomme::new(ConsommeParams::new().unwrap());
+
+    let addr = consomme
+        .create_virtual_address(IpAddr::V6(std::net::Ipv6Addr::LOCALHOST))
+        .unwrap();
+    // IPv6 virtual addresses are allocated from the fe80::ff:fe00:NNNN:1 range.
+    assert_eq!(
+        addr,
+        IpAddr::V6(std::net::Ipv6Addr::new(
+            0xfe80, 0, 0, 0, 0x00ff, 0xfe00, 0x0001, 0x0001
+        ))
+    );
+}

--- a/vm/devices/net/net_consomme/src/lib.rs
+++ b/vm/devices/net/net_consomme/src/lib.rs
@@ -194,6 +194,10 @@ pub enum ConsommeMessageError {
     /// Error executing request on current network instance.
     #[error("bind error")]
     Bind(consomme::BindError),
+    /// The subnet's virtual address pool is exhausted, so no virtual address
+    /// could be allocated.
+    #[error("virtual address pool exhausted")]
+    VirtualAddressPoolExhausted,
 }
 
 /// Callback to modify network state dynamically.
@@ -228,6 +232,7 @@ enum ConsommeMessage {
     BindPort(Rpc<PortForwardConfig, Result<(), consomme::BindError>>),
     UnbindPort(Rpc<PortUnbindConfig, Result<(), consomme::BindError>>),
     UpdateState(Rpc<ConsommeParamsUpdateFn, ()>),
+    CreateVirtualAddress(Rpc<IpAddr, Option<IpAddr>>),
 }
 
 impl ConsommeControl {
@@ -298,6 +303,22 @@ impl ConsommeControl {
             .call(ConsommeMessage::UpdateState, f)
             .await
             .map_err(ConsommeMessageError::Mesh)
+    }
+
+    /// Allocates a virtual IP address within the endpoint's subnet and routes
+    /// guest traffic sent to it to `destination` on the host.
+    ///
+    /// Returns [`ConsommeMessageError::VirtualAddressPoolExhausted`] if the
+    /// subnet's virtual address pool is exhausted.
+    pub async fn create_virtual_address(
+        &self,
+        destination: IpAddr,
+    ) -> Result<IpAddr, ConsommeMessageError> {
+        self.send
+            .call(ConsommeMessage::CreateVirtualAddress, destination)
+            .await
+            .map_err(ConsommeMessageError::Mesh)?
+            .ok_or(ConsommeMessageError::VirtualAddressPoolExhausted)
     }
 }
 
@@ -618,6 +639,9 @@ fn process_message(
                 consomme.get_mut().clear_local_addr_map();
                 consomme.update_dns_nameservers()
             });
+        }
+        ConsommeMessage::CreateVirtualAddress(rpc) => {
+            rpc.handle_sync(|destination| consomme.get_mut().create_virtual_address(destination));
         }
     }
 }


### PR DESCRIPTION
This change adds API support for creating virtual addresses in consommé. 

Virtual addresses are special IP addresses that routes traffic to a specified destination, in the context of the host. This is to be used in `wslc` to implement `host.wslc.internal`, which will work by creating a virtual address mapping to `127.0.0.1`, and a DNS A record pointing to the virtual IP address.

The DNS change will be done in a separate change