### PR TITLE
sidecar: add diagnostics for non-contiguous node layout

### DIFF
--- a/openhcl/openhcl_boot/src/sidecar.rs
+++ b/openhcl/openhcl_boot/src/sidecar.rs
@@ -244,6 +244,11 @@ pub fn start_sidecar<'a>(
                 base_vp,
                 vp_count: cpus.len() as u32,
             };
+            log::info!(
+                "sidecar: created node index={} base_vp={base_vp} vp_count={} vnode={local_vnode}",
+                *node_count,
+                cpus.len(),
+            );
             if initial_state.per_cpu_state_specified {
                 // If per-CPU state is specified, make sure to explicitly state that
                 // sidecar should not start the base vp of this node.
@@ -290,12 +295,17 @@ pub fn start_sidecar<'a>(
     let boot_end_reftime = minimal_rt::reftime::reference_time();
 
     let SidecarOutput { nodes, error: _ } = sidecar_output;
-    Some(SidecarConfig {
+    let config = SidecarConfig {
         num_cpus: partition_info.cpus.len(),
         start_reftime: boot_start_reftime,
         end_reftime: boot_end_reftime,
         node_params: &sidecar_params.nodes[..node_count],
         nodes: &nodes[..node_count],
         per_cpu_state: &sidecar_params.initial_state,
-    })
+    };
+    log::info!(
+        "sidecar: linux command line: {}",
+        config.kernel_command_line()
+    );
+    Some(config)
 }

--- a/openhcl/openhcl_boot/src/sidecar.rs
+++ b/openhcl/openhcl_boot/src/sidecar.rs
@@ -304,7 +304,7 @@ pub fn start_sidecar<'a>(
         per_cpu_state: &sidecar_params.initial_state,
     };
     log::info!(
-        "sidecar: linux command line: {}",
+        "sidecar: boot_cpus parameter: {}",
         config.kernel_command_line()
     );
     Some(config)

--- a/openhcl/sidecar_client/src/lib.rs
+++ b/openhcl/sidecar_client/src/lib.rs
@@ -149,10 +149,24 @@ impl SidecarClient {
                 }
                 Err(err) => return Err(err),
             };
+            if node.cpus.start > expected_base {
+                tracing::info!(
+                    node = nodes.len(),
+                    gap_start = expected_base,
+                    gap_end = node.cpus.start,
+                    "sidecar node follows a gap; earlier node(s) skipped (no sidecar-started APs)"
+                );
+            }
             assert_eq!(node.cpus.start, expected_base);
             expected_base = node.cpus.end;
             nodes.push(node);
         }
+        let layout: Vec<Range<u32>> = nodes.iter().map(|node| node.cpus.clone()).collect();
+        tracing::info!(
+            ?layout,
+            "sidecar client initialized with {} node(s)",
+            nodes.len()
+        );
         Ok(Some(Self { nodes }))
     }
 


### PR DESCRIPTION
Log created/skipped nodes and boot_cpus= in openhcl_boot; log gaps and the final layout in sidecar_client.