### PR TITLE
Resolve Dependabot alerts (cmov, postcss, react-router v8 migration)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,5 +50,5 @@ flowey-persist
 # Node.js dependencies and artifacts
 node_modules/
 
-# Build output directories for logview_new
-**/logview_new/dist*
+# Build output directories for logview
+**/logview/dist*

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -823,9 +823,9 @@ dependencies = [
 
 [[package]]
 name = "cmov"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "cms"

--- a/petri/logview/README.md
+++ b/petri/logview/README.md
@@ -30,7 +30,7 @@ After installation, you should have the following key dependencies:
 **Runtime Dependencies:**
 
 - `react` & `react-dom` - React framework
-- `react-router-dom` - Client-side routing
+- `react-router` - Client-side routing
 - `@tanstack/react-query` - Data fetching and caching
 - `@tanstack/react-table` - Table component library
 - `@tanstack/react-virtual` - Virtual scrolling

--- a/petri/logview/README.md
+++ b/petri/logview/README.md
@@ -4,7 +4,7 @@ A React-based web application for viewing and analyzing Petri logs, built with T
 
 ## Prerequisites
 
-- **Node.js** (version `^20.19.0 || >=22.12.0`, as required by Vite 8)
+- **Node.js** (version `>=22.22.0`, as required by react-router 8)
 - **npm** (comes with Node.js)
 
 ## Initial Setup

--- a/petri/logview/package-lock.json
+++ b/petri/logview/package-lock.json
@@ -14,7 +14,7 @@
         "@tanstack/react-virtual": "^3.13.12",
         "react": "^19.2.1",
         "react-dom": "^19.2.1",
-        "react-router-dom": "7.18.0"
+        "react-router": "^8.3.0"
       },
       "devDependencies": {
         "@types/react": "^19.2.7",
@@ -788,18 +788,10 @@
         "node": ">= 6"
       }
     },
-    "node_modules/cookie": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
-      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
+    "node_modules/cookie-es": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-3.1.1.tgz",
+      "integrity": "sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg=="
     },
     "node_modules/cssesc": {
       "version": "3.0.0",
@@ -1384,9 +1376,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -1394,7 +1386,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "license": "MIT",
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -1487,9 +1478,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "dev": true,
       "funding": [
         {
@@ -1505,10 +1496,8 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -1688,64 +1677,42 @@
       "license": "MIT"
     },
     "node_modules/react": {
-      "version": "19.2.4",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
-      "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
-      "license": "MIT",
-      "peer": true,
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
+      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.4",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
-      "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
-      "license": "MIT",
-      "peer": true,
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
+      "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.4"
+        "react": "^19.2.8"
       }
     },
     "node_modules/react-router": {
-      "version": "7.18.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.0.tgz",
-      "integrity": "sha512-pTTGt8J+ji1NOmYnjzT+bAJy/1zD+Jp4ziO6cL7T3ZLvXKtusO7BpFqlRXitqpcPVqllsIXFHRMt+2/k3Xn6HQ==",
-      "license": "MIT",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-8.3.0.tgz",
+      "integrity": "sha512-qyPMvW83jGIct3yiieisxdk9M745anqhpIMKN5m1t6yBMfgVPpt77aHOqs5fUlEJRMCGffg9BaQLH9oPVOL7xQ==",
       "dependencies": {
-        "cookie": "^1.0.1",
-        "set-cookie-parser": "^2.6.0"
+        "cookie-es": "^3.1.1"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.22.0"
       },
       "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
+        "react": ">=19.2.7",
+        "react-dom": ">=19.2.7"
       },
       "peerDependenciesMeta": {
         "react-dom": {
           "optional": true
         }
-      }
-    },
-    "node_modules/react-router-dom": {
-      "version": "7.18.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.0.tgz",
-      "integrity": "sha512-Fi0yY6kgtKae/Th2xibdWK0KSdYZ4B53Gyf6wRtomOKWgpNm7H7+DyfDhncdz9FKbpS+1jmDhg3F4WoGJ+yFOA==",
-      "license": "MIT",
-      "dependencies": {
-        "react-router": "7.18.0"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
       }
     },
     "node_modules/read-cache": {
@@ -1865,12 +1832,6 @@
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
-      "license": "MIT"
-    },
-    "node_modules/set-cookie-parser": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
-      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
       "license": "MIT"
     },
     "node_modules/source-map-js": {

--- a/petri/logview/package-lock.json
+++ b/petri/logview/package-lock.json
@@ -12,8 +12,8 @@
         "@tanstack/react-query": "^5.90.2",
         "@tanstack/react-table": "^8.21.3",
         "@tanstack/react-virtual": "^3.13.12",
-        "react": "^19.2.1",
-        "react-dom": "^19.2.1",
+        "react": "^19.2.7",
+        "react-dom": "^19.2.7",
         "react-router": "^8.3.0"
       },
       "devDependencies": {
@@ -29,7 +29,7 @@
         "vite": "^8.0.0"
       },
       "engines": {
-        "node": "^20.19.0 || >=22.12.0"
+        "node": ">=22.22.0"
       }
     },
     "node_modules/@alloc/quick-lru": {

--- a/petri/logview/package.json
+++ b/petri/logview/package.json
@@ -3,8 +3,8 @@
     "@tanstack/react-query": "^5.90.2",
     "@tanstack/react-table": "^8.21.3",
     "@tanstack/react-virtual": "^3.13.12",
-    "react": "^19.2.1",
-    "react-dom": "^19.2.1",
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7",
     "react-router": "^8.3.0"
   },
   "devDependencies": {
@@ -35,6 +35,6 @@
   "license": "ISC",
   "type": "module",
   "engines": {
-    "node": "^20.19.0 || >=22.12.0"
+    "node": ">=22.22.0"
   }
 }

--- a/petri/logview/package.json
+++ b/petri/logview/package.json
@@ -5,7 +5,7 @@
     "@tanstack/react-virtual": "^3.13.12",
     "react": "^19.2.1",
     "react-dom": "^19.2.1",
-    "react-router-dom": "7.18.0"
+    "react-router": "^8.3.0"
   },
   "devDependencies": {
     "@types/react": "^19.2.7",

--- a/petri/logview/src/docs/docs.tsx
+++ b/petri/logview/src/docs/docs.tsx
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import React from "react";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import { Menu } from "../menu";
 import "../styles/common.css";
 import "../../tailwind.css";

--- a/petri/logview/src/log_viewer.tsx
+++ b/petri/logview/src/log_viewer.tsx
@@ -3,7 +3,7 @@
 
 import React, { useState, useEffect, useRef, useMemo } from "react";
 import { Menu } from "./menu";
-import { Link, useParams, useLocation, useNavigate } from "react-router-dom";
+import { Link, useParams, useLocation, useNavigate } from "react-router";
 import { VirtualizedTable } from "./virtualized_table";
 import { fetchProcessedLog } from "./utils/fetch_logs_data";
 import { useQuery } from "@tanstack/react-query";

--- a/petri/logview/src/main.tsx
+++ b/petri/logview/src/main.tsx
@@ -3,12 +3,12 @@
 
 import React from "react";
 import ReactDOM from "react-dom/client";
-import { HashRouter } from "react-router-dom";
+import { HashRouter } from "react-router";
 import "../tailwind.css";
 import "./styles/main.css";
-import { Routes, Route } from "react-router-dom";
+import { Routes, Route } from "react-router";
 import { Runs } from "./runs";
-import { Navigate } from "react-router-dom";
+import { Navigate } from "react-router";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { startDataPrefetching } from "./utils/fetch_runs_data";
 import { RunDetails } from "./run_details";

--- a/petri/logview/src/menu.tsx
+++ b/petri/logview/src/menu.tsx
@@ -3,7 +3,7 @@
 
 import React, { useState, useCallback, useEffect } from "react";
 import { createPortal } from "react-dom";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import "./styles/menu.css";
 
 // Menu component that opens from the left side

--- a/petri/logview/src/run_details.tsx
+++ b/petri/logview/src/run_details.tsx
@@ -7,7 +7,7 @@ import { SortingState } from "@tanstack/react-table";
 import { TestResult } from "./data_defs";
 import { Menu } from "./menu";
 import { VirtualizedTable } from "./virtualized_table";
-import { Link, useParams } from "react-router-dom";
+import { Link, useParams } from "react-router";
 import { useQuery } from "@tanstack/react-query";
 import { fetchRunDetails } from "./utils/fetch_runs_data";
 import { parseRunKey } from "./data_defs";

--- a/petri/logview/src/runs.tsx
+++ b/petri/logview/src/runs.tsx
@@ -10,7 +10,7 @@ import { RunData } from "./data_defs";
 import { fetchRunData } from "./utils/fetch_runs_data.ts";
 import { Menu } from "./menu";
 import { VirtualizedTable } from "./virtualized_table.tsx";
-import { Link, useSearchParams } from "react-router-dom";
+import { Link, useSearchParams } from "react-router";
 import { SearchInput } from "./search";
 import { run_filters } from "./branch_quick_filters";
 import {

--- a/petri/logview/src/search.tsx
+++ b/petri/logview/src/search.tsx
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import React, { useEffect, useRef } from "react";
-import { useLocation, useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router";
 import "./styles/common.css";
 
 interface SearchInputProps {

--- a/petri/logview/src/table_defs/run_details.tsx
+++ b/petri/logview/src/table_defs/run_details.tsx
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { ColumnDef } from "@tanstack/react-table";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import { TestResult } from "../data_defs";
 
 export const defaultSorting = [

--- a/petri/logview/src/table_defs/runs.tsx
+++ b/petri/logview/src/table_defs/runs.tsx
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { ColumnDef } from "@tanstack/react-table";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import { RunData, parseRunKey } from "../data_defs";
 import "../styles/runs.css";
 

--- a/petri/logview/src/table_defs/test_details.tsx
+++ b/petri/logview/src/table_defs/test_details.tsx
@@ -3,7 +3,7 @@
 
 import { ColumnDef } from '@tanstack/react-table';
 import { TestRunInfo, parseRunKey } from '../data_defs';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import '../styles/common.css';
 
 export const defaultSorting = [

--- a/petri/logview/src/table_defs/tests.tsx
+++ b/petri/logview/src/table_defs/tests.tsx
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { ColumnDef } from '@tanstack/react-table';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { TestData } from '../data_defs';
 import '../styles/common.css';
 

--- a/petri/logview/src/test_details.tsx
+++ b/petri/logview/src/test_details.tsx
@@ -16,7 +16,7 @@ import {
 } from "./data_defs";
 import { Menu } from "./menu.tsx";
 import { VirtualizedTable } from "./virtualized_table.tsx";
-import { Link, useParams, useSearchParams } from "react-router-dom";
+import { Link, useParams, useSearchParams } from "react-router";
 import { SearchInput } from "./search";
 import {
   createColumns,

--- a/petri/logview/src/tests.tsx
+++ b/petri/logview/src/tests.tsx
@@ -16,7 +16,7 @@ import {
 } from "./data_defs";
 import { Menu } from "./menu.tsx";
 import { VirtualizedTable } from "./virtualized_table.tsx";
-import { Link, useSearchParams } from "react-router-dom";
+import { Link, useSearchParams } from "react-router";
 import { SearchInput } from "./search";
 import {
   createColumns,


### PR DESCRIPTION
Resolves the three open Dependabot security alerts in `petri/logview` and `Cargo.lock`.

| Alert | Package | Change | Severity |
|-------|---------|--------|----------|
| [#45](https://github.com/microsoft/openvmm/security/dependabot/45) | `cmov` (Cargo.lock) | 0.5.3 → 0.5.4 (GHSA-3rjw-m598-pq24) | medium |
| [#46](https://github.com/microsoft/openvmm/security/dependabot/46) | `postcss` (petri/logview) | 8.5.15 → 8.5.25 (GHSA-r28c-9q8g-f849) | high |
| [#47](https://github.com/microsoft/openvmm/security/dependabot/47) | `react-router` (petri/logview) | 7.18.0 → 8.3.0 (GHSA-qwww-vcr4-c8h2) | high |

### react-router v8 migration

The `react-router` advisory has no fix in the 7.x line: `react-router-dom` stopped at
`7.18.2`, which is still inside the vulnerable range (`>= 7.12.0, < 8.3.0`). React Router
v8 merged `react-router-dom` back into `react-router`, so the only non-vulnerable option
is moving to `react-router@8`. Downgrading below `7.12.0` was rejected because it
reintroduces numerous other high-severity React Router advisories fixed after `7.11.0`.

- Replaced the `react-router-dom` dependency with `react-router@^8.3.0`.
- Switched all 15 import sites from `react-router-dom` to `react-router`.
- The APIs in use (`Link`, `useParams`, `useSearchParams`, `useLocation`, `useNavigate`,
  `HashRouter`, `Routes`, `Route`, `Navigate`) are unchanged in v8.

`react-router@8.3.0` requires `react >= 19.2.7` and Node `>= 22.22.0`, so `react` /
`react-dom` are bumped to `^19.2.7` (locked at `19.2.8`) and the `engines.node` field
and README prerequisites are updated to match.

### Misc

- Fixed a stale `.gitignore` entry (`logview_new/dist*` → `logview/dist*`) so the Vite
  build output stays ignored.

### Verification

- `npm audit` → **0 vulnerabilities**
- `vite build` → succeeds
- No remaining `react-router-dom` imports

### Note on pre-existing issues

Two failures reproduce on unmodified `main` and are **not** introduced by this PR:

- `npm ci` fails due to `@emnapi/*` optional-dependency drift in the lockfile.
- `tsc --noEmit` reports an unused `escapeHtml` in `src/utils/fetch_logs_data.ts`
  (file untouched here; `vite build` does not typecheck).
