### PR TITLE
firmware_uefi: remove unnecessary protobuf and incorrect reference to templates in ttrpc

### DIFF
--- a/openvmm/openvmm_entry/src/ttrpc/mod.rs
+++ b/openvmm/openvmm_entry/src/ttrpc/mod.rs
@@ -749,34 +749,34 @@ impl VmService {
                     format!("failed to open uefi firmware {}", uefi.firmware_path)
                 })?;
                 let initial_variables = uefi.initial_variables.unwrap_or_default();
-                let uefi_vars = match (arch, initial_variables.secure_boot_template()) {
+                let base_template_json = match (arch, initial_variables.secure_boot_template()) {
                     (_, vmservice::uefi::initial_variables::SecureBootTemplate::None) => {
-                        Default::default()
+                        None
                     }
                     (
                         vm_manifest_builder::MachineArch::X86_64,
                         vmservice::uefi::initial_variables::SecureBootTemplate::MicrosoftWindows,
-                    ) => {
-                        hyperv_secure_boot_templates::x64::microsoft_windows()
-                    }
+                    ) => Some(
+                        firmware_uefi_resources::x64_secure_boot_templates::microsoft_windows(),
+                    ),
                     (
                         vm_manifest_builder::MachineArch::Aarch64,
                         vmservice::uefi::initial_variables::SecureBootTemplate::MicrosoftWindows,
-                    ) => {
-                        hyperv_secure_boot_templates::aarch64::microsoft_windows()
-                    }
+                    ) => Some(
+                        firmware_uefi_resources::aarch64_secure_boot_templates::microsoft_windows(),
+                    ),
                     (
                         vm_manifest_builder::MachineArch::X86_64,
                         vmservice::uefi::initial_variables::SecureBootTemplate::MicrosoftUefiCertificateAuthority,
-                    ) => {
-                        hyperv_secure_boot_templates::x64::microsoft_uefi_ca()
-                    }
+                    ) => Some(
+                        firmware_uefi_resources::x64_secure_boot_templates::microsoft_uefi_ca(),
+                    ),
                     (
                         vm_manifest_builder::MachineArch::Aarch64,
                         vmservice::uefi::initial_variables::SecureBootTemplate::MicrosoftUefiCertificateAuthority,
-                    ) => {
-                        hyperv_secure_boot_templates::aarch64::microsoft_uefi_ca()
-                    }
+                    ) => Some(
+                        firmware_uefi_resources::aarch64_secure_boot_templates::microsoft_uefi_ca(),
+                    ),
                 };
                 (
                     LoadMode::Uefi {
@@ -807,21 +807,22 @@ impl VmService {
                         force_dma_bounce: false,
                     },
                     vm_manifest_builder::BaseChipsetType::HypervGen2Uefi,
-                    Some((uefi_vars, uefi.secure_boot_enabled)),
+                    Some((base_template_json, uefi.secure_boot_enabled)),
                 )
             }
         };
 
         let mut chipset_builder =
             VmManifestBuilder::new(base_chipset_type, arch).with_serial(ports);
-        if let Some((uefi_vars, secure_boot_enabled)) = uefi_config {
+        if let Some((base_template_json, secure_boot_enabled)) = uefi_config {
             // The UEFI helper device backs the firmware's variable store and
             // runtime services, so it is required for a UEFI boot. The store is
             // ephemeral: with no VMGS file configured there is nowhere to
             // persist boot entries or secure boot state across reboots.
             chipset_builder = chipset_builder.with_uefi(vm_manifest_builder::UefiManifest::new(
                 arch,
-                uefi_vars,
+                base_template_json,
+                None,
                 secure_boot_enabled,
                 firmware_uefi_resources::LogLevel::make_default(),
                 None,

--- a/vm/devices/firmware/firmware_uefi_custom_vars/src/delta.rs
+++ b/vm/devices/firmware/firmware_uefi_custom_vars/src/delta.rs
@@ -6,10 +6,9 @@
 
 use super::Signature;
 use super::UefiVar;
-use mesh_protobuf::Protobuf;
 
 /// Changes to apply to a collection of UEFI nvram variables.
-#[derive(Debug, Clone, Protobuf)]
+#[derive(Debug, Clone)]
 pub struct UefiVarsDelta {
     /// Secure Boot signature vars
     pub signatures: SignaturesDelta,
@@ -17,7 +16,7 @@ pub struct UefiVarsDelta {
     pub non_signature_vars: Vec<(String, UefiVar)>,
 }
 
-#[derive(Debug, Clone, Protobuf)]
+#[derive(Debug, Clone)]
 pub enum SignaturesDelta {
     /// Vars should append onto underlying template
     Append(SignaturesAppend),
@@ -26,7 +25,7 @@ pub enum SignaturesDelta {
 }
 
 /// Append CANNOT be used with `pk`
-#[derive(Debug, Clone, Protobuf)]
+#[derive(Debug, Clone)]
 pub struct SignaturesAppend {
     pub kek: Option<Vec<Signature>>,
     pub db: Option<Vec<Signature>>,
@@ -38,7 +37,7 @@ pub struct SignaturesAppend {
 /// Replace the underlying template signatures, optionally using `Default` values
 /// from a base template. If no base template is provided, all required signature
 /// values must be specified explicitly.
-#[derive(Debug, Clone, Protobuf)]
+#[derive(Debug, Clone)]
 pub struct SignaturesReplace {
     pub pk: SignatureDelta,
     pub kek: SignatureDeltaVec,
@@ -48,7 +47,7 @@ pub struct SignaturesReplace {
     pub moklistx: Option<SignatureDeltaVec>,
 }
 
-#[derive(Debug, Clone, Protobuf)]
+#[derive(Debug, Clone)]
 pub enum SignatureDelta {
     Sig(Signature),
     /// "Default" will pull the value of the signature from the specified
@@ -58,7 +57,7 @@ pub enum SignatureDelta {
     Default,
 }
 
-#[derive(Debug, Clone, Protobuf)]
+#[derive(Debug, Clone)]
 pub enum SignatureDeltaVec {
     Sigs(Vec<Signature>),
     /// "Default" will pull the value of the signature from the specified


### PR DESCRIPTION
This supplements a previous PR: https://github.com/microsoft/openvmm/pull/4013

This fixes some uncaught mistakes such as incorrect references to the templates in `ttrpc/mod.rs`. It also addresses a minor copilot comment on unnecessary Protobuf traits for certain structs in `delta.rs`