### PR TITLE
smbios: add configurable guest DMI identity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2893,6 +2893,7 @@ version = "0.0.0"
 dependencies = [
  "inspect",
  "mesh",
+ "smbios_defs",
  "thiserror 2.0.16",
  "vm_resource",
  "vmgs_resources",
@@ -3051,6 +3052,7 @@ dependencies = [
  "power_resources",
  "scsi_buffers",
  "serde_json",
+ "smbios_defs",
  "task_control",
  "test_igvm_agent_lib",
  "thiserror 2.0.16",
@@ -5747,6 +5749,7 @@ dependencies = [
  "mesh_worker",
  "net_backend_resources",
  "openvmm_pcat_locator",
+ "smbios_defs",
  "thiserror 2.0.16",
  "unix_socket",
  "virt",
@@ -6440,6 +6443,7 @@ dependencies = [
  "serial_16550_resources",
  "serial_core",
  "serial_socket",
+ "smbios_defs",
  "sparse_mmap",
  "storvsp_resources",
  "tempfile",
@@ -7713,6 +7717,14 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "smbios_defs"
+version = "0.0.0"
+dependencies = [
+ "guid",
+ "mesh",
+]
 
 [[package]]
 name = "smmu"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2944,6 +2944,7 @@ version = "0.0.0"
 dependencies = [
  "inspect",
  "mesh",
+ "smbios_defs",
  "thiserror 2.0.16",
  "vm_resource",
  "vmgs_resources",
@@ -3102,6 +3103,7 @@ dependencies = [
  "power_resources",
  "scsi_buffers",
  "serde_json",
+ "smbios_defs",
  "task_control",
  "test_igvm_agent_lib",
  "thiserror 2.0.16",
@@ -5829,6 +5831,7 @@ dependencies = [
  "mesh_worker",
  "net_backend_resources",
  "openvmm_pcat_locator",
+ "smbios_defs",
  "thiserror 2.0.16",
  "unix_socket",
  "virt",
@@ -6524,6 +6527,7 @@ dependencies = [
  "serial_16550_resources",
  "serial_core",
  "serial_socket",
+ "smbios_defs",
  "sparse_mmap",
  "storvsp_resources",
  "tempfile",
@@ -7798,6 +7802,14 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "smbios_defs"
+version = "0.0.0"
+dependencies = [
+ "guid",
+ "mesh",
+]
 
 [[package]]
 name = "smmu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -249,6 +249,7 @@ uefi_specs = { path = "vm/devices/firmware/uefi_specs" }
 uefi_nvram_specvars = { path = "vm/devices/firmware/uefi_nvram_specvars" }
 hyperv_secure_boot_templates = { path = "vm/devices/firmware/hyperv_secure_boot_templates" }
 hyperv_uefi_custom_vars_json = { path = "vm/devices/firmware/hyperv_uefi_custom_vars_json" }
+smbios_defs = { path = "vm/devices/firmware/smbios_defs" }
 framebuffer = { path = "vm/devices/framebuffer" }
 hcl_compat_uefi_nvram_resources = { path = "vm/devices/firmware/hcl_compat_uefi_nvram_resources" }
 hcl_compat_uefi_nvram_storage = { path = "vm/devices/firmware/hcl_compat_uefi_nvram_storage" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -257,6 +257,7 @@ uefi_specs = { path = "vm/devices/firmware/uefi_specs" }
 uefi_nvram_specvars = { path = "vm/devices/firmware/uefi_nvram_specvars" }
 hyperv_secure_boot_templates = { path = "vm/devices/firmware/hyperv_secure_boot_templates" }
 hyperv_uefi_custom_vars_json = { path = "vm/devices/firmware/hyperv_uefi_custom_vars_json" }
+smbios_defs = { path = "vm/devices/firmware/smbios_defs" }
 framebuffer = { path = "vm/devices/framebuffer" }
 hcl_compat_uefi_nvram_resources = { path = "vm/devices/firmware/hcl_compat_uefi_nvram_resources" }
 hcl_compat_uefi_nvram_storage = { path = "vm/devices/firmware/hcl_compat_uefi_nvram_storage" }

--- a/Guide/src/reference/devices/firmware/linux_direct.md
+++ b/Guide/src/reference/devices/firmware/linux_direct.md
@@ -112,12 +112,13 @@ so `/sys/class/dmi/id/*` reads consistently regardless of boot path:
 |------------|---------------|
 | `sys_vendor` | `OpenVMM` |
 | `product_name` | `OpenVMM Virtual Machine` |
-| `product_uuid` | The VM's BIOS GUID (the all-zero GUID unless set) |
+| `product_uuid` | Not exposed unless the VM's BIOS GUID is set |
 
 The `product_uuid` is sourced from the same VM BIOS GUID used by the UEFI boot
 path, so a guest reports the same UUID whether booted via UEFI or direct boot.
-It defaults to the all-zero GUID; pass `--smbios type=1,uuid=<GUID>` (or
-`uuid=random`) to override it.
+The SMBIOS UUID defaults to the all-zero GUID, which Linux treats as not
+present and therefore does not expose as `product_uuid`. Pass
+`--smbios type=1,uuid=<GUID>` (or `uuid=random`) to set it.
 
 ## CLI Usage
 

--- a/Guide/src/reference/devices/firmware/linux_direct.md
+++ b/Guide/src/reference/devices/firmware/linux_direct.md
@@ -49,9 +49,7 @@ On x86_64, OpenVMM follows the standard Linux boot protocol:
    table, which lives in its own reserved region in low memory just above the
    ACPI tables (so it can grow well past the 64 KiB F-segment). Both regions
    are reserved in the e820 map so they are not overwritten before the scan.
-   Guests can then read `/sys/class/dmi/id/*`. There is no configuration
-   surface yet, so every direct-boot VM reports a fixed default OpenVMM
-   identity.
+   Guests can then read `/sys/class/dmi/id/*`.
 6. A GDT and initial page tables are set up.
 7. The BSP register state is configured and execution begins.
 
@@ -104,6 +102,22 @@ from the DT; no EFI structures or ACPI tables are involved.
 Device tree mode is not supported on x86_64. Passing `--device-tree` on x86
 will result in an error.
 ```
+
+## SMBIOS / DMI Identity
+
+On both architectures the synthesized SMBIOS tables expose a default identity,
+so `/sys/class/dmi/id/*` reads consistently regardless of boot path:
+
+| sysfs file | Default value |
+|------------|---------------|
+| `sys_vendor` | `OpenVMM` |
+| `product_name` | `OpenVMM Virtual Machine` |
+| `product_uuid` | The VM's BIOS GUID (the all-zero GUID unless set) |
+
+The `product_uuid` is sourced from the same VM BIOS GUID used by the UEFI boot
+path, so a guest reports the same UUID whether booted via UEFI or direct boot.
+It defaults to the all-zero GUID; pass `--smbios type=1,uuid=<GUID>` (or
+`uuid=random`) to override it.
 
 ## CLI Usage
 

--- a/Guide/src/reference/openvmm/management/cli.md
+++ b/Guide/src/reference/openvmm/management/cli.md
@@ -134,6 +134,40 @@ as well as the generated CLI help (via `cargo run -- --help`).
   `--memory-backing-file <PATH>`: Deprecated aliases for `--memory`
   parameters. Prefer `shared=off`, `prefetch=on`, `thp=on`, and
   `file=<PATH>`.
+* `--smbios <PARAMS>`: Override the SMBIOS (DMI) identity reported to the
+  guest (repeatable). Uses the format
+  `type=N,key=value[,key=value...]`, following QEMU's `-smbios` syntax and
+  key names. As with QEMU, `type=N` is required (there is no default). Keys
+  left unset use the loader's built-in default identity (OpenVMM / OpenVMM
+  Virtual Machine). The system UUID defaults to the all-zero GUID unless
+  overridden with `uuid=<GUID>`; `uuid=random` requests a freshly generated
+  per-VM GUID. Unknown types and unknown keys are rejected.
+
+  Applies to both Linux direct boot and UEFI boot. On UEFI boot the firmware
+  builds the SMBIOS tables, so only `type=1` (System) fields can be
+  overridden — the firmware self-describes the BIOS, so setting any `type=0`
+  (BIOS) field is rejected with an error rather than silently ignored.
+
+  Supported keys:
+
+  | `type` | Keys | Linux `/sys/class/dmi/id/` |
+  | --- | --- | --- |
+  | `0` (BIOS) | `vendor`, `version`, `date`, `release` | `bios_vendor`, `bios_version`, `bios_date`, `bios_release` |
+  | `1` (System) | `manufacturer`, `product`, `version`, `serial`, `uuid`, `sku`, `family` | `sys_vendor`, `product_name`, `product_version`, `product_serial`, `product_uuid`, `product_sku`, `product_family` |
+
+  `version` is the free-form BIOS version string, whereas `release` is the
+  numeric System BIOS Major/Minor Release, given as `MAJOR.MINOR` (each a
+  number in `0..=255`, e.g. `release=4.1`), matching QEMU.
+
+  ```bash
+  --smbios type=1,manufacturer=Contoso,product="Virtual Machine"
+  --smbios type=1,uuid=12345678-9abc-def0-1234-56789abcdef0
+  --smbios type=1,uuid=random
+  --smbios type=1,manufacturer=Contoso --smbios type=0,vendor=Contoso,version=1.0,release=4.1
+  ```
+
+  See [Linux Direct Boot](../../devices/firmware/linux_direct.md) for how the
+  tables are delivered to the guest.
 * `--pidfile <PATH>`: Write the process ID to the specified file on startup,
   and remove it on clean exit. If the process is killed with `SIGKILL` or
   crashes, the pidfile is not removed — consumers should verify the PID is

--- a/Guide/src/reference/openvmm/management/cli.md
+++ b/Guide/src/reference/openvmm/management/cli.md
@@ -143,10 +143,12 @@ as well as the generated CLI help (via `cargo run -- --help`).
   overridden with `uuid=<GUID>`; `uuid=random` requests a freshly generated
   per-VM GUID. Unknown types and unknown keys are rejected.
 
-  Applies to both Linux direct boot and UEFI boot. On UEFI boot the firmware
+  Applies to Linux direct, UEFI, and PCAT boot. On UEFI boot the firmware
   builds the SMBIOS tables, so only `type=1` (System) fields can be
   overridden — the firmware self-describes the BIOS, so setting any `type=0`
-  (BIOS) field is rejected with an error rather than silently ignored.
+  (BIOS) field is rejected with an error rather than silently ignored. On
+  PCAT boot, only the `type=1` `serial` and `uuid` fields can be overridden;
+  all other fields are rejected with an error.
 
   Supported keys:
 

--- a/Guide/src/reference/openvmm/management/cli.md
+++ b/Guide/src/reference/openvmm/management/cli.md
@@ -184,44 +184,18 @@ describes the source definitions.
   parameters. Prefer `shared=off`, `prefetch=on`, `thp=on`, and
   `file=<PATH>`.
 * `--smbios <PARAMS>`: Override the SMBIOS (DMI) identity reported to the
-  guest (repeatable). Uses the format
-  `type=N,key=value[,key=value...]`, following QEMU's `-smbios` syntax and
-  key names. As with QEMU, `type=N` is required (there is no default). Keys
-  left unset use the selected boot path's built-in default identity — for
-  example, the OpenVMM direct loader defaults to `OpenVMM` / `OpenVMM Virtual
-  Machine`, OpenHCL direct boot to `OpenHCL` / `OpenHCL Virtual Machine`, and
-  firmware-backed (UEFI/PCAT) paths keep their own built-in defaults. The
-  system UUID defaults to the all-zero GUID unless overridden with
-  `uuid=<GUID>`; `uuid=random` requests a freshly generated per-VM GUID.
-  Unknown types and unknown keys are rejected.
+  guest (repeatable), using `type=N,key=value[,key=value...]`.
+  Type 0 supports `vendor`, `version`, `date`, and `release`; Type 1 supports
+  `manufacturer`, `product`, `version`, `serial`, `uuid`, `sku`, and `family`.
+  Use `uuid=random` to generate a per-VM system UUID.
 
-  Applies to Linux direct, UEFI, and PCAT boot. On UEFI boot the firmware
-  builds the SMBIOS tables, so only `type=1` (System) fields can be
-  overridden — the firmware self-describes the BIOS, so setting any `type=0`
-  (BIOS) field is rejected with an error rather than silently ignored. On
-  PCAT boot, only the `type=1` `serial` and `uuid` fields can be overridden;
-  all other fields are rejected with an error.
-
-  Supported keys:
-
-  | `type` | Keys | Linux `/sys/class/dmi/id/` |
-  | --- | --- | --- |
-  | `0` (BIOS) | `vendor`, `version`, `date`, `release` | `bios_vendor`, `bios_version`, `bios_date`, `bios_release` |
-  | `1` (System) | `manufacturer`, `product`, `version`, `serial`, `uuid`, `sku`, `family` | `sys_vendor`, `product_name`, `product_version`, `product_serial`, `product_uuid`, `product_sku`, `product_family` |
-
-  `version` is the free-form BIOS version string, whereas `release` is the
-  numeric System BIOS Major/Minor Release, given as `MAJOR.MINOR` (each a
-  number in `0..=255`, e.g. `release=4.1`), matching QEMU.
+  OpenVMM Linux direct boot supports both types. OpenHCL Linux direct and UEFI
+  support Type 1 only. PCAT supports only Type 1 `serial` and `uuid`.
+  Unsupported fields are rejected.
 
   ```bash
   --smbios type=1,manufacturer=Contoso,product="Virtual Machine"
-  --smbios type=1,uuid=12345678-9abc-def0-1234-56789abcdef0
-  --smbios type=1,uuid=random
-  --smbios type=1,manufacturer=Contoso --smbios type=0,vendor=Contoso,version=1.0,release=4.1
   ```
-
-  See [Linux Direct Boot](../../devices/firmware/linux_direct.md) for how the
-  tables are delivered to the guest.
 * `--pidfile <PATH>`: Write the process ID to the specified file on startup,
   and remove it on clean exit. If the process is killed with `SIGKILL` or
   crashes, the pidfile is not removed — consumers should verify the PID is

--- a/Guide/src/reference/openvmm/management/cli.md
+++ b/Guide/src/reference/openvmm/management/cli.md
@@ -192,10 +192,12 @@ describes the source definitions.
   overridden with `uuid=<GUID>`; `uuid=random` requests a freshly generated
   per-VM GUID. Unknown types and unknown keys are rejected.
 
-  Applies to both Linux direct boot and UEFI boot. On UEFI boot the firmware
+  Applies to Linux direct, UEFI, and PCAT boot. On UEFI boot the firmware
   builds the SMBIOS tables, so only `type=1` (System) fields can be
   overridden — the firmware self-describes the BIOS, so setting any `type=0`
-  (BIOS) field is rejected with an error rather than silently ignored.
+  (BIOS) field is rejected with an error rather than silently ignored. On
+  PCAT boot, only the `type=1` `serial` and `uuid` fields can be overridden;
+  all other fields are rejected with an error.
 
   Supported keys:
 

--- a/Guide/src/reference/openvmm/management/cli.md
+++ b/Guide/src/reference/openvmm/management/cli.md
@@ -187,10 +187,13 @@ describes the source definitions.
   guest (repeatable). Uses the format
   `type=N,key=value[,key=value...]`, following QEMU's `-smbios` syntax and
   key names. As with QEMU, `type=N` is required (there is no default). Keys
-  left unset use the loader's built-in default identity (OpenVMM / OpenVMM
-  Virtual Machine). The system UUID defaults to the all-zero GUID unless
-  overridden with `uuid=<GUID>`; `uuid=random` requests a freshly generated
-  per-VM GUID. Unknown types and unknown keys are rejected.
+  left unset use the selected boot path's built-in default identity — for
+  example, the OpenVMM direct loader defaults to `OpenVMM` / `OpenVMM Virtual
+  Machine`, OpenHCL direct boot to `OpenHCL` / `OpenHCL Virtual Machine`, and
+  firmware-backed (UEFI/PCAT) paths keep their own built-in defaults. The
+  system UUID defaults to the all-zero GUID unless overridden with
+  `uuid=<GUID>`; `uuid=random` requests a freshly generated per-VM GUID.
+  Unknown types and unknown keys are rejected.
 
   Applies to Linux direct, UEFI, and PCAT boot. On UEFI boot the firmware
   builds the SMBIOS tables, so only `type=1` (System) fields can be

--- a/Guide/src/reference/openvmm/management/cli.md
+++ b/Guide/src/reference/openvmm/management/cli.md
@@ -183,6 +183,40 @@ describes the source definitions.
   `--memory-backing-file <PATH>`: Deprecated aliases for `--memory`
   parameters. Prefer `shared=off`, `prefetch=on`, `thp=on`, and
   `file=<PATH>`.
+* `--smbios <PARAMS>`: Override the SMBIOS (DMI) identity reported to the
+  guest (repeatable). Uses the format
+  `type=N,key=value[,key=value...]`, following QEMU's `-smbios` syntax and
+  key names. As with QEMU, `type=N` is required (there is no default). Keys
+  left unset use the loader's built-in default identity (OpenVMM / OpenVMM
+  Virtual Machine). The system UUID defaults to the all-zero GUID unless
+  overridden with `uuid=<GUID>`; `uuid=random` requests a freshly generated
+  per-VM GUID. Unknown types and unknown keys are rejected.
+
+  Applies to both Linux direct boot and UEFI boot. On UEFI boot the firmware
+  builds the SMBIOS tables, so only `type=1` (System) fields can be
+  overridden — the firmware self-describes the BIOS, so setting any `type=0`
+  (BIOS) field is rejected with an error rather than silently ignored.
+
+  Supported keys:
+
+  | `type` | Keys | Linux `/sys/class/dmi/id/` |
+  | --- | --- | --- |
+  | `0` (BIOS) | `vendor`, `version`, `date`, `release` | `bios_vendor`, `bios_version`, `bios_date`, `bios_release` |
+  | `1` (System) | `manufacturer`, `product`, `version`, `serial`, `uuid`, `sku`, `family` | `sys_vendor`, `product_name`, `product_version`, `product_serial`, `product_uuid`, `product_sku`, `product_family` |
+
+  `version` is the free-form BIOS version string, whereas `release` is the
+  numeric System BIOS Major/Minor Release, given as `MAJOR.MINOR` (each a
+  number in `0..=255`, e.g. `release=4.1`), matching QEMU.
+
+  ```bash
+  --smbios type=1,manufacturer=Contoso,product="Virtual Machine"
+  --smbios type=1,uuid=12345678-9abc-def0-1234-56789abcdef0
+  --smbios type=1,uuid=random
+  --smbios type=1,manufacturer=Contoso --smbios type=0,vendor=Contoso,version=1.0,release=4.1
+  ```
+
+  See [Linux Direct Boot](../../devices/firmware/linux_direct.md) for how the
+  tables are delivered to the guest.
 * `--pidfile <PATH>`: Write the process ID to the specified file on startup,
   and remove it on clean exit. If the process is killed with `SIGKILL` or
   crashes, the pidfile is not removed — consumers should verify the PID is

--- a/openhcl/underhill_core/Cargo.toml
+++ b/openhcl/underhill_core/Cargo.toml
@@ -120,6 +120,7 @@ vpci_relay.workspace = true
 watchdog_core.workspace = true
 watchdog_vmgs_format.workspace = true
 scsi_buffers.workspace = true
+
 acpi_spec = { workspace = true, features = ["std"] }
 hvdef.workspace = true
 igvm.workspace = true

--- a/openhcl/underhill_core/Cargo.toml
+++ b/openhcl/underhill_core/Cargo.toml
@@ -120,7 +120,6 @@ vpci_relay.workspace = true
 watchdog_core.workspace = true
 watchdog_vmgs_format.workspace = true
 scsi_buffers.workspace = true
-
 acpi_spec = { workspace = true, features = ["std"] }
 hvdef.workspace = true
 igvm.workspace = true

--- a/openhcl/underhill_core/src/loader/mod.rs
+++ b/openhcl/underhill_core/src/loader/mod.rs
@@ -280,6 +280,50 @@ fn load_linux(params: LoadLinuxParams<'_>) -> Result<VpContext, Error> {
         },
     };
 
+    // Synthesize SMBIOS tables from the host-provided platform settings so the
+    // guest kernel's DMI scan finds them. Type 0 (BIOS) has no host-provided
+    // source, so default identity strings are used; Type 1 (System) is
+    // populated from `DevicePlatformSettings`.
+    //
+    // The host forwards the same identity to the UEFI firmware, but it omits any
+    // empty field and lets the firmware substitute its own default. There is no
+    // firmware behind the direct-boot path, so to avoid a guest seeing a blank
+    // `sys_vendor`/`product_name`, empty manufacturer and product strings fall
+    // back to OpenHCL defaults (mirroring the OpenVMM direct-boot loader). The
+    // remaining identity fields are passed through as-is; the SMBIOS builder
+    // truncates any interior NUL and treats an empty string as "no string".
+    let smbios = &platform_config.smbios;
+    let manufacturer = if smbios.system_manufacturer.is_empty() {
+        "OpenHCL"
+    } else {
+        &smbios.system_manufacturer
+    };
+    let product_name = if smbios.system_product_name.is_empty() {
+        "OpenHCL Virtual Machine"
+    } else {
+        &smbios.system_product_name
+    };
+    let smbios_tables = loader::smbios::SmbiosTables {
+        bios: loader::smbios::SmbiosBiosInfo {
+            vendor: "OpenHCL",
+            version: "OpenHCL Direct",
+            release_date: "06/19/2026",
+            major: 0,
+            minor: 0,
+        },
+        system: loader::smbios::SmbiosSystemInfo {
+            manufacturer,
+            product_name,
+            version: &smbios.system_version,
+            serial_number: &smbios.serial_number,
+            sku_number: &smbios.system_sku_number,
+            family: &smbios.system_family,
+            // The Type 1 UUID uses the same VM BIOS GUID as the UEFI path; its
+            // raw bytes go in directly with no byte-order swap.
+            uuid: platform_config.general.bios_guid.into(),
+        },
+    };
+
     let mut loader = vm_loader::Loader::new(gm.clone(), mem_layout, hvdef::Vtl::Vtl0);
 
     let initrd_info = if let Some((initrd_base, initrd_size)) = initrd {
@@ -326,9 +370,9 @@ fn load_linux(params: LoadLinuxParams<'_>) -> Result<VpContext, Error> {
         bzimage_setup_header: None,
     };
 
-    // The loader owns the sub-1 MB layout; we supply only the command line and
-    // a builder that produces the ACPI tables at the loader's chosen address.
-    // OpenHCL's VTL0 direct boot exposes no SMBIOS identity.
+    // The loader owns the sub-1 MB layout; we supply only the command line, a
+    // builder that produces the ACPI tables at the loader's chosen address, and
+    // the SMBIOS identity forwarded by the host.
     loader::linux::load_config_x86(
         &mut loader,
         &load_info,
@@ -369,7 +413,7 @@ fn load_linux(params: LoadLinuxParams<'_>) -> Result<VpContext, Error> {
                 tables: acpi_tables.tables,
             }
         },
-        None,
+        Some(smbios_tables),
         None,
     )
     .map_err(Error::LinuxLoader)?;
@@ -537,19 +581,19 @@ pub fn write_uefi_config(
     .add(&config::BiosGuid(platform_config.general.bios_guid))
     .add_cstring(
         config::BlobStructureType::SmbiosSystemSerialNumber,
-        &platform_config.smbios.serial_number,
+        platform_config.smbios.serial_number.as_bytes(),
     )
     .add_cstring(
         config::BlobStructureType::SmbiosBaseSerialNumber,
-        &platform_config.smbios.base_board_serial_number,
+        platform_config.smbios.base_board_serial_number.as_bytes(),
     )
     .add_cstring(
         config::BlobStructureType::SmbiosChassisSerialNumber,
-        &platform_config.smbios.chassis_serial_number,
+        platform_config.smbios.chassis_serial_number.as_bytes(),
     )
     .add_cstring(
         config::BlobStructureType::SmbiosChassisAssetTag,
-        &platform_config.smbios.chassis_asset_tag,
+        platform_config.smbios.chassis_asset_tag.as_bytes(),
     );
 
     cfg.add(&config::NvdimmCount {
@@ -563,31 +607,34 @@ pub fn write_uefi_config(
 
     cfg.add_cstring(
         config::BlobStructureType::SmbiosSystemManufacturer,
-        &platform_config.smbios.system_manufacturer,
+        platform_config.smbios.system_manufacturer.as_bytes(),
     )
     .add_cstring(
         config::BlobStructureType::SmbiosSystemProductName,
-        &platform_config.smbios.system_product_name,
+        platform_config.smbios.system_product_name.as_bytes(),
     )
     .add_cstring(
         config::BlobStructureType::SmbiosSystemVersion,
-        &platform_config.smbios.system_version,
+        platform_config.smbios.system_version.as_bytes(),
     )
     .add_cstring(
         config::BlobStructureType::SmbiosSystemSkuNumber,
-        &platform_config.smbios.system_sku_number,
+        platform_config.smbios.system_sku_number.as_bytes(),
     )
     .add_cstring(
         config::BlobStructureType::SmbiosSystemFamily,
-        &platform_config.smbios.system_family,
+        platform_config.smbios.system_family.as_bytes(),
     )
     .add_cstring(
         config::BlobStructureType::SmbiosBiosLockString,
-        &platform_config.smbios.bios_lock_string,
+        platform_config.smbios.bios_lock_string.as_bytes(),
     )
     .add_cstring(
         config::BlobStructureType::SmbiosMemoryDeviceSerialNumber,
-        &platform_config.smbios.memory_device_serial_number,
+        platform_config
+            .smbios
+            .memory_device_serial_number
+            .as_bytes(),
     )
     .add_cstring(
         config::BlobStructureType::SmbiosProcessorManufacturer,

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -2712,11 +2712,15 @@ async fn new_underhill_vm(
                 num_lock_enabled: dps.general.num_lock_enabled,
                 smbios: firmware_pcat::config::SmbiosConstants {
                     bios_guid: dps.general.bios_guid,
-                    system_serial_number: dps.smbios.serial_number.clone(),
-                    base_board_serial_number: (dps.smbios).base_board_serial_number.clone(),
-                    chassis_serial_number: (dps.smbios).chassis_serial_number.clone(),
-                    chassis_asset_tag: (dps.smbios).chassis_asset_tag.clone(),
-                    bios_lock_string: dps.smbios.bios_lock_string.clone(),
+                    system_serial_number: dps.smbios.serial_number.clone().into_bytes(),
+                    base_board_serial_number: dps
+                        .smbios
+                        .base_board_serial_number
+                        .clone()
+                        .into_bytes(),
+                    chassis_serial_number: dps.smbios.chassis_serial_number.clone().into_bytes(),
+                    chassis_asset_tag: dps.smbios.chassis_asset_tag.clone().into_bytes(),
+                    bios_lock_string: dps.smbios.bios_lock_string.clone().into_bytes(),
                     processor_manufacturer: dps.smbios.processor_manufacturer.clone(),
                     processor_version: dps.smbios.processor_version.clone(),
                     cpu_info_bundle: Some(firmware_pcat::config::SmbiosProcessorInfoBundle {

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -2712,7 +2712,21 @@ async fn new_underhill_vm(
                 num_lock_enabled: dps.general.num_lock_enabled,
                 smbios: firmware_pcat::config::SmbiosConstants {
                     bios_guid: dps.general.bios_guid,
-                    system_serial_number: dps.smbios.serial_number.clone().into_bytes(),
+                    // Truncate rather than fail: the serial comes from the host
+                    // via DPS, and the PCAT config port caps each string at a
+                    // fixed length regardless.
+                    system_serial_number: {
+                        let mut serial = dps.smbios.serial_number.clone().into_bytes();
+                        if serial.len() > firmware_pcat::config::SMBIOS_STRING_MAX_LEN {
+                            tracing::warn!(
+                                len = serial.len(),
+                                max = firmware_pcat::config::SMBIOS_STRING_MAX_LEN,
+                                "SMBIOS system serial number too long; truncating for PCAT"
+                            );
+                            serial.truncate(firmware_pcat::config::SMBIOS_STRING_MAX_LEN);
+                        }
+                        serial
+                    },
                     base_board_serial_number: dps
                         .smbios
                         .base_board_serial_number

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -2692,11 +2692,15 @@ async fn new_underhill_vm(
                 num_lock_enabled: dps.general.num_lock_enabled,
                 smbios: firmware_pcat::config::SmbiosConstants {
                     bios_guid: dps.general.bios_guid,
-                    system_serial_number: dps.smbios.serial_number.clone(),
-                    base_board_serial_number: (dps.smbios).base_board_serial_number.clone(),
-                    chassis_serial_number: (dps.smbios).chassis_serial_number.clone(),
-                    chassis_asset_tag: (dps.smbios).chassis_asset_tag.clone(),
-                    bios_lock_string: dps.smbios.bios_lock_string.clone(),
+                    system_serial_number: dps.smbios.serial_number.clone().into_bytes(),
+                    base_board_serial_number: dps
+                        .smbios
+                        .base_board_serial_number
+                        .clone()
+                        .into_bytes(),
+                    chassis_serial_number: dps.smbios.chassis_serial_number.clone().into_bytes(),
+                    chassis_asset_tag: dps.smbios.chassis_asset_tag.clone().into_bytes(),
+                    bios_lock_string: dps.smbios.bios_lock_string.clone().into_bytes(),
                     processor_manufacturer: dps.smbios.processor_manufacturer.clone(),
                     processor_version: dps.smbios.processor_version.clone(),
                     cpu_info_bundle: Some(firmware_pcat::config::SmbiosProcessorInfoBundle {

--- a/openvmm/openvmm_core/src/worker/dispatch.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch.rs
@@ -1489,6 +1489,7 @@ impl InitializedVm {
             LoadMode::Pcat {
                 firmware,
                 boot_order,
+                smbios,
             } => {
                 tracing::debug!(?firmware, "Loading BIOS firmware.");
                 let rom_builder = RomBuilder::new("bios".into(), Box::new(mapper.clone()));
@@ -1566,23 +1567,7 @@ impl InitializedVm {
                                 })
                             },
                             num_lock_enabled: false,
-                            // TODO: these are all very bogus values, and need to be swapped out with something better
-                            smbios: firmware_pcat::config::SmbiosConstants {
-                                bios_guid: guid::Guid {
-                                    data1: 0xC4066C45,
-                                    data2: 0x503D,
-                                    data3: 0x40E8,
-                                    data4: [0xB1, 0x5C, 0x31, 0x26, 0x4E, 0x5F, 0xE1, 0xD9],
-                                },
-                                system_serial_number: "9583-9572-9874-4843-7295-1653-92".into(),
-                                base_board_serial_number: "9583-9572-9874-4843-7295-1653-92".into(),
-                                chassis_serial_number: "9583-9572-9874-4843-7295-1653-92".into(),
-                                chassis_asset_tag: "9583-9572-9874-4843-7295-1653-92".into(),
-                                bios_lock_string: "00000000000000000000000000000000".into(),
-                                processor_manufacturer: b"\0".to_vec(),
-                                processor_version: b"\0".to_vec(),
-                                cpu_info_bundle: None,
-                            },
+                            smbios: super::vm_loaders::pcat::smbios_constants_from_config(smbios)?,
                         }
                     },
                 })
@@ -3111,6 +3096,7 @@ impl LoadedVmInner {
                 ref cmdline,
                 enable_serial,
                 boot_mode,
+                ref smbios,
             } => {
                 match boot_mode {
                     openvmm_defs::config::LinuxDirectBootMode::DeviceTree => {
@@ -3124,6 +3110,7 @@ impl LoadedVmInner {
                     cmdline,
                     mem_layout: &self.mem_layout,
                     isolation: self.hypervisor_cfg.with_isolation,
+                    smbios,
                 };
                 super::vm_loaders::linux::load_linux_x86(&kernel_config, &self.gm, |gpa| {
                     let tables = acpi_builder.build_acpi_tables(gpa, |dsdt| {
@@ -3153,6 +3140,7 @@ impl LoadedVmInner {
                 ref cmdline,
                 enable_serial,
                 boot_mode,
+                ref smbios,
             } => {
                 use openvmm_defs::config::LinuxDirectBootMode;
 
@@ -3162,6 +3150,7 @@ impl LoadedVmInner {
                     cmdline,
                     mem_layout: &self.mem_layout,
                     isolation: self.hypervisor_cfg.with_isolation,
+                    smbios,
                 };
 
                 let build_acpi = if boot_mode == LinuxDirectBootMode::Acpi {
@@ -3207,7 +3196,7 @@ impl LoadedVmInner {
                 enable_vpci_boot,
                 uefi_console_mode,
                 default_boot_always_attempt,
-                bios_guid,
+                ref smbios,
                 enable_vmbus,
                 force_dma_bounce,
             } => {
@@ -3243,7 +3232,7 @@ impl LoadedVmInner {
                     serial: enable_serial,
                     uefi_console_mode,
                     default_boot_always_attempt,
-                    bios_guid,
+                    smbios: (**smbios).clone(),
                     vmbus: enable_vmbus,
                     force_dma_bounce,
                 };

--- a/openvmm/openvmm_core/src/worker/dispatch.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch.rs
@@ -1611,6 +1611,7 @@ impl InitializedVm {
                 firmware,
                 boot_order,
                 hibernation_enabled,
+                smbios,
             } => {
                 tracing::debug!(?firmware, "Loading BIOS firmware.");
                 let rom_builder = RomBuilder::new("bios".into(), Box::new(mapper.clone()));
@@ -1688,23 +1689,7 @@ impl InitializedVm {
                                 })
                             },
                             num_lock_enabled: false,
-                            // TODO: these are all very bogus values, and need to be swapped out with something better
-                            smbios: firmware_pcat::config::SmbiosConstants {
-                                bios_guid: guid::Guid {
-                                    data1: 0xC4066C45,
-                                    data2: 0x503D,
-                                    data3: 0x40E8,
-                                    data4: [0xB1, 0x5C, 0x31, 0x26, 0x4E, 0x5F, 0xE1, 0xD9],
-                                },
-                                system_serial_number: "9583-9572-9874-4843-7295-1653-92".into(),
-                                base_board_serial_number: "9583-9572-9874-4843-7295-1653-92".into(),
-                                chassis_serial_number: "9583-9572-9874-4843-7295-1653-92".into(),
-                                chassis_asset_tag: "9583-9572-9874-4843-7295-1653-92".into(),
-                                bios_lock_string: "00000000000000000000000000000000".into(),
-                                processor_manufacturer: b"\0".to_vec(),
-                                processor_version: b"\0".to_vec(),
-                                cpu_info_bundle: None,
-                            },
+                            smbios: super::vm_loaders::pcat::smbios_constants_from_config(smbios)?,
                         }
                     },
                 })
@@ -3254,6 +3239,7 @@ impl LoadedVmInner {
                 enable_serial,
                 isolation,
                 boot_mode,
+                ref smbios,
             } => {
                 match boot_mode {
                     openvmm_defs::config::LinuxDirectBootMode::DeviceTree => {
@@ -3294,6 +3280,7 @@ impl LoadedVmInner {
                     cmdline,
                     mem_layout: &self.mem_layout,
                     isolation,
+                    smbios,
                 };
                 super::vm_loaders::linux::load_linux_x86(
                     &kernel_config,
@@ -3330,6 +3317,7 @@ impl LoadedVmInner {
                 enable_serial,
                 isolation,
                 boot_mode,
+                ref smbios,
             } => {
                 use openvmm_defs::config::LinuxDirectBootMode;
 
@@ -3342,6 +3330,7 @@ impl LoadedVmInner {
                     cmdline,
                     mem_layout: &self.mem_layout,
                     isolation: super::vm_loaders::linux::KernelIsolationConfig::None,
+                    smbios,
                 };
 
                 let build_acpi = if boot_mode == LinuxDirectBootMode::Acpi {
@@ -3387,7 +3376,7 @@ impl LoadedVmInner {
                 enable_vpci_boot,
                 uefi_console_mode,
                 default_boot_always_attempt,
-                bios_guid,
+                ref smbios,
                 enable_vmbus,
                 force_dma_bounce,
                 enable_hv,
@@ -3425,7 +3414,7 @@ impl LoadedVmInner {
                     serial: enable_serial,
                     uefi_console_mode,
                     default_boot_always_attempt,
-                    bios_guid,
+                    smbios: (**smbios).clone(),
                     vmbus: enable_vmbus,
                     force_dma_bounce,
                     hv: enable_hv,

--- a/openvmm/openvmm_core/src/worker/vm_loaders/linux.rs
+++ b/openvmm/openvmm_core/src/worker/vm_loaders/linux.rs
@@ -52,6 +52,7 @@ pub struct KernelConfig<'a> {
     pub cmdline: &'a str,
     pub mem_layout: &'a MemoryLayout,
     pub isolation: KernelIsolationConfig,
+    pub smbios: &'a openvmm_defs::config::SmbiosConfig,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -106,29 +107,68 @@ fn complete_snp_direct_ram_imports(
     }
 }
 
-/// The default SMBIOS identity for firmware-less Linux direct boot.
+/// Merges the owned SMBIOS override config into the borrowed table view the
+/// builder consumes, substituting the `loader` crate's default strings for any
+/// unset (`None`) override.
 ///
-/// There is no configuration surface yet, so every direct-boot VM gets this
-/// fixed OpenVMM identity. The UUID is left nil.
-fn default_smbios_tables() -> loader::smbios::SmbiosTables<'static> {
+/// This merge lives here in `openvmm_core` because it is the only crate that
+/// sees both the `loader` crate's default string constants and `openvmm_defs`'
+/// override config — `openvmm_defs` deliberately does not duplicate the default
+/// literals, and `loader` does not depend on `openvmm_defs`.
+fn smbios_tables_from_config(
+    config: &openvmm_defs::config::SmbiosConfig,
+) -> loader::smbios::SmbiosTables<'_> {
     use loader::smbios;
+
+    // Destructure fully so that adding a field to `SmbiosConfig` (or either of
+    // its per-type override sub-structs) is a compile error here until it is
+    // wired into the table view, rather than being silently dropped.
+    let openvmm_defs::config::SmbiosConfig { bios, system } = config;
+    let openvmm_defs::config::SmbiosBiosOverrides {
+        vendor,
+        version: bios_version,
+        release_date,
+        release,
+    } = bios;
+    let openvmm_defs::config::SmbiosSystemOverrides {
+        manufacturer,
+        product_name,
+        version: system_version,
+        serial_number,
+        sku_number,
+        family,
+        uuid,
+    } = system;
+
+    const DEFAULT_BIOS_VENDOR: &str = "OpenVMM";
+    const DEFAULT_BIOS_VERSION: &str = "OpenVMM Direct";
+    const DEFAULT_BIOS_RELEASE_DATE: &str = "06/19/2026";
+    const DEFAULT_BIOS_MAJOR: u8 = 0;
+    const DEFAULT_BIOS_MINOR: u8 = 0;
+    const DEFAULT_MANUFACTURER: &str = "OpenVMM";
+    const DEFAULT_PRODUCT_NAME: &str = "OpenVMM Virtual Machine";
 
     smbios::SmbiosTables {
         bios: smbios::SmbiosBiosInfo {
-            vendor: "OpenVMM",
-            version: "OpenVMM Direct",
-            release_date: "06/19/2026",
-            major: 0,
-            minor: 0,
+            vendor: vendor.as_deref().unwrap_or(DEFAULT_BIOS_VENDOR),
+            version: bios_version.as_deref().unwrap_or(DEFAULT_BIOS_VERSION),
+            release_date: release_date.as_deref().unwrap_or(DEFAULT_BIOS_RELEASE_DATE),
+            major: release.map_or(DEFAULT_BIOS_MAJOR, |(major, _)| major),
+            minor: release.map_or(DEFAULT_BIOS_MINOR, |(_, minor)| minor),
         },
         system: smbios::SmbiosSystemInfo {
-            manufacturer: "OpenVMM",
-            product_name: "OpenVMM Virtual Machine",
-            version: "",
-            serial_number: "",
-            sku_number: "",
-            family: "",
-            uuid: [0; 16],
+            manufacturer: manufacturer.as_deref().unwrap_or(DEFAULT_MANUFACTURER),
+            product_name: product_name.as_deref().unwrap_or(DEFAULT_PRODUCT_NAME),
+            version: system_version.as_deref().unwrap_or(""),
+            serial_number: serial_number.as_deref().unwrap_or(""),
+            sku_number: sku_number.as_deref().unwrap_or(""),
+            family: family.as_deref().unwrap_or(""),
+            // SMBIOS (>= 2.6) stores the Type 1 UUID's first three fields
+            // little-endian, which is exactly the in-memory byte layout of our
+            // `Guid` type, so its raw bytes go in directly with no swap. The
+            // UEFI boot path uses the same VM BIOS GUID, so a guest reports the
+            // same `product_uuid` whether booted via UEFI or direct boot.
+            uuid: (*uuid).into(),
         },
     }
 }
@@ -168,7 +208,7 @@ pub fn load_linux_x86(
     let mut loader = Loader::new(gm.clone(), cfg.mem_layout, hvdef::Vtl::Vtl0);
 
     // The loader owns the sub-1 MB layout; we supply only the kernel, command
-    // line, an ACPI builder, and the default SMBIOS identity.
+    // line, an ACPI builder, and the configured SMBIOS identity.
     loader::linux::load_x86(
         &mut loader,
         &mut kernel_file,
@@ -176,7 +216,7 @@ pub fn load_linux_x86(
         &cmdline,
         cfg.mem_layout,
         acpi_at_gpa,
-        Some(default_smbios_tables()),
+        Some(smbios_tables_from_config(cfg.smbios)),
         snp_boot,
     )
     .map_err(Error::Loader)?;
@@ -692,6 +732,7 @@ fn write_efi_and_acpi_tables(
     rsdp_addr: u64,
     mem_layout: &MemoryLayout,
     acpi_tables: &vmm_core::acpi_builder::BuiltAcpiTables,
+    smbios: &openvmm_defs::config::SmbiosConfig,
 ) -> Result<Aarch64EfiInfo, Error> {
     use memory_range::MemoryRange;
     use uefi_specs::uefi::boot::ACPI_20_TABLE_GUID;
@@ -756,7 +797,7 @@ fn write_efi_and_acpi_tables(
     cursor += loader::smbios::ENTRY_POINT_SIZE as u64;
     cursor = align_up(cursor, 16);
     let smbios_table_addr = cursor;
-    let smbios = loader::smbios::build(&default_smbios_tables(), smbios_table_addr);
+    let smbios = loader::smbios::build(&smbios_tables_from_config(smbios), smbios_table_addr);
     cursor += smbios.structure_table.len() as u64;
 
     // Compute how many pages the metadata region spans.
@@ -994,6 +1035,7 @@ pub fn load_linux_arm64(
             rsdp_addr,
             cfg.mem_layout,
             &acpi_tables,
+            cfg.smbios,
         )?;
         build_stub_dt(cfg.cmdline, initrd_start, initrd_end, &efi_info)
             .map_err(|e| Error::Dt(DtError(e)))?

--- a/openvmm/openvmm_core/src/worker/vm_loaders/linux.rs
+++ b/openvmm/openvmm_core/src/worker/vm_loaders/linux.rs
@@ -51,31 +51,71 @@ pub struct KernelConfig<'a> {
     pub cmdline: &'a str,
     pub mem_layout: &'a MemoryLayout,
     pub isolation: Option<IsolationType>,
+    pub smbios: &'a openvmm_defs::config::SmbiosConfig,
 }
 
-/// The default SMBIOS identity for firmware-less Linux direct boot.
+/// Merges the owned SMBIOS override config into the borrowed table view the
+/// builder consumes, substituting the `loader` crate's default strings for any
+/// unset (`None`) override.
 ///
-/// There is no configuration surface yet, so every direct-boot VM gets this
-/// fixed OpenVMM identity. The UUID is left nil.
-fn default_smbios_tables() -> loader::smbios::SmbiosTables<'static> {
+/// This merge lives here in `openvmm_core` because it is the only crate that
+/// sees both the `loader` crate's default string constants and `openvmm_defs`'
+/// override config — `openvmm_defs` deliberately does not duplicate the default
+/// literals, and `loader` does not depend on `openvmm_defs`.
+fn smbios_tables_from_config(
+    config: &openvmm_defs::config::SmbiosConfig,
+) -> loader::smbios::SmbiosTables<'_> {
     use loader::smbios;
+
+    // Destructure fully so that adding a field to `SmbiosConfig` (or either of
+    // its per-type override sub-structs) is a compile error here until it is
+    // wired into the table view, rather than being silently dropped.
+    let openvmm_defs::config::SmbiosConfig { bios, system } = config;
+    let openvmm_defs::config::SmbiosBiosOverrides {
+        vendor,
+        version: bios_version,
+        release_date,
+        release,
+    } = bios;
+    let openvmm_defs::config::SmbiosSystemOverrides {
+        manufacturer,
+        product_name,
+        version: system_version,
+        serial_number,
+        sku_number,
+        family,
+        uuid,
+    } = system;
+
+    const DEFAULT_BIOS_VENDOR: &str = "OpenVMM";
+    const DEFAULT_BIOS_VERSION: &str = "OpenVMM Direct";
+    const DEFAULT_BIOS_RELEASE_DATE: &str = "06/19/2026";
+    const DEFAULT_BIOS_MAJOR: u8 = 0;
+    const DEFAULT_BIOS_MINOR: u8 = 0;
+    const DEFAULT_MANUFACTURER: &str = "OpenVMM";
+    const DEFAULT_PRODUCT_NAME: &str = "OpenVMM Virtual Machine";
 
     smbios::SmbiosTables {
         bios: smbios::SmbiosBiosInfo {
-            vendor: "OpenVMM",
-            version: "OpenVMM Direct",
-            release_date: "06/19/2026",
-            major: 0,
-            minor: 0,
+            vendor: vendor.as_deref().unwrap_or(DEFAULT_BIOS_VENDOR),
+            version: bios_version.as_deref().unwrap_or(DEFAULT_BIOS_VERSION),
+            release_date: release_date.as_deref().unwrap_or(DEFAULT_BIOS_RELEASE_DATE),
+            major: release.map_or(DEFAULT_BIOS_MAJOR, |(major, _)| major),
+            minor: release.map_or(DEFAULT_BIOS_MINOR, |(_, minor)| minor),
         },
         system: smbios::SmbiosSystemInfo {
-            manufacturer: "OpenVMM",
-            product_name: "OpenVMM Virtual Machine",
-            version: "",
-            serial_number: "",
-            sku_number: "",
-            family: "",
-            uuid: [0; 16],
+            manufacturer: manufacturer.as_deref().unwrap_or(DEFAULT_MANUFACTURER),
+            product_name: product_name.as_deref().unwrap_or(DEFAULT_PRODUCT_NAME),
+            version: system_version.as_deref().unwrap_or(""),
+            serial_number: serial_number.as_deref().unwrap_or(""),
+            sku_number: sku_number.as_deref().unwrap_or(""),
+            family: family.as_deref().unwrap_or(""),
+            // SMBIOS (>= 2.6) stores the Type 1 UUID's first three fields
+            // little-endian, which is exactly the in-memory byte layout of our
+            // `Guid` type, so its raw bytes go in directly with no swap. The
+            // UEFI boot path uses the same VM BIOS GUID, so a guest reports the
+            // same `product_uuid` whether booted via UEFI or direct boot.
+            uuid: (*uuid).into(),
         },
     }
 }
@@ -110,7 +150,7 @@ pub fn load_linux_x86(
     let mut loader = Loader::new(gm.clone(), cfg.mem_layout, hvdef::Vtl::Vtl0);
 
     // The loader owns the sub-1 MB layout; we supply only the kernel, command
-    // line, an ACPI builder, and the default SMBIOS identity.
+    // line, an ACPI builder, and the configured SMBIOS identity.
     loader::linux::load_x86(
         &mut loader,
         &mut kernel_file,
@@ -118,7 +158,7 @@ pub fn load_linux_x86(
         &cmdline,
         cfg.mem_layout,
         acpi_at_gpa,
-        Some(default_smbios_tables()),
+        Some(smbios_tables_from_config(cfg.smbios)),
         snp_boot,
     )
     .map_err(Error::Loader)?;
@@ -611,6 +651,7 @@ fn write_efi_and_acpi_tables(
     rsdp_addr: u64,
     mem_layout: &MemoryLayout,
     acpi_tables: &vmm_core::acpi_builder::BuiltAcpiTables,
+    smbios: &openvmm_defs::config::SmbiosConfig,
 ) -> Result<Aarch64EfiInfo, Error> {
     use memory_range::MemoryRange;
     use uefi_specs::uefi::boot::ACPI_20_TABLE_GUID;
@@ -675,7 +716,7 @@ fn write_efi_and_acpi_tables(
     cursor += loader::smbios::ENTRY_POINT_SIZE as u64;
     cursor = align_up(cursor, 16);
     let smbios_table_addr = cursor;
-    let smbios = loader::smbios::build(&default_smbios_tables(), smbios_table_addr);
+    let smbios = loader::smbios::build(&smbios_tables_from_config(smbios), smbios_table_addr);
     cursor += smbios.structure_table.len() as u64;
 
     // Compute how many pages the metadata region spans.
@@ -903,6 +944,7 @@ pub fn load_linux_arm64(
             rsdp_addr,
             cfg.mem_layout,
             &acpi_tables,
+            cfg.smbios,
         )?;
         build_stub_dt(cfg.cmdline, initrd_start, initrd_end, &efi_info)
             .map_err(|e| Error::Dt(DtError(e)))?

--- a/openvmm/openvmm_core/src/worker/vm_loaders/linux.rs
+++ b/openvmm/openvmm_core/src/worker/vm_loaders/linux.rs
@@ -110,19 +110,12 @@ fn complete_snp_direct_ram_imports(
 /// Merges the owned SMBIOS override config into the borrowed table view the
 /// builder consumes, substituting the `loader` crate's default strings for any
 /// unset (`None`) override.
-///
-/// This merge lives here in `openvmm_core` because it is the only crate that
-/// sees both the `loader` crate's default string constants and `openvmm_defs`'
-/// override config — `openvmm_defs` deliberately does not duplicate the default
-/// literals, and `loader` does not depend on `openvmm_defs`.
 fn smbios_tables_from_config(
     config: &openvmm_defs::config::SmbiosConfig,
 ) -> loader::smbios::SmbiosTables<'_> {
     use loader::smbios;
 
-    // Destructure fully so that adding a field to `SmbiosConfig` (or either of
-    // its per-type override sub-structs) is a compile error here until it is
-    // wired into the table view, rather than being silently dropped.
+    // Destructure fully so new fields must be wired into the table view.
     let openvmm_defs::config::SmbiosConfig { bios, system } = config;
     let openvmm_defs::config::SmbiosBiosOverrides {
         vendor,

--- a/openvmm/openvmm_core/src/worker/vm_loaders/pcat.rs
+++ b/openvmm/openvmm_core/src/worker/vm_loaders/pcat.rs
@@ -11,6 +11,8 @@ use vm_topology::memory::MemoryLayout;
 pub enum Error {
     #[error("pcat loader error")]
     Loader(#[source] loader::pcat::Error),
+    #[error("{0} is not configurable on PCAT boot")]
+    UnsupportedSmbiosField(&'static str),
 }
 
 /// Load the PCAT BIOS.
@@ -22,4 +24,86 @@ pub fn load_pcat(gm: &GuestMemory, mem_layout: &MemoryLayout) -> Result<Vec<X86R
     let mut loader = Loader::new(gm.clone(), mem_layout, hvdef::Vtl::Vtl0);
     loader::pcat::load(&mut loader, None, mem_layout.max_ram_below_4gb()).map_err(Error::Loader)?;
     Ok(loader.initial_regs())
+}
+
+/// Adapt the shared [`openvmm_defs::config::SmbiosConfig`] into the PCAT BIOS's
+/// [`firmware_pcat::config::SmbiosConstants`].
+///
+/// The PCAT BIOS ROM builds the SMBIOS tables itself and only queries the host
+/// for a fixed set of values over an I/O port. Only the system UUID (BIOS GUID)
+/// and system serial number have a corresponding query, so those are the only
+/// overrides that can be honored. Every other override is rejected (fail
+/// closed) rather than being silently dropped, mirroring the UEFI path's
+/// handling of fields the firmware self-describes.
+#[cfg_attr(not(guest_arch = "x86_64"), expect(dead_code))]
+pub fn smbios_constants_from_config(
+    smbios: &openvmm_defs::config::SmbiosConfig,
+) -> Result<firmware_pcat::config::SmbiosConstants, Error> {
+    let openvmm_defs::config::SmbiosConfig {
+        bios:
+            openvmm_defs::config::SmbiosBiosOverrides {
+                vendor,
+                version: bios_version,
+                release_date,
+                release,
+            },
+        system:
+            openvmm_defs::config::SmbiosSystemOverrides {
+                manufacturer,
+                product_name,
+                version: system_version,
+                serial_number,
+                sku_number,
+                family,
+                uuid,
+            },
+    } = smbios;
+
+    // Type 0 (BIOS Information): the PCAT BIOS ROM self-describes the BIOS, so
+    // reject any override rather than silently dropping it.
+    if vendor.is_some() {
+        return Err(Error::UnsupportedSmbiosField("SMBIOS BIOS vendor"));
+    }
+    if bios_version.is_some() {
+        return Err(Error::UnsupportedSmbiosField("SMBIOS BIOS version"));
+    }
+    if release_date.is_some() {
+        return Err(Error::UnsupportedSmbiosField("SMBIOS BIOS release date"));
+    }
+    if release.is_some() {
+        return Err(Error::UnsupportedSmbiosField("SMBIOS BIOS release"));
+    }
+
+    // Type 1 (System Information): the BIOS ROM hardcodes these strings and
+    // exposes no query for them, so reject overrides. Only the UUID and serial
+    // number are delivered to the ROM.
+    if manufacturer.is_some() {
+        return Err(Error::UnsupportedSmbiosField("SMBIOS system manufacturer"));
+    }
+    if product_name.is_some() {
+        return Err(Error::UnsupportedSmbiosField("SMBIOS system product name"));
+    }
+    if system_version.is_some() {
+        return Err(Error::UnsupportedSmbiosField("SMBIOS system version"));
+    }
+    if sku_number.is_some() {
+        return Err(Error::UnsupportedSmbiosField("SMBIOS system SKU number"));
+    }
+    if family.is_some() {
+        return Err(Error::UnsupportedSmbiosField("SMBIOS system family"));
+    }
+
+    Ok(firmware_pcat::config::SmbiosConstants {
+        bios_guid: *uuid,
+        system_serial_number: serial_number.clone().unwrap_or_default().into_bytes(),
+        // The remaining fields have no shared-config representation yet. Leave
+        // them empty.
+        base_board_serial_number: Vec::new(),
+        chassis_serial_number: Vec::new(),
+        chassis_asset_tag: Vec::new(),
+        bios_lock_string: Vec::new(),
+        processor_manufacturer: b"\0".to_vec(),
+        processor_version: b"\0".to_vec(),
+        cpu_info_bundle: None,
+    })
 }

--- a/openvmm/openvmm_core/src/worker/vm_loaders/uefi.rs
+++ b/openvmm/openvmm_core/src/worker/vm_loaders/uefi.rs
@@ -3,7 +3,6 @@
 
 use crate::worker::memory_layout::ChipsetMmioRanges;
 use guestmem::GuestMemory;
-use guid::Guid;
 use hvdef::HV_PAGE_SIZE;
 use loader::importer::Register;
 use loader::uefi::IMAGE_SIZE;
@@ -26,6 +25,8 @@ pub enum Error {
     Loader(#[source] loader::uefi::Error),
     #[error("failed to build PCIe ACPI tables")]
     PcieAcpi(#[source] vmm_core::acpi_builder::PcieAcpiBuildError),
+    #[error("SMBIOS field `{0}` cannot be configured on UEFI boot")]
+    UnsupportedSmbiosField(&'static str),
     #[cfg(guest_arch = "aarch64")]
     #[error("UEFI boot with GICv2 is not supported")]
     GicV2NotSupported,
@@ -43,7 +44,12 @@ pub struct UefiLoadSettings {
     pub serial: bool,
     pub uefi_console_mode: Option<UefiConsoleMode>,
     pub default_boot_always_attempt: bool,
-    pub bios_guid: Guid,
+    /// SMBIOS (DMI) configuration. The system UUID is delivered as the VM's
+    /// `BiosGuid`, and any set Type 1 (System Information) overrides are emitted
+    /// as config blobs so the firmware reports the configured identity. Type 0
+    /// (BIOS) overrides are rejected because the firmware self-describes the
+    /// BIOS (see [`add_smbios_blobs`]).
+    pub smbios: openvmm_defs::config::SmbiosConfig,
     /// Whether VMBus is present in this VM. When `false`, the firmware's
     /// `vmbus_disabled` flag is set; the `MmioRanges` blob is still provided
     /// but the high MMIO range will be empty. The firmware must support this
@@ -146,7 +152,6 @@ pub fn load_uefi(params: &LoadUefiParams<'_>) -> Result<Vec<Register>, Error> {
         flags: 0,
     })
     .add_raw(config::BlobStructureType::MemoryMap, memory_map.as_bytes())
-    .add(&config::BiosGuid(settings.bios_guid))
     .add(&config::Entropy(entropy))
     .add(&config::MmioRanges([
         config::Mmio {
@@ -169,6 +174,11 @@ pub fn load_uefi(params: &LoadUefiParams<'_>) -> Result<Vec<Register>, Error> {
         },
     })
     .add(&flags);
+
+    // Emit the SMBIOS configuration: the system UUID (as the VM's `BiosGuid`)
+    // plus any overridden Type 1 strings. Rejects overrides the firmware can't
+    // honor.
+    add_smbios_blobs(&mut cfg, &settings.smbios)?;
 
     #[cfg(guest_arch = "aarch64")]
     {
@@ -230,4 +240,154 @@ pub fn load_uefi(params: &LoadUefiParams<'_>) -> Result<Vec<Register>, Error> {
     .map_err(Error::Loader)?;
 
     Ok(loader.initial_regs())
+}
+
+/// Adds the SMBIOS configuration to the UEFI config blob, failing closed on any
+/// override the firmware can't honor.
+///
+/// On UEFI boot the firmware builds the SMBIOS tables itself, so only fields
+/// with a corresponding config blob can be overridden. The entire
+/// [`SmbiosConfig`](openvmm_defs::config::SmbiosConfig) is destructured here in
+/// one place so every field must be explicitly handled — emitted as a blob, or
+/// rejected with an error because the firmware self-describes it. Adding a field
+/// to `SmbiosConfig` is therefore a compile error until its UEFI handling is
+/// decided, rather than being silently dropped. As blobs are added for
+/// currently-unsupported fields, the corresponding override simply stops
+/// erroring.
+fn add_smbios_blobs(
+    cfg: &mut config::Blob,
+    smbios: &openvmm_defs::config::SmbiosConfig,
+) -> Result<(), Error> {
+    use config::BlobStructureType;
+
+    let openvmm_defs::config::SmbiosConfig {
+        bios:
+            openvmm_defs::config::SmbiosBiosOverrides {
+                vendor,
+                version: bios_version,
+                release_date,
+                release,
+            },
+        system:
+            openvmm_defs::config::SmbiosSystemOverrides {
+                manufacturer,
+                product_name,
+                version: system_version,
+                serial_number,
+                sku_number,
+                family,
+                uuid,
+            },
+    } = smbios;
+
+    // Type 0 (BIOS Information) has no config blobs: the firmware self-describes
+    // the BIOS, so reject any override rather than silently dropping it.
+    if vendor.is_some() {
+        return Err(Error::UnsupportedSmbiosField("BIOS vendor"));
+    }
+    if bios_version.is_some() {
+        return Err(Error::UnsupportedSmbiosField("BIOS version"));
+    }
+    if release_date.is_some() {
+        return Err(Error::UnsupportedSmbiosField("BIOS release date"));
+    }
+    if release.is_some() {
+        return Err(Error::UnsupportedSmbiosField("BIOS release"));
+    }
+
+    // Type 1 (System Information): the UUID is always delivered as the VM's
+    // `BiosGuid`; the string fields are emitted only when overridden (otherwise
+    // the firmware uses its own default).
+    cfg.add(&config::BiosGuid(*uuid));
+    for (structure_type, value) in [
+        (BlobStructureType::SmbiosSystemManufacturer, manufacturer),
+        (BlobStructureType::SmbiosSystemProductName, product_name),
+        (BlobStructureType::SmbiosSystemVersion, system_version),
+        (BlobStructureType::SmbiosSystemSerialNumber, serial_number),
+        (BlobStructureType::SmbiosSystemSkuNumber, sku_number),
+        (BlobStructureType::SmbiosSystemFamily, family),
+    ] {
+        if let Some(value) = value {
+            cfg.add_cstring(structure_type, value.as_bytes());
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use openvmm_defs::config::SmbiosBiosOverrides;
+    use openvmm_defs::config::SmbiosConfig;
+    use openvmm_defs::config::SmbiosSystemOverrides;
+
+    #[test]
+    fn accepts_system_overrides() {
+        let smbios = SmbiosConfig {
+            bios: SmbiosBiosOverrides::default(),
+            system: SmbiosSystemOverrides {
+                manufacturer: Some("Acme".to_string()),
+                family: Some("Widgets".to_string()),
+                ..Default::default()
+            },
+        };
+        let mut cfg = config::Blob::new();
+        add_smbios_blobs(&mut cfg, &smbios).unwrap();
+    }
+
+    #[test]
+    fn rejects_bios_overrides() {
+        for bios in [
+            SmbiosBiosOverrides {
+                vendor: Some("Acme".to_string()),
+                ..Default::default()
+            },
+            SmbiosBiosOverrides {
+                version: Some("1.0".to_string()),
+                ..Default::default()
+            },
+            SmbiosBiosOverrides {
+                release_date: Some("01/01/2020".to_string()),
+                ..Default::default()
+            },
+            SmbiosBiosOverrides {
+                release: Some((4, 1)),
+                ..Default::default()
+            },
+        ] {
+            let smbios = SmbiosConfig {
+                bios,
+                system: SmbiosSystemOverrides::default(),
+            };
+            let mut cfg = config::Blob::new();
+            assert!(matches!(
+                add_smbios_blobs(&mut cfg, &smbios),
+                Err(Error::UnsupportedSmbiosField(_))
+            ));
+        }
+    }
+
+    #[test]
+    fn emits_uuid_and_only_set_string_overrides() {
+        // The default config (no string overrides) still emits the `BiosGuid`.
+        let mut cfg = config::Blob::new();
+        add_smbios_blobs(&mut cfg, &SmbiosConfig::default()).unwrap();
+        let baseline = cfg.complete().len();
+
+        // Setting a Type 1 string override emits an additional blob.
+        let mut cfg = config::Blob::new();
+        add_smbios_blobs(
+            &mut cfg,
+            &SmbiosConfig {
+                system: SmbiosSystemOverrides {
+                    manufacturer: Some("Acme".to_string()),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert!(cfg.complete().len() > baseline);
+    }
 }

--- a/openvmm/openvmm_core/src/worker/vm_loaders/uefi.rs
+++ b/openvmm/openvmm_core/src/worker/vm_loaders/uefi.rs
@@ -3,7 +3,6 @@
 
 use crate::worker::memory_layout::ChipsetMmioRanges;
 use guestmem::GuestMemory;
-use guid::Guid;
 use hvdef::HV_PAGE_SIZE;
 use loader::importer::Register;
 use loader::uefi::IMAGE_SIZE;
@@ -26,6 +25,8 @@ pub enum Error {
     Loader(#[source] loader::uefi::Error),
     #[error("failed to build PCIe ACPI tables")]
     PcieAcpi(#[source] vmm_core::acpi_builder::PcieAcpiBuildError),
+    #[error("SMBIOS field `{0}` cannot be configured on UEFI boot")]
+    UnsupportedSmbiosField(&'static str),
     #[cfg(guest_arch = "aarch64")]
     #[error("UEFI boot with GICv2 is not supported")]
     GicV2NotSupported,
@@ -42,7 +43,12 @@ pub struct UefiLoadSettings {
     pub serial: bool,
     pub uefi_console_mode: Option<UefiConsoleMode>,
     pub default_boot_always_attempt: bool,
-    pub bios_guid: Guid,
+    /// SMBIOS (DMI) configuration. The system UUID is delivered as the VM's
+    /// `BiosGuid`, and any set Type 1 (System Information) overrides are emitted
+    /// as config blobs so the firmware reports the configured identity. Type 0
+    /// (BIOS) overrides are rejected because the firmware self-describes the
+    /// BIOS (see [`add_smbios_blobs`]).
+    pub smbios: openvmm_defs::config::SmbiosConfig,
     /// Whether VMBus is present in this VM. When `false`, the firmware's
     /// `vmbus_disabled` flag is set; the `MmioRanges` blob is still provided
     /// but the high MMIO range will be empty. The firmware must support this
@@ -143,7 +149,6 @@ pub fn load_uefi(params: &LoadUefiParams<'_>) -> Result<Vec<Register>, Error> {
         flags: 0,
     })
     .add_raw(config::BlobStructureType::MemoryMap, memory_map.as_bytes())
-    .add(&config::BiosGuid(settings.bios_guid))
     .add(&config::Entropy(entropy))
     .add(&config::MmioRanges([
         config::Mmio {
@@ -166,6 +171,11 @@ pub fn load_uefi(params: &LoadUefiParams<'_>) -> Result<Vec<Register>, Error> {
         },
     })
     .add(&flags);
+
+    // Emit the SMBIOS configuration: the system UUID (as the VM's `BiosGuid`)
+    // plus any overridden Type 1 strings. Rejects overrides the firmware can't
+    // honor.
+    add_smbios_blobs(&mut cfg, &settings.smbios)?;
 
     #[cfg(guest_arch = "aarch64")]
     {
@@ -226,4 +236,154 @@ pub fn load_uefi(params: &LoadUefiParams<'_>) -> Result<Vec<Register>, Error> {
     .map_err(Error::Loader)?;
 
     Ok(loader.initial_regs())
+}
+
+/// Adds the SMBIOS configuration to the UEFI config blob, failing closed on any
+/// override the firmware can't honor.
+///
+/// On UEFI boot the firmware builds the SMBIOS tables itself, so only fields
+/// with a corresponding config blob can be overridden. The entire
+/// [`SmbiosConfig`](openvmm_defs::config::SmbiosConfig) is destructured here in
+/// one place so every field must be explicitly handled — emitted as a blob, or
+/// rejected with an error because the firmware self-describes it. Adding a field
+/// to `SmbiosConfig` is therefore a compile error until its UEFI handling is
+/// decided, rather than being silently dropped. As blobs are added for
+/// currently-unsupported fields, the corresponding override simply stops
+/// erroring.
+fn add_smbios_blobs(
+    cfg: &mut config::Blob,
+    smbios: &openvmm_defs::config::SmbiosConfig,
+) -> Result<(), Error> {
+    use config::BlobStructureType;
+
+    let openvmm_defs::config::SmbiosConfig {
+        bios:
+            openvmm_defs::config::SmbiosBiosOverrides {
+                vendor,
+                version: bios_version,
+                release_date,
+                release,
+            },
+        system:
+            openvmm_defs::config::SmbiosSystemOverrides {
+                manufacturer,
+                product_name,
+                version: system_version,
+                serial_number,
+                sku_number,
+                family,
+                uuid,
+            },
+    } = smbios;
+
+    // Type 0 (BIOS Information) has no config blobs: the firmware self-describes
+    // the BIOS, so reject any override rather than silently dropping it.
+    if vendor.is_some() {
+        return Err(Error::UnsupportedSmbiosField("BIOS vendor"));
+    }
+    if bios_version.is_some() {
+        return Err(Error::UnsupportedSmbiosField("BIOS version"));
+    }
+    if release_date.is_some() {
+        return Err(Error::UnsupportedSmbiosField("BIOS release date"));
+    }
+    if release.is_some() {
+        return Err(Error::UnsupportedSmbiosField("BIOS release"));
+    }
+
+    // Type 1 (System Information): the UUID is always delivered as the VM's
+    // `BiosGuid`; the string fields are emitted only when overridden (otherwise
+    // the firmware uses its own default).
+    cfg.add(&config::BiosGuid(*uuid));
+    for (structure_type, value) in [
+        (BlobStructureType::SmbiosSystemManufacturer, manufacturer),
+        (BlobStructureType::SmbiosSystemProductName, product_name),
+        (BlobStructureType::SmbiosSystemVersion, system_version),
+        (BlobStructureType::SmbiosSystemSerialNumber, serial_number),
+        (BlobStructureType::SmbiosSystemSkuNumber, sku_number),
+        (BlobStructureType::SmbiosSystemFamily, family),
+    ] {
+        if let Some(value) = value {
+            cfg.add_cstring(structure_type, value.as_bytes());
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use openvmm_defs::config::SmbiosBiosOverrides;
+    use openvmm_defs::config::SmbiosConfig;
+    use openvmm_defs::config::SmbiosSystemOverrides;
+
+    #[test]
+    fn accepts_system_overrides() {
+        let smbios = SmbiosConfig {
+            bios: SmbiosBiosOverrides::default(),
+            system: SmbiosSystemOverrides {
+                manufacturer: Some("Acme".to_string()),
+                family: Some("Widgets".to_string()),
+                ..Default::default()
+            },
+        };
+        let mut cfg = config::Blob::new();
+        add_smbios_blobs(&mut cfg, &smbios).unwrap();
+    }
+
+    #[test]
+    fn rejects_bios_overrides() {
+        for bios in [
+            SmbiosBiosOverrides {
+                vendor: Some("Acme".to_string()),
+                ..Default::default()
+            },
+            SmbiosBiosOverrides {
+                version: Some("1.0".to_string()),
+                ..Default::default()
+            },
+            SmbiosBiosOverrides {
+                release_date: Some("01/01/2020".to_string()),
+                ..Default::default()
+            },
+            SmbiosBiosOverrides {
+                release: Some((4, 1)),
+                ..Default::default()
+            },
+        ] {
+            let smbios = SmbiosConfig {
+                bios,
+                system: SmbiosSystemOverrides::default(),
+            };
+            let mut cfg = config::Blob::new();
+            assert!(matches!(
+                add_smbios_blobs(&mut cfg, &smbios),
+                Err(Error::UnsupportedSmbiosField(_))
+            ));
+        }
+    }
+
+    #[test]
+    fn emits_uuid_and_only_set_string_overrides() {
+        // The default config (no string overrides) still emits the `BiosGuid`.
+        let mut cfg = config::Blob::new();
+        add_smbios_blobs(&mut cfg, &SmbiosConfig::default()).unwrap();
+        let baseline = cfg.complete().len();
+
+        // Setting a Type 1 string override emits an additional blob.
+        let mut cfg = config::Blob::new();
+        add_smbios_blobs(
+            &mut cfg,
+            &SmbiosConfig {
+                system: SmbiosSystemOverrides {
+                    manufacturer: Some("Acme".to_string()),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert!(cfg.complete().len() > baseline);
+    }
 }

--- a/openvmm/openvmm_defs/Cargo.toml
+++ b/openvmm/openvmm_defs/Cargo.toml
@@ -22,6 +22,7 @@ get_resources.workspace = true
 ide_resources.workspace = true
 input_core.workspace = true
 net_backend_resources.workspace = true
+smbios_defs.workspace = true
 virt.workspace = true
 vmm_core_defs.workspace = true
 

--- a/openvmm/openvmm_defs/src/config.rs
+++ b/openvmm/openvmm_defs/src/config.rs
@@ -130,6 +130,13 @@ pub enum LinuxIsolationConfig {
     },
 }
 
+/// SMBIOS (DMI) identity configuration, shared with the Guest Emulation
+/// Transport and the firmware load paths. Defined in [`smbios_defs`] so that
+/// both `openvmm_defs` and `get_resources` reference a single representation.
+pub use smbios_defs::SmbiosBiosOverrides;
+pub use smbios_defs::SmbiosConfig;
+pub use smbios_defs::SmbiosSystemOverrides;
+
 #[derive(MeshPayload, Debug)]
 pub enum LoadMode {
     Linux {
@@ -139,6 +146,8 @@ pub enum LoadMode {
         enable_serial: bool,
         isolation: LinuxIsolationConfig,
         boot_mode: LinuxDirectBootMode,
+        // Boxed to keep the `Linux` variant from dominating `LoadMode`'s size.
+        smbios: Box<SmbiosConfig>,
     },
     Uefi {
         firmware: File,
@@ -151,7 +160,10 @@ pub enum LoadMode {
         enable_vpci_boot: bool,
         uefi_console_mode: Option<UefiConsoleMode>,
         default_boot_always_attempt: bool,
-        bios_guid: Guid,
+        // Boxed to keep the `Uefi` variant from dominating `LoadMode`'s size.
+        // The VM's BIOS GUID is sourced from `smbios.system.uuid`, so UEFI and
+        // Linux direct boot share a single UUID origin.
+        smbios: Box<SmbiosConfig>,
         enable_vmbus: bool,
         force_dma_bounce: bool,
         enable_hv: bool,
@@ -163,6 +175,10 @@ pub enum LoadMode {
         boot_order: [PcatBootDevice; 4],
         /// Whether the guest firmware should enable hibernation (S4) support.
         hibernation_enabled: bool,
+        // Boxed to keep the `Pcat` variant from dominating `LoadMode`'s size.
+        // Only the system UUID and serial number are honored; the PCAT BIOS ROM
+        // self-describes everything else, so other overrides are rejected.
+        smbios: Box<SmbiosConfig>,
     },
     Igvm {
         file: File,

--- a/openvmm/openvmm_defs/src/config.rs
+++ b/openvmm/openvmm_defs/src/config.rs
@@ -118,6 +118,13 @@ pub enum LinuxDirectBootMode {
     Acpi,
 }
 
+/// SMBIOS (DMI) identity configuration, shared with the Guest Emulation
+/// Transport and the firmware load paths. Defined in [`smbios_defs`] so that
+/// both `openvmm_defs` and `get_resources` reference a single representation.
+pub use smbios_defs::SmbiosBiosOverrides;
+pub use smbios_defs::SmbiosConfig;
+pub use smbios_defs::SmbiosSystemOverrides;
+
 #[derive(MeshPayload, Debug)]
 pub enum LoadMode {
     Linux {
@@ -126,6 +133,8 @@ pub enum LoadMode {
         cmdline: String,
         enable_serial: bool,
         boot_mode: LinuxDirectBootMode,
+        // Boxed to keep the `Linux` variant from dominating `LoadMode`'s size.
+        smbios: Box<SmbiosConfig>,
     },
     Uefi {
         firmware: File,
@@ -138,13 +147,20 @@ pub enum LoadMode {
         enable_vpci_boot: bool,
         uefi_console_mode: Option<UefiConsoleMode>,
         default_boot_always_attempt: bool,
-        bios_guid: Guid,
+        // Boxed to keep the `Uefi` variant from dominating `LoadMode`'s size.
+        // The VM's BIOS GUID is sourced from `smbios.system.uuid`, so UEFI and
+        // Linux direct boot share a single UUID origin.
+        smbios: Box<SmbiosConfig>,
         enable_vmbus: bool,
         force_dma_bounce: bool,
     },
     Pcat {
         firmware: RomFileLocation,
         boot_order: [PcatBootDevice; 4],
+        // Boxed to keep the `Pcat` variant from dominating `LoadMode`'s size.
+        // Only the system UUID and serial number are honored; the PCAT BIOS ROM
+        // self-describes everything else, so other overrides are rejected.
+        smbios: Box<SmbiosConfig>,
     },
     Igvm {
         file: File,

--- a/openvmm/openvmm_defs/src/config.rs
+++ b/openvmm/openvmm_defs/src/config.rs
@@ -3,6 +3,10 @@
 
 //! Configuration for the VM worker.
 
+pub use smbios_defs::SmbiosBiosOverrides;
+pub use smbios_defs::SmbiosConfig;
+pub use smbios_defs::SmbiosSystemOverrides;
+
 use guid::Guid;
 use input_core::InputData;
 use memory_range::MemoryRange;
@@ -129,13 +133,6 @@ pub enum LinuxIsolationConfig {
         restricted_injection: bool,
     },
 }
-
-/// SMBIOS (DMI) identity configuration, shared with the Guest Emulation
-/// Transport and the firmware load paths. Defined in [`smbios_defs`] so that
-/// both `openvmm_defs` and `get_resources` reference a single representation.
-pub use smbios_defs::SmbiosBiosOverrides;
-pub use smbios_defs::SmbiosConfig;
-pub use smbios_defs::SmbiosSystemOverrides;
 
 #[derive(MeshPayload, Debug)]
 pub enum LoadMode {

--- a/openvmm/openvmm_entry/src/cli_args.rs
+++ b/openvmm/openvmm_entry/src/cli_args.rs
@@ -285,6 +285,44 @@ Examples:
     #[clap(long, conflicts_with_all = ["uefi", "pcat", "igvm"])]
     pub device_tree: bool,
 
+    /// SMBIOS (DMI) identity overrides for Linux direct boot (repeatable).
+    #[clap(
+        long,
+        value_name = "PARAMS",
+        value_parser = parse_smbios,
+        long_help = r#"Override SMBIOS (DMI) identity for Linux direct boot.
+
+Syntax: type=N,key=value[,key=value...]
+
+`type` selects the SMBIOS structure and is required (matching QEMU's
+`-smbios`; there is no default). Key names follow QEMU's `-smbios`
+convention. Unset keys use the loader's built-in default identity. Repeat
+--smbios to set fields across multiple structure types.
+
+Type 0 (BIOS Information):
+    vendor=<STRING>          BIOS vendor
+    version=<STRING>         BIOS version
+    date=<STRING>            BIOS release date
+    release=<MAJOR.MINOR>    System BIOS Major/Minor Release (e.g. 4.1)
+
+Type 1 (System Information):
+    manufacturer=<STRING>    system manufacturer (sys_vendor)
+    product=<STRING>         product name (product_name)
+    version=<STRING>         product version (product_version)
+    serial=<STRING>          serial number (product_serial)
+    uuid=<GUID|random>       system UUID (product_uuid); `random` generates a
+                             fresh per-VM GUID. Unset => all-zero GUID.
+    sku=<STRING>             SKU number (product_sku)
+    family=<STRING>          product family (product_family)
+
+Examples:
+    --smbios type=1,manufacturer=Contoso,product="Virtual Machine"
+    --smbios type=1,uuid=12345678-9abc-def0-1234-56789abcdef0
+    --smbios type=1,uuid=random
+    --smbios type=0,vendor=Contoso,version=1.0"#
+    )]
+    pub smbios: Vec<SmbiosCli>,
+
     /// enable vtl2 - only supported in WHP and simulated without hypervisor support currently
     ///
     /// Currently implies --get.
@@ -1557,6 +1595,212 @@ fn parse_acs_capability_mask(value: &str) -> anyhow::Result<u16> {
     } else {
         value.parse::<u16>().context("invalid ACS capability mask")
     }
+}
+
+/// A parsed SMBIOS `release=MAJOR.MINOR` value: exactly two `u8` components
+/// separated by a dot, matching QEMU's `sscanf("%hhu.%hhu")`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SmbiosRelease(pub u8, pub u8);
+
+impl FromStr for SmbiosRelease {
+    type Err = anyhow::Error;
+
+    fn from_str(value: &str) -> anyhow::Result<Self> {
+        let (major, minor) = value
+            .split_once('.')
+            .with_context(|| format!("invalid smbios release '{value}', expected MAJOR.MINOR"))?;
+        let major = major
+            .parse::<u8>()
+            .with_context(|| format!("invalid smbios release major '{major}'"))?;
+        let minor = minor
+            .parse::<u8>()
+            .with_context(|| format!("invalid smbios release minor '{minor}'"))?;
+        Ok(SmbiosRelease(major, minor))
+    }
+}
+
+/// A parsed SMBIOS `uuid=` value: either an explicit GUID or the literal
+/// `random`, which requests a freshly generated per-VM GUID.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SmbiosUuid {
+    /// Generate a fresh random GUID when the VM is created.
+    Random,
+    /// Use this fixed GUID.
+    Fixed(Guid),
+}
+
+impl FromStr for SmbiosUuid {
+    type Err = anyhow::Error;
+
+    fn from_str(value: &str) -> anyhow::Result<Self> {
+        if value == "random" {
+            Ok(SmbiosUuid::Random)
+        } else {
+            let guid = value
+                .parse::<Guid>()
+                .with_context(|| format!("invalid smbios uuid '{value}'"))?;
+            Ok(SmbiosUuid::Fixed(guid))
+        }
+    }
+}
+
+/// SMBIOS Type 0 (BIOS Information) overrides parsed from a `--smbios type=0,…`
+/// argument. Field names mirror `SmbiosBiosOverrides`.
+#[derive(Debug, Clone, Default, PartialEq, Eq, vmm_cli::KeyValueArgs)]
+pub struct SmbiosBiosCli {
+    /// BIOS vendor (`vendor`).
+    pub vendor: Option<String>,
+    /// BIOS version (`version`).
+    pub version: Option<String>,
+    /// BIOS release date (`date`).
+    #[kv(key = "date")]
+    pub release_date: Option<String>,
+    /// System BIOS Major/Minor Release (`release=MAJOR.MINOR`).
+    pub release: Option<SmbiosRelease>,
+}
+
+/// SMBIOS Type 1 (System Information) overrides parsed from a `--smbios type=1,…`
+/// argument. Field names mirror `SmbiosSystemOverrides`.
+#[derive(Debug, Clone, Default, PartialEq, Eq, vmm_cli::KeyValueArgs)]
+pub struct SmbiosSystemCli {
+    /// System manufacturer (`manufacturer`).
+    pub manufacturer: Option<String>,
+    /// System product name (`product`).
+    #[kv(key = "product")]
+    pub product_name: Option<String>,
+    /// System version (`version`).
+    pub version: Option<String>,
+    /// System serial number (`serial`).
+    #[kv(key = "serial")]
+    pub serial_number: Option<String>,
+    /// System SKU number (`sku`).
+    #[kv(key = "sku")]
+    pub sku_number: Option<String>,
+    /// System family (`family`).
+    pub family: Option<String>,
+    /// System UUID (`uuid=GUID` or `uuid=random`).
+    pub uuid: Option<SmbiosUuid>,
+}
+
+/// SMBIOS (DMI) identity overrides parsed from `--smbios` arguments, grouped by
+/// SMBIOS structure type to mirror the required `type=N` CLI prefix and the
+/// loader's `SmbiosConfig` layout.
+///
+/// Each `--smbios` argument targets exactly one type; multiple arguments are
+/// merged with [`SmbiosCli::merge`].
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct SmbiosCli {
+    /// Type 0 (BIOS Information) overrides.
+    pub bios: SmbiosBiosCli,
+    /// Type 1 (System Information) overrides.
+    pub system: SmbiosSystemCli,
+}
+
+/// Set an override slot, erroring if it is already set.
+fn smbios_set_once<T>(slot: &mut Option<T>, key: &str, value: T) -> anyhow::Result<()> {
+    anyhow::ensure!(slot.is_none(), "duplicate smbios option '{key}'");
+    *slot = Some(value);
+    Ok(())
+}
+
+impl SmbiosCli {
+    /// Merge another parsed `--smbios` argument into this one, erroring if any
+    /// field is set by both.
+    pub fn merge(&mut self, other: SmbiosCli) -> anyhow::Result<()> {
+        let SmbiosCli {
+            bios:
+                SmbiosBiosCli {
+                    vendor,
+                    version: bios_version,
+                    release_date,
+                    release,
+                },
+            system:
+                SmbiosSystemCli {
+                    manufacturer,
+                    product_name,
+                    version: system_version,
+                    serial_number,
+                    sku_number,
+                    family,
+                    uuid,
+                },
+        } = other;
+        merge_smbios_field(&mut self.bios.vendor, vendor, 0, "vendor")?;
+        merge_smbios_field(&mut self.bios.version, bios_version, 0, "version")?;
+        merge_smbios_field(&mut self.bios.release_date, release_date, 0, "date")?;
+        merge_smbios_field(&mut self.bios.release, release, 0, "release")?;
+        merge_smbios_field(
+            &mut self.system.manufacturer,
+            manufacturer,
+            1,
+            "manufacturer",
+        )?;
+        merge_smbios_field(&mut self.system.product_name, product_name, 1, "product")?;
+        merge_smbios_field(&mut self.system.version, system_version, 1, "version")?;
+        merge_smbios_field(&mut self.system.serial_number, serial_number, 1, "serial")?;
+        merge_smbios_field(&mut self.system.sku_number, sku_number, 1, "sku")?;
+        merge_smbios_field(&mut self.system.family, family, 1, "family")?;
+        merge_smbios_field(&mut self.system.uuid, uuid, 1, "uuid")?;
+        Ok(())
+    }
+}
+
+/// Merge a single override field, erroring if both sides are set. `typ` is the
+/// SMBIOS structure type the field belongs to, included in the error message.
+fn merge_smbios_field<T>(
+    dst: &mut Option<T>,
+    src: Option<T>,
+    typ: u8,
+    key: &str,
+) -> anyhow::Result<()> {
+    if let Some(value) = src {
+        smbios_set_once(dst, &format!("type={typ} {key}"), value)?;
+    }
+    Ok(())
+}
+
+/// Parse a single `--smbios` argument: `type=N,key=value[,key=value...]`.
+///
+/// Matches QEMU's `-smbios` syntax: `type=N` is required (there is no default)
+/// and selects the key namespace; the remaining `key=value` pairs are parsed by
+/// the matching per-type `KeyValueArgs` struct. Unknown types and unknown keys
+/// are hard errors (no silent drop).
+fn parse_smbios(s: &str) -> anyhow::Result<SmbiosCli> {
+    let mut typ: Option<u8> = None;
+    let mut rest = Vec::new();
+    for part in s.split(',') {
+        let (key, value) = part
+            .split_once('=')
+            .with_context(|| format!("invalid smbios option '{part}', expected key=value"))?;
+        if key.is_empty() || value.is_empty() {
+            anyhow::bail!("invalid smbios option '{part}', expected key=value");
+        }
+        if key == "type" {
+            anyhow::ensure!(typ.is_none(), "duplicate smbios option 'type'");
+            typ = Some(
+                value
+                    .parse::<u8>()
+                    .with_context(|| format!("invalid smbios type '{value}'"))?,
+            );
+        } else {
+            rest.push(part);
+        }
+    }
+
+    let typ = typ.context("smbios option requires 'type=N' (e.g. 'type=1')")?;
+    let rest = rest.join(",");
+    Ok(match typ {
+        0 => SmbiosCli {
+            bios: rest.parse()?,
+            ..Default::default()
+        },
+        1 => SmbiosCli {
+            system: rest.parse()?,
+            ..Default::default()
+        },
+        other => anyhow::bail!("unsupported smbios type '{other}' (expected 0 or 1)"),
+    })
 }
 
 fn parse_memory_config(s: &str) -> anyhow::Result<MemoryCli> {
@@ -4766,6 +5010,190 @@ mod tests {
                 .hugepage_size,
             Some(vmm_cli::MemorySize(3 * 1024 * 1024))
         );
+    }
+
+    #[test]
+    fn test_smbios_requires_type() {
+        // Matching QEMU, `type=` is mandatory — there is no default.
+        assert!(parse_smbios("manufacturer=Contoso,family=Foo").is_err());
+    }
+
+    #[test]
+    fn test_smbios_all_system_keys() {
+        let parsed = parse_smbios(
+            "type=1,manufacturer=M,product=P,version=V,serial=S,sku=K,family=F,\
+             uuid=12345678-9abc-def0-1234-56789abcdef0",
+        )
+        .unwrap();
+        assert_eq!(
+            parsed,
+            SmbiosCli {
+                system: SmbiosSystemCli {
+                    manufacturer: Some("M".to_string()),
+                    product_name: Some("P".to_string()),
+                    version: Some("V".to_string()),
+                    serial_number: Some("S".to_string()),
+                    sku_number: Some("K".to_string()),
+                    family: Some("F".to_string()),
+                    uuid: Some(SmbiosUuid::Fixed(
+                        "12345678-9abc-def0-1234-56789abcdef0"
+                            .parse::<Guid>()
+                            .unwrap()
+                    )),
+                },
+                ..Default::default()
+            }
+        );
+    }
+
+    #[test]
+    fn test_smbios_bios_keys() {
+        let parsed =
+            parse_smbios("type=0,vendor=Contoso,version=1.0,date=01/01/2026,release=4.1").unwrap();
+        assert_eq!(
+            parsed,
+            SmbiosCli {
+                bios: SmbiosBiosCli {
+                    vendor: Some("Contoso".to_string()),
+                    version: Some("1.0".to_string()),
+                    release_date: Some("01/01/2026".to_string()),
+                    release: Some(SmbiosRelease(4, 1)),
+                },
+                ..Default::default()
+            }
+        );
+    }
+
+    #[test]
+    fn test_smbios_release_parsing() {
+        // Valid MAJOR.MINOR.
+        assert_eq!(
+            parse_smbios("type=0,release=4.1").unwrap().bios.release,
+            Some(SmbiosRelease(4, 1))
+        );
+        assert_eq!(
+            parse_smbios("type=0,release=255.0").unwrap().bios.release,
+            Some(SmbiosRelease(255, 0))
+        );
+        // Missing the dot, extra components, out-of-range, and non-numeric all
+        // error (matching QEMU's strict two-`u8` parse).
+        assert!(parse_smbios("type=0,release=4").is_err());
+        assert!(parse_smbios("type=0,release=4.1.0").is_err());
+        assert!(parse_smbios("type=0,release=256.0").is_err());
+        assert!(parse_smbios("type=0,release=x.y").is_err());
+        // `release` is a type=0 key only.
+        assert!(parse_smbios("type=1,release=4.1").is_err());
+    }
+
+    #[test]
+    fn test_smbios_uuid() {
+        // An explicit GUID parses to `Fixed`.
+        assert_eq!(
+            parse_smbios("type=1,uuid=12345678-9abc-def0-1234-56789abcdef0")
+                .unwrap()
+                .system
+                .uuid,
+            Some(SmbiosUuid::Fixed(
+                "12345678-9abc-def0-1234-56789abcdef0"
+                    .parse::<Guid>()
+                    .unwrap()
+            ))
+        );
+        // The literal `random` parses to `Random`.
+        assert_eq!(
+            parse_smbios("type=1,uuid=random").unwrap().system.uuid,
+            Some(SmbiosUuid::Random)
+        );
+    }
+
+    #[test]
+    fn test_smbios_version_disambiguated_by_type() {
+        // `version` belongs to BIOS under type=0 and System under type=1.
+        let bios = parse_smbios("type=0,version=1.0").unwrap();
+        assert_eq!(bios.bios.version.as_deref(), Some("1.0"));
+        assert_eq!(bios.system.version, None);
+
+        let system = parse_smbios("type=1,version=2.0").unwrap();
+        assert_eq!(system.system.version.as_deref(), Some("2.0"));
+        assert_eq!(system.bios.version, None);
+    }
+
+    #[test]
+    fn test_smbios_rejects_invalid() {
+        // Missing type.
+        assert!(parse_smbios("manufacturer=M").is_err());
+        // Unknown key for the type.
+        assert!(parse_smbios("type=0,manufacturer=M").is_err());
+        assert!(parse_smbios("type=1,nonsense=x").is_err());
+        // Unknown / unsupported type.
+        assert!(parse_smbios("type=2,vendor=M").is_err());
+        assert!(parse_smbios("type=bad,vendor=M").is_err());
+        // Malformed key=value.
+        assert!(parse_smbios("type=1,manufacturer").is_err());
+        assert!(parse_smbios("=value").is_err());
+        assert!(parse_smbios("type=1,manufacturer=").is_err());
+        // Duplicate key within one argument.
+        assert!(parse_smbios("type=1,manufacturer=A,manufacturer=B").is_err());
+        assert!(parse_smbios("type=0,type=1,vendor=M").is_err());
+        // Invalid UUID.
+        assert!(parse_smbios("type=1,uuid=not-a-guid").is_err());
+    }
+
+    #[test]
+    fn test_smbios_merge_across_arguments() {
+        let mut merged = SmbiosCli::default();
+        merged
+            .merge(parse_smbios("type=0,vendor=Contoso").unwrap())
+            .unwrap();
+        merged
+            .merge(parse_smbios("type=1,manufacturer=M,family=F").unwrap())
+            .unwrap();
+        assert_eq!(
+            merged,
+            SmbiosCli {
+                bios: SmbiosBiosCli {
+                    vendor: Some("Contoso".to_string()),
+                    ..Default::default()
+                },
+                system: SmbiosSystemCli {
+                    manufacturer: Some("M".to_string()),
+                    family: Some("F".to_string()),
+                    ..Default::default()
+                },
+            }
+        );
+    }
+
+    #[test]
+    fn test_smbios_merge_rejects_conflicts() {
+        let mut merged = SmbiosCli::default();
+        merged
+            .merge(parse_smbios("type=1,manufacturer=A").unwrap())
+            .unwrap();
+        // The same field set by a second argument is a hard error.
+        assert!(
+            merged
+                .merge(parse_smbios("type=1,manufacturer=B").unwrap())
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn test_smbios_arg_repeatable() {
+        let opt = Options::try_parse_from([
+            "openvmm",
+            "--smbios",
+            "type=1,manufacturer=Contoso",
+            "--smbios",
+            "type=0,vendor=Acme",
+        ])
+        .unwrap();
+        assert_eq!(opt.smbios.len(), 2);
+        assert_eq!(
+            opt.smbios[0].system.manufacturer.as_deref(),
+            Some("Contoso")
+        );
+        assert_eq!(opt.smbios[1].bios.vendor.as_deref(), Some("Acme"));
     }
 
     #[test]

--- a/openvmm/openvmm_entry/src/cli_args.rs
+++ b/openvmm/openvmm_entry/src/cli_args.rs
@@ -308,14 +308,13 @@ Examples:
 
 Syntax: type=N,key=value[,key=value...]
 
-`type` selects the SMBIOS structure and is required (matching QEMU's
-`-smbios`; there is no default). Key names follow QEMU's `-smbios`
-convention. Unset keys use the loader's built-in default identity. Repeat
---smbios to set fields across multiple structure types.
+`type` selects the SMBIOS structure and is required; there is no default.
+Unset keys use the loader's built-in default identity. Repeat --smbios to set
+fields across multiple structure types.
 
-Linux direct boot supports all listed fields. UEFI boot supports Type 1
-fields only. PCAT boot supports only Type 1 `serial` and `uuid`. Unsupported
-fields are rejected with an error.
+OpenVMM Linux direct boot supports all listed fields. OpenHCL Linux direct
+boot and UEFI boot support Type 1 fields only. PCAT boot supports only Type 1
+`serial` and `uuid`. Unsupported fields are rejected with an error.
 
 Type 0 (BIOS Information):
     vendor=<STRING>          BIOS vendor
@@ -1691,7 +1690,7 @@ fn parse_acs_capability_mask(value: &str) -> anyhow::Result<u16> {
 }
 
 /// A parsed SMBIOS `release=MAJOR.MINOR` value: exactly two `u8` components
-/// separated by a dot, matching QEMU's `sscanf("%hhu.%hhu")`.
+/// separated by a dot.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SmbiosRelease(pub u8, pub u8);
 
@@ -1855,10 +1854,10 @@ fn merge_smbios_field<T>(
 
 /// Parse a single `--smbios` argument: `type=N,key=value[,key=value...]`.
 ///
-/// Matches QEMU's `-smbios` syntax: `type=N` is required (there is no default)
-/// and selects the key namespace; the remaining `key=value` pairs are parsed by
-/// the matching per-type `KeyValueArgs` struct. Unknown types and unknown keys
-/// are hard errors (no silent drop).
+/// `type=N` is required (there is no default) and selects the key namespace;
+/// the remaining `key=value` pairs are parsed by the matching per-type
+/// `KeyValueArgs` struct. Unknown types and unknown keys are hard errors (no
+/// silent drop).
 fn parse_smbios(s: &str) -> anyhow::Result<SmbiosCli> {
     let mut typ: Option<u8> = None;
     let mut rest = Vec::new();
@@ -5139,7 +5138,7 @@ mod tests {
 
     #[test]
     fn test_smbios_requires_type() {
-        // Matching QEMU, `type=` is mandatory — there is no default.
+        // `type=` is mandatory; there is no default.
         assert!(parse_smbios("manufacturer=Contoso,family=Foo").is_err());
     }
 
@@ -5201,7 +5200,7 @@ mod tests {
             Some(SmbiosRelease(255, 0))
         );
         // Missing the dot, extra components, out-of-range, and non-numeric all
-        // error (matching QEMU's strict two-`u8` parse).
+        // error.
         assert!(parse_smbios("type=0,release=4").is_err());
         assert!(parse_smbios("type=0,release=4.1.0").is_err());
         assert!(parse_smbios("type=0,release=256.0").is_err());

--- a/openvmm/openvmm_entry/src/cli_args.rs
+++ b/openvmm/openvmm_entry/src/cli_args.rs
@@ -299,6 +299,44 @@ Examples:
     #[clap(long, conflicts_with_all = ["uefi", "pcat", "igvm"])]
     pub device_tree: bool,
 
+    /// SMBIOS (DMI) identity overrides for Linux direct boot (repeatable).
+    #[clap(
+        long,
+        value_name = "PARAMS",
+        value_parser = parse_smbios,
+        long_help = r#"Override SMBIOS (DMI) identity for Linux direct boot.
+
+Syntax: type=N,key=value[,key=value...]
+
+`type` selects the SMBIOS structure and is required (matching QEMU's
+`-smbios`; there is no default). Key names follow QEMU's `-smbios`
+convention. Unset keys use the loader's built-in default identity. Repeat
+--smbios to set fields across multiple structure types.
+
+Type 0 (BIOS Information):
+    vendor=<STRING>          BIOS vendor
+    version=<STRING>         BIOS version
+    date=<STRING>            BIOS release date
+    release=<MAJOR.MINOR>    System BIOS Major/Minor Release (e.g. 4.1)
+
+Type 1 (System Information):
+    manufacturer=<STRING>    system manufacturer (sys_vendor)
+    product=<STRING>         product name (product_name)
+    version=<STRING>         product version (product_version)
+    serial=<STRING>          serial number (product_serial)
+    uuid=<GUID|random>       system UUID (product_uuid); `random` generates a
+                             fresh per-VM GUID. Unset => all-zero GUID.
+    sku=<STRING>             SKU number (product_sku)
+    family=<STRING>          product family (product_family)
+
+Examples:
+    --smbios type=1,manufacturer=Contoso,product="Virtual Machine"
+    --smbios type=1,uuid=12345678-9abc-def0-1234-56789abcdef0
+    --smbios type=1,uuid=random
+    --smbios type=0,vendor=Contoso,version=1.0"#
+    )]
+    pub smbios: Vec<SmbiosCli>,
+
     /// enable vtl2 - only supported in WHP and simulated without hypervisor support currently
     ///
     /// Currently implies --get.
@@ -1646,6 +1684,212 @@ fn parse_acs_capability_mask(value: &str) -> anyhow::Result<u16> {
     } else {
         value.parse::<u16>().context("invalid ACS capability mask")
     }
+}
+
+/// A parsed SMBIOS `release=MAJOR.MINOR` value: exactly two `u8` components
+/// separated by a dot, matching QEMU's `sscanf("%hhu.%hhu")`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SmbiosRelease(pub u8, pub u8);
+
+impl FromStr for SmbiosRelease {
+    type Err = anyhow::Error;
+
+    fn from_str(value: &str) -> anyhow::Result<Self> {
+        let (major, minor) = value
+            .split_once('.')
+            .with_context(|| format!("invalid smbios release '{value}', expected MAJOR.MINOR"))?;
+        let major = major
+            .parse::<u8>()
+            .with_context(|| format!("invalid smbios release major '{major}'"))?;
+        let minor = minor
+            .parse::<u8>()
+            .with_context(|| format!("invalid smbios release minor '{minor}'"))?;
+        Ok(SmbiosRelease(major, minor))
+    }
+}
+
+/// A parsed SMBIOS `uuid=` value: either an explicit GUID or the literal
+/// `random`, which requests a freshly generated per-VM GUID.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SmbiosUuid {
+    /// Generate a fresh random GUID when the VM is created.
+    Random,
+    /// Use this fixed GUID.
+    Fixed(Guid),
+}
+
+impl FromStr for SmbiosUuid {
+    type Err = anyhow::Error;
+
+    fn from_str(value: &str) -> anyhow::Result<Self> {
+        if value == "random" {
+            Ok(SmbiosUuid::Random)
+        } else {
+            let guid = value
+                .parse::<Guid>()
+                .with_context(|| format!("invalid smbios uuid '{value}'"))?;
+            Ok(SmbiosUuid::Fixed(guid))
+        }
+    }
+}
+
+/// SMBIOS Type 0 (BIOS Information) overrides parsed from a `--smbios type=0,…`
+/// argument. Field names mirror `SmbiosBiosOverrides`.
+#[derive(Debug, Clone, Default, PartialEq, Eq, vmm_cli::KeyValueArgs)]
+pub struct SmbiosBiosCli {
+    /// BIOS vendor (`vendor`).
+    pub vendor: Option<String>,
+    /// BIOS version (`version`).
+    pub version: Option<String>,
+    /// BIOS release date (`date`).
+    #[kv(key = "date")]
+    pub release_date: Option<String>,
+    /// System BIOS Major/Minor Release (`release=MAJOR.MINOR`).
+    pub release: Option<SmbiosRelease>,
+}
+
+/// SMBIOS Type 1 (System Information) overrides parsed from a `--smbios type=1,…`
+/// argument. Field names mirror `SmbiosSystemOverrides`.
+#[derive(Debug, Clone, Default, PartialEq, Eq, vmm_cli::KeyValueArgs)]
+pub struct SmbiosSystemCli {
+    /// System manufacturer (`manufacturer`).
+    pub manufacturer: Option<String>,
+    /// System product name (`product`).
+    #[kv(key = "product")]
+    pub product_name: Option<String>,
+    /// System version (`version`).
+    pub version: Option<String>,
+    /// System serial number (`serial`).
+    #[kv(key = "serial")]
+    pub serial_number: Option<String>,
+    /// System SKU number (`sku`).
+    #[kv(key = "sku")]
+    pub sku_number: Option<String>,
+    /// System family (`family`).
+    pub family: Option<String>,
+    /// System UUID (`uuid=GUID` or `uuid=random`).
+    pub uuid: Option<SmbiosUuid>,
+}
+
+/// SMBIOS (DMI) identity overrides parsed from `--smbios` arguments, grouped by
+/// SMBIOS structure type to mirror the required `type=N` CLI prefix and the
+/// loader's `SmbiosConfig` layout.
+///
+/// Each `--smbios` argument targets exactly one type; multiple arguments are
+/// merged with [`SmbiosCli::merge`].
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct SmbiosCli {
+    /// Type 0 (BIOS Information) overrides.
+    pub bios: SmbiosBiosCli,
+    /// Type 1 (System Information) overrides.
+    pub system: SmbiosSystemCli,
+}
+
+/// Set an override slot, erroring if it is already set.
+fn smbios_set_once<T>(slot: &mut Option<T>, key: &str, value: T) -> anyhow::Result<()> {
+    anyhow::ensure!(slot.is_none(), "duplicate smbios option '{key}'");
+    *slot = Some(value);
+    Ok(())
+}
+
+impl SmbiosCli {
+    /// Merge another parsed `--smbios` argument into this one, erroring if any
+    /// field is set by both.
+    pub fn merge(&mut self, other: SmbiosCli) -> anyhow::Result<()> {
+        let SmbiosCli {
+            bios:
+                SmbiosBiosCli {
+                    vendor,
+                    version: bios_version,
+                    release_date,
+                    release,
+                },
+            system:
+                SmbiosSystemCli {
+                    manufacturer,
+                    product_name,
+                    version: system_version,
+                    serial_number,
+                    sku_number,
+                    family,
+                    uuid,
+                },
+        } = other;
+        merge_smbios_field(&mut self.bios.vendor, vendor, 0, "vendor")?;
+        merge_smbios_field(&mut self.bios.version, bios_version, 0, "version")?;
+        merge_smbios_field(&mut self.bios.release_date, release_date, 0, "date")?;
+        merge_smbios_field(&mut self.bios.release, release, 0, "release")?;
+        merge_smbios_field(
+            &mut self.system.manufacturer,
+            manufacturer,
+            1,
+            "manufacturer",
+        )?;
+        merge_smbios_field(&mut self.system.product_name, product_name, 1, "product")?;
+        merge_smbios_field(&mut self.system.version, system_version, 1, "version")?;
+        merge_smbios_field(&mut self.system.serial_number, serial_number, 1, "serial")?;
+        merge_smbios_field(&mut self.system.sku_number, sku_number, 1, "sku")?;
+        merge_smbios_field(&mut self.system.family, family, 1, "family")?;
+        merge_smbios_field(&mut self.system.uuid, uuid, 1, "uuid")?;
+        Ok(())
+    }
+}
+
+/// Merge a single override field, erroring if both sides are set. `typ` is the
+/// SMBIOS structure type the field belongs to, included in the error message.
+fn merge_smbios_field<T>(
+    dst: &mut Option<T>,
+    src: Option<T>,
+    typ: u8,
+    key: &str,
+) -> anyhow::Result<()> {
+    if let Some(value) = src {
+        smbios_set_once(dst, &format!("type={typ} {key}"), value)?;
+    }
+    Ok(())
+}
+
+/// Parse a single `--smbios` argument: `type=N,key=value[,key=value...]`.
+///
+/// Matches QEMU's `-smbios` syntax: `type=N` is required (there is no default)
+/// and selects the key namespace; the remaining `key=value` pairs are parsed by
+/// the matching per-type `KeyValueArgs` struct. Unknown types and unknown keys
+/// are hard errors (no silent drop).
+fn parse_smbios(s: &str) -> anyhow::Result<SmbiosCli> {
+    let mut typ: Option<u8> = None;
+    let mut rest = Vec::new();
+    for part in s.split(',') {
+        let (key, value) = part
+            .split_once('=')
+            .with_context(|| format!("invalid smbios option '{part}', expected key=value"))?;
+        if key.is_empty() || value.is_empty() {
+            anyhow::bail!("invalid smbios option '{part}', expected key=value");
+        }
+        if key == "type" {
+            anyhow::ensure!(typ.is_none(), "duplicate smbios option 'type'");
+            typ = Some(
+                value
+                    .parse::<u8>()
+                    .with_context(|| format!("invalid smbios type '{value}'"))?,
+            );
+        } else {
+            rest.push(part);
+        }
+    }
+
+    let typ = typ.context("smbios option requires 'type=N' (e.g. 'type=1')")?;
+    let rest = rest.join(",");
+    Ok(match typ {
+        0 => SmbiosCli {
+            bios: rest.parse()?,
+            ..Default::default()
+        },
+        1 => SmbiosCli {
+            system: rest.parse()?,
+            ..Default::default()
+        },
+        other => anyhow::bail!("unsupported smbios type '{other}' (expected 0 or 1)"),
+    })
 }
 
 fn parse_memory_config(s: &str) -> anyhow::Result<MemoryCli> {
@@ -4887,6 +5131,190 @@ mod tests {
                 .hugepage_size,
             Some(vmm_cli::MemorySize(3 * 1024 * 1024))
         );
+    }
+
+    #[test]
+    fn test_smbios_requires_type() {
+        // Matching QEMU, `type=` is mandatory — there is no default.
+        assert!(parse_smbios("manufacturer=Contoso,family=Foo").is_err());
+    }
+
+    #[test]
+    fn test_smbios_all_system_keys() {
+        let parsed = parse_smbios(
+            "type=1,manufacturer=M,product=P,version=V,serial=S,sku=K,family=F,\
+             uuid=12345678-9abc-def0-1234-56789abcdef0",
+        )
+        .unwrap();
+        assert_eq!(
+            parsed,
+            SmbiosCli {
+                system: SmbiosSystemCli {
+                    manufacturer: Some("M".to_string()),
+                    product_name: Some("P".to_string()),
+                    version: Some("V".to_string()),
+                    serial_number: Some("S".to_string()),
+                    sku_number: Some("K".to_string()),
+                    family: Some("F".to_string()),
+                    uuid: Some(SmbiosUuid::Fixed(
+                        "12345678-9abc-def0-1234-56789abcdef0"
+                            .parse::<Guid>()
+                            .unwrap()
+                    )),
+                },
+                ..Default::default()
+            }
+        );
+    }
+
+    #[test]
+    fn test_smbios_bios_keys() {
+        let parsed =
+            parse_smbios("type=0,vendor=Contoso,version=1.0,date=01/01/2026,release=4.1").unwrap();
+        assert_eq!(
+            parsed,
+            SmbiosCli {
+                bios: SmbiosBiosCli {
+                    vendor: Some("Contoso".to_string()),
+                    version: Some("1.0".to_string()),
+                    release_date: Some("01/01/2026".to_string()),
+                    release: Some(SmbiosRelease(4, 1)),
+                },
+                ..Default::default()
+            }
+        );
+    }
+
+    #[test]
+    fn test_smbios_release_parsing() {
+        // Valid MAJOR.MINOR.
+        assert_eq!(
+            parse_smbios("type=0,release=4.1").unwrap().bios.release,
+            Some(SmbiosRelease(4, 1))
+        );
+        assert_eq!(
+            parse_smbios("type=0,release=255.0").unwrap().bios.release,
+            Some(SmbiosRelease(255, 0))
+        );
+        // Missing the dot, extra components, out-of-range, and non-numeric all
+        // error (matching QEMU's strict two-`u8` parse).
+        assert!(parse_smbios("type=0,release=4").is_err());
+        assert!(parse_smbios("type=0,release=4.1.0").is_err());
+        assert!(parse_smbios("type=0,release=256.0").is_err());
+        assert!(parse_smbios("type=0,release=x.y").is_err());
+        // `release` is a type=0 key only.
+        assert!(parse_smbios("type=1,release=4.1").is_err());
+    }
+
+    #[test]
+    fn test_smbios_uuid() {
+        // An explicit GUID parses to `Fixed`.
+        assert_eq!(
+            parse_smbios("type=1,uuid=12345678-9abc-def0-1234-56789abcdef0")
+                .unwrap()
+                .system
+                .uuid,
+            Some(SmbiosUuid::Fixed(
+                "12345678-9abc-def0-1234-56789abcdef0"
+                    .parse::<Guid>()
+                    .unwrap()
+            ))
+        );
+        // The literal `random` parses to `Random`.
+        assert_eq!(
+            parse_smbios("type=1,uuid=random").unwrap().system.uuid,
+            Some(SmbiosUuid::Random)
+        );
+    }
+
+    #[test]
+    fn test_smbios_version_disambiguated_by_type() {
+        // `version` belongs to BIOS under type=0 and System under type=1.
+        let bios = parse_smbios("type=0,version=1.0").unwrap();
+        assert_eq!(bios.bios.version.as_deref(), Some("1.0"));
+        assert_eq!(bios.system.version, None);
+
+        let system = parse_smbios("type=1,version=2.0").unwrap();
+        assert_eq!(system.system.version.as_deref(), Some("2.0"));
+        assert_eq!(system.bios.version, None);
+    }
+
+    #[test]
+    fn test_smbios_rejects_invalid() {
+        // Missing type.
+        assert!(parse_smbios("manufacturer=M").is_err());
+        // Unknown key for the type.
+        assert!(parse_smbios("type=0,manufacturer=M").is_err());
+        assert!(parse_smbios("type=1,nonsense=x").is_err());
+        // Unknown / unsupported type.
+        assert!(parse_smbios("type=2,vendor=M").is_err());
+        assert!(parse_smbios("type=bad,vendor=M").is_err());
+        // Malformed key=value.
+        assert!(parse_smbios("type=1,manufacturer").is_err());
+        assert!(parse_smbios("=value").is_err());
+        assert!(parse_smbios("type=1,manufacturer=").is_err());
+        // Duplicate key within one argument.
+        assert!(parse_smbios("type=1,manufacturer=A,manufacturer=B").is_err());
+        assert!(parse_smbios("type=0,type=1,vendor=M").is_err());
+        // Invalid UUID.
+        assert!(parse_smbios("type=1,uuid=not-a-guid").is_err());
+    }
+
+    #[test]
+    fn test_smbios_merge_across_arguments() {
+        let mut merged = SmbiosCli::default();
+        merged
+            .merge(parse_smbios("type=0,vendor=Contoso").unwrap())
+            .unwrap();
+        merged
+            .merge(parse_smbios("type=1,manufacturer=M,family=F").unwrap())
+            .unwrap();
+        assert_eq!(
+            merged,
+            SmbiosCli {
+                bios: SmbiosBiosCli {
+                    vendor: Some("Contoso".to_string()),
+                    ..Default::default()
+                },
+                system: SmbiosSystemCli {
+                    manufacturer: Some("M".to_string()),
+                    family: Some("F".to_string()),
+                    ..Default::default()
+                },
+            }
+        );
+    }
+
+    #[test]
+    fn test_smbios_merge_rejects_conflicts() {
+        let mut merged = SmbiosCli::default();
+        merged
+            .merge(parse_smbios("type=1,manufacturer=A").unwrap())
+            .unwrap();
+        // The same field set by a second argument is a hard error.
+        assert!(
+            merged
+                .merge(parse_smbios("type=1,manufacturer=B").unwrap())
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn test_smbios_arg_repeatable() {
+        let opt = Options::try_parse_from([
+            "openvmm",
+            "--smbios",
+            "type=1,manufacturer=Contoso",
+            "--smbios",
+            "type=0,vendor=Acme",
+        ])
+        .unwrap();
+        assert_eq!(opt.smbios.len(), 2);
+        assert_eq!(
+            opt.smbios[0].system.manufacturer.as_deref(),
+            Some("Contoso")
+        );
+        assert_eq!(opt.smbios[1].bios.vendor.as_deref(), Some("Acme"));
     }
 
     #[test]

--- a/openvmm/openvmm_entry/src/cli_args.rs
+++ b/openvmm/openvmm_entry/src/cli_args.rs
@@ -296,7 +296,7 @@ Examples:
     /// Use a full device tree instead of ACPI tables for ARM64 Linux direct
     /// boot. By default, ARM64 uses ACPI mode (stub DT + EFI + ACPI tables).
     /// This flag selects the legacy DT-only path. Rejected on x86.
-    #[clap(long, conflicts_with_all = ["uefi", "pcat", "igvm"])]
+    #[clap(long, conflicts_with_all = ["uefi", "pcat", "igvm", "smbios"])]
     pub device_tree: bool,
 
     /// SMBIOS (DMI) identity overrides (repeatable).

--- a/openvmm/openvmm_entry/src/cli_args.rs
+++ b/openvmm/openvmm_entry/src/cli_args.rs
@@ -285,12 +285,12 @@ Examples:
     #[clap(long, conflicts_with_all = ["uefi", "pcat", "igvm"])]
     pub device_tree: bool,
 
-    /// SMBIOS (DMI) identity overrides for Linux direct boot (repeatable).
+    /// SMBIOS (DMI) identity overrides (repeatable).
     #[clap(
         long,
         value_name = "PARAMS",
         value_parser = parse_smbios,
-        long_help = r#"Override SMBIOS (DMI) identity for Linux direct boot.
+        long_help = r#"Override the guest's SMBIOS (DMI) identity.
 
 Syntax: type=N,key=value[,key=value...]
 
@@ -298,6 +298,10 @@ Syntax: type=N,key=value[,key=value...]
 `-smbios`; there is no default). Key names follow QEMU's `-smbios`
 convention. Unset keys use the loader's built-in default identity. Repeat
 --smbios to set fields across multiple structure types.
+
+Linux direct boot supports all listed fields. UEFI boot supports Type 1
+fields only. PCAT boot supports only Type 1 `serial` and `uuid`. Unsupported
+fields are rejected with an error.
 
 Type 0 (BIOS Information):
     vendor=<STRING>          BIOS vendor

--- a/openvmm/openvmm_entry/src/cli_args.rs
+++ b/openvmm/openvmm_entry/src/cli_args.rs
@@ -299,12 +299,12 @@ Examples:
     #[clap(long, conflicts_with_all = ["uefi", "pcat", "igvm"])]
     pub device_tree: bool,
 
-    /// SMBIOS (DMI) identity overrides for Linux direct boot (repeatable).
+    /// SMBIOS (DMI) identity overrides (repeatable).
     #[clap(
         long,
         value_name = "PARAMS",
         value_parser = parse_smbios,
-        long_help = r#"Override SMBIOS (DMI) identity for Linux direct boot.
+        long_help = r#"Override the guest's SMBIOS (DMI) identity.
 
 Syntax: type=N,key=value[,key=value...]
 
@@ -312,6 +312,10 @@ Syntax: type=N,key=value[,key=value...]
 `-smbios`; there is no default). Key names follow QEMU's `-smbios`
 convention. Unset keys use the loader's built-in default identity. Repeat
 --smbios to set fields across multiple structure types.
+
+Linux direct boot supports all listed fields. UEFI boot supports Type 1
+fields only. PCAT boot supports only Type 1 `serial` and `uuid`. Unsupported
+fields are rejected with an error.
 
 Type 0 (BIOS Information):
     vendor=<STRING>          BIOS vendor

--- a/openvmm/openvmm_entry/src/lib.rs
+++ b/openvmm/openvmm_entry/src/lib.rs
@@ -225,6 +225,62 @@ fn build_switch_list(all_switches: &[cli_args::GenericPcieSwitchCli]) -> Vec<Pci
         .collect()
 }
 
+/// Build the loader's [`SmbiosConfig`](openvmm_defs::config::SmbiosConfig) from
+/// the parsed `--smbios` arguments.
+///
+/// Multiple `--smbios` arguments are merged (erroring on a field set twice).
+/// String overrides left unset fall through to the loader's default identity.
+/// The system UUID defaults to the all-zero GUID unless overridden with
+/// `uuid=GUID`; `uuid=random` requests a freshly generated per-VM GUID.
+fn smbios_config_from_cli(
+    args: &[cli_args::SmbiosCli],
+) -> anyhow::Result<openvmm_defs::config::SmbiosConfig> {
+    let mut merged = cli_args::SmbiosCli::default();
+    for arg in args {
+        merged.merge(arg.clone())?;
+    }
+    let cli_args::SmbiosCli {
+        bios:
+            cli_args::SmbiosBiosCli {
+                vendor: bios_vendor,
+                version: bios_version,
+                release_date: bios_release_date,
+                release: bios_release,
+            },
+        system:
+            cli_args::SmbiosSystemCli {
+                manufacturer: system_manufacturer,
+                product_name: system_product,
+                version: system_version,
+                serial_number: system_serial,
+                sku_number: system_sku,
+                family: system_family,
+                uuid: system_uuid,
+            },
+    } = merged;
+    Ok(openvmm_defs::config::SmbiosConfig {
+        bios: openvmm_defs::config::SmbiosBiosOverrides {
+            vendor: bios_vendor,
+            version: bios_version,
+            release_date: bios_release_date,
+            release: bios_release.map(|r| (r.0, r.1)),
+        },
+        system: openvmm_defs::config::SmbiosSystemOverrides {
+            manufacturer: system_manufacturer,
+            product_name: system_product,
+            version: system_version,
+            serial_number: system_serial,
+            sku_number: system_sku,
+            family: system_family,
+            uuid: match system_uuid {
+                None => Guid::ZERO,
+                Some(cli_args::SmbiosUuid::Random) => Guid::new_random(),
+                Some(cli_args::SmbiosUuid::Fixed(guid)) => guid,
+            },
+        },
+    })
+}
+
 async fn vm_config_from_command_line(
     spawner: impl Spawn,
     mesh: &VmmMesh,
@@ -1225,8 +1281,17 @@ async fn vm_config_from_command_line(
         ));
     }
 
-    // TODO: load from VMGS file if it exists
-    let bios_guid = Guid::new_random();
+    // Build the SMBIOS config once, up front, so that UEFI and Linux direct
+    // boot share a single source for the VM's BIOS GUID / system UUID. The TPM
+    // also keys off this GUID.
+    let smbios = Box::new(smbios_config_from_cli(&opt.smbios)?);
+    let bios_guid = smbios.system.uuid;
+
+    // Capture the SMBIOS config for the OpenHCL/GED path before `smbios` is
+    // potentially moved into a non-VTL2 LoadMode below. The GED forwards only
+    // the system identity to the paravisor and fails closed on BIOS overrides
+    // it cannot honor, so it is delivered as the shared `SmbiosConfig`.
+    let ged_smbios = (*smbios).clone();
 
     let layout_config = chipset.layout_config();
     let VmChipsetResult {
@@ -1274,6 +1339,7 @@ async fn vm_config_from_command_line(
                 .pcat_boot_order
                 .map(|x| x.0)
                 .unwrap_or(DEFAULT_PCAT_BOOT_ORDER),
+            smbios,
         };
     } else if opt.uefi {
         use openvmm_defs::config::UefiConsoleMode;
@@ -1305,7 +1371,7 @@ async fn vm_config_from_command_line(
                 UefiConsoleModeCli::None => UefiConsoleMode::None,
             }),
             default_boot_always_attempt: opt.default_boot_always_attempt,
-            bios_guid,
+            smbios,
             enable_vmbus: !opt.no_vmbus,
             force_dma_bounce: opt.uefi_force_dma_bounce,
         };
@@ -1351,6 +1417,7 @@ async fn vm_config_from_command_line(
             } else {
                 openvmm_defs::config::LinuxDirectBootMode::Acpi
             },
+            smbios,
         };
     }
 
@@ -1474,6 +1541,7 @@ async fn vm_config_from_command_line(
                         }
                     },
                     force_dma_bounce_enabled: opt.uefi_force_dma_bounce,
+                    smbios: ged_smbios,
                 }
                 .into_resource(),
             ),

--- a/openvmm/openvmm_entry/src/lib.rs
+++ b/openvmm/openvmm_entry/src/lib.rs
@@ -255,6 +255,62 @@ fn base_chipset_type(opt: &Options) -> BaseChipsetType {
     }
 }
 
+/// Build the loader's [`SmbiosConfig`](openvmm_defs::config::SmbiosConfig) from
+/// the parsed `--smbios` arguments.
+///
+/// Multiple `--smbios` arguments are merged (erroring on a field set twice).
+/// String overrides left unset fall through to the loader's default identity.
+/// The system UUID defaults to the all-zero GUID unless overridden with
+/// `uuid=GUID`; `uuid=random` requests a freshly generated per-VM GUID.
+fn smbios_config_from_cli(
+    args: &[cli_args::SmbiosCli],
+) -> anyhow::Result<openvmm_defs::config::SmbiosConfig> {
+    let mut merged = cli_args::SmbiosCli::default();
+    for arg in args {
+        merged.merge(arg.clone())?;
+    }
+    let cli_args::SmbiosCli {
+        bios:
+            cli_args::SmbiosBiosCli {
+                vendor: bios_vendor,
+                version: bios_version,
+                release_date: bios_release_date,
+                release: bios_release,
+            },
+        system:
+            cli_args::SmbiosSystemCli {
+                manufacturer: system_manufacturer,
+                product_name: system_product,
+                version: system_version,
+                serial_number: system_serial,
+                sku_number: system_sku,
+                family: system_family,
+                uuid: system_uuid,
+            },
+    } = merged;
+    Ok(openvmm_defs::config::SmbiosConfig {
+        bios: openvmm_defs::config::SmbiosBiosOverrides {
+            vendor: bios_vendor,
+            version: bios_version,
+            release_date: bios_release_date,
+            release: bios_release.map(|r| (r.0, r.1)),
+        },
+        system: openvmm_defs::config::SmbiosSystemOverrides {
+            manufacturer: system_manufacturer,
+            product_name: system_product,
+            version: system_version,
+            serial_number: system_serial,
+            sku_number: system_sku,
+            family: system_family,
+            uuid: match system_uuid {
+                None => Guid::ZERO,
+                Some(cli_args::SmbiosUuid::Random) => Guid::new_random(),
+                Some(cli_args::SmbiosUuid::Fixed(guid)) => guid,
+            },
+        },
+    })
+}
+
 async fn vm_config_from_command_line(
     spawner: impl Spawn,
     mesh: &VmmMesh,
@@ -1247,8 +1303,17 @@ async fn vm_config_from_command_line(
         ));
     }
 
-    // TODO: load from VMGS file if it exists
-    let bios_guid = Guid::new_random();
+    // Build the SMBIOS config once, up front, so that UEFI and Linux direct
+    // boot share a single source for the VM's BIOS GUID / system UUID. The TPM
+    // also keys off this GUID.
+    let smbios = Box::new(smbios_config_from_cli(&opt.smbios)?);
+    let bios_guid = smbios.system.uuid;
+
+    // Capture the SMBIOS config for the OpenHCL/GED path before `smbios` is
+    // potentially moved into a non-VTL2 LoadMode below. The GED forwards only
+    // the system identity to the paravisor and fails closed on BIOS overrides
+    // it cannot honor, so it is delivered as the shared `SmbiosConfig`.
+    let ged_smbios = (*smbios).clone();
 
     let layout_config = chipset.layout_config();
     let VmChipsetResult {
@@ -1304,6 +1369,7 @@ async fn vm_config_from_command_line(
                 .map(|x| x.0)
                 .unwrap_or(DEFAULT_PCAT_BOOT_ORDER),
             hibernation_enabled: opt.hibernation,
+            smbios,
         };
     } else if opt.uefi {
         use openvmm_defs::config::UefiConsoleMode;
@@ -1339,7 +1405,7 @@ async fn vm_config_from_command_line(
                 UefiConsoleModeCli::None => UefiConsoleMode::None,
             }),
             default_boot_always_attempt: opt.default_boot_always_attempt,
-            bios_guid,
+            smbios,
             enable_vmbus: !opt.no_vmbus,
             force_dma_bounce: opt.uefi_force_dma_bounce,
             enable_hv: !opt.no_hv,
@@ -1394,6 +1460,7 @@ async fn vm_config_from_command_line(
             } else {
                 openvmm_defs::config::LinuxDirectBootMode::Acpi
             },
+            smbios,
         };
     }
 
@@ -1518,6 +1585,7 @@ async fn vm_config_from_command_line(
                         }
                     },
                     force_dma_bounce_enabled: opt.uefi_force_dma_bounce,
+                    smbios: ged_smbios,
                 }
                 .into_resource(),
             ),

--- a/openvmm/openvmm_entry/src/lib.rs
+++ b/openvmm/openvmm_entry/src/lib.rs
@@ -1354,6 +1354,17 @@ async fn vm_config_from_command_line(
                 irq: ComPort::Com3.irq().into(),
             }),
         };
+
+        // An IGVM launch carries no SMBIOS field of its own; the identity is
+        // only delivered over the GET/GED channel, which is absent here. Reject
+        // overrides that would otherwise be silently dropped.
+        let smbios_requested = !opt.smbios.is_empty();
+        let smbios_delivered_via_get = with_get && with_hv;
+        if smbios_requested && !smbios_delivered_via_get {
+            anyhow::bail!(
+                "--smbios is not supported for IGVM launches without an OpenHCL GET channel"
+            );
+        }
     } else if opt.pcat {
         // Emit a nice error early instead of complaining about missing firmware.
         if arch != MachineArch::X86_64 {

--- a/openvmm/openvmm_entry/src/ttrpc/mod.rs
+++ b/openvmm/openvmm_entry/src/ttrpc/mod.rs
@@ -718,6 +718,10 @@ impl VmService {
         #[cfg(guest_arch = "x86_64")]
         let arch = vm_manifest_builder::MachineArch::X86_64;
 
+        // SMBIOS identity is applied regardless of boot type; build it once and
+        // move it into whichever LoadMode is selected below.
+        let smbios = Box::new(smbios_config_from_proto(req_config.smbios_config.take())?);
+
         // The boot configuration also determines the base chipset, since the
         // firmware and the device model have to agree on the platform.
         let (load_mode, base_chipset_type, uefi_config) = match req_config
@@ -739,6 +743,7 @@ impl VmService {
                         cmdline: boot.kernel_cmdline,
                         enable_serial: true,
                         boot_mode: openvmm_defs::config::LinuxDirectBootMode::Acpi,
+                        smbios,
                     },
                     vm_manifest_builder::BaseChipsetType::HyperVGen2LinuxDirect,
                     None,
@@ -788,7 +793,7 @@ impl VmService {
                         // anything it launches would have nowhere to write on a
                         // VM with no graphics adapter.
                         uefi_console_mode: com1_configured.then_some(UefiConsoleMode::Com1),
-                        bios_guid: Guid::new_random(),
+                        smbios,
                         enable_vmbus: true,
                         // Everything below is fixed for now. The proto has no
                         // way to express these yet; fields will be added as
@@ -1408,6 +1413,63 @@ fn open_socket_backend(
     } else {
         (bind_serial, "bind")
     }
+}
+
+/// Convert the proto `SMBIOSConfig` (untrusted input) into the loader's
+/// [`SmbiosConfig`](openvmm_defs::config::SmbiosConfig).
+///
+/// An absent message or absent field falls through to the loader's built-in
+/// default identity. The system UUID defaults to the all-zero GUID when unset.
+fn smbios_config_from_proto(
+    proto: Option<vmservice::SmbiosConfig>,
+) -> anyhow::Result<openvmm_defs::config::SmbiosConfig> {
+    let vmservice::SmbiosConfig { bios, system } = proto.unwrap_or_default();
+
+    let vmservice::smbios_config::Bios {
+        vendor,
+        version: bios_version,
+        release_date,
+        release,
+    } = bios.unwrap_or_default();
+    let release = release
+        .map(|r| {
+            let major = u8::try_from(r.major).context("smbios bios release major out of range")?;
+            let minor = u8::try_from(r.minor).context("smbios bios release minor out of range")?;
+            anyhow::Ok((major, minor))
+        })
+        .transpose()?;
+
+    let vmservice::smbios_config::System {
+        manufacturer,
+        product_name,
+        version: system_version,
+        serial_number,
+        sku_number,
+        family,
+        uuid,
+    } = system.unwrap_or_default();
+    let uuid = match uuid {
+        Some(uuid) => uuid.parse::<Guid>().context("invalid smbios system uuid")?,
+        None => Guid::ZERO,
+    };
+
+    Ok(openvmm_defs::config::SmbiosConfig {
+        bios: openvmm_defs::config::SmbiosBiosOverrides {
+            vendor,
+            version: bios_version,
+            release_date,
+            release,
+        },
+        system: openvmm_defs::config::SmbiosSystemOverrides {
+            manufacturer,
+            product_name,
+            version: system_version,
+            serial_number,
+            sku_number,
+            family,
+            uuid,
+        },
+    })
 }
 
 /// Convert a ttrpc `PortConfig` (untrusted input) into a `HostPortConfig`,

--- a/openvmm/openvmm_entry/src/ttrpc/mod.rs
+++ b/openvmm/openvmm_entry/src/ttrpc/mod.rs
@@ -766,6 +766,10 @@ impl VmService {
         #[cfg(guest_arch = "x86_64")]
         let arch = vm_manifest_builder::MachineArch::X86_64;
 
+        // SMBIOS identity is applied regardless of boot type; build it once and
+        // move it into whichever LoadMode is selected below.
+        let smbios = Box::new(smbios_config_from_proto(req_config.smbios_config.take())?);
+
         // The boot configuration also determines the base chipset, since the
         // firmware and the device model have to agree on the platform.
         let (load_mode, base_chipset_type, uefi_config) = match req_config
@@ -788,6 +792,7 @@ impl VmService {
                         enable_serial: true,
                         isolation: openvmm_defs::config::LinuxIsolationConfig::None,
                         boot_mode: openvmm_defs::config::LinuxDirectBootMode::Acpi,
+                        smbios,
                     },
                     vm_manifest_builder::BaseChipsetType::HyperVGen2LinuxDirect,
                     None,
@@ -837,7 +842,7 @@ impl VmService {
                         // anything it launches would have nowhere to write on a
                         // VM with no graphics adapter.
                         uefi_console_mode: com1_configured.then_some(UefiConsoleMode::Com1),
-                        bios_guid: Guid::new_random(),
+                        smbios,
                         enable_vmbus: true,
                         // Everything below is fixed for now. The proto has no
                         // way to express these yet; fields will be added as
@@ -1461,6 +1466,63 @@ fn open_socket_backend(
     } else {
         (bind_serial, "bind")
     }
+}
+
+/// Convert the proto `SMBIOSConfig` (untrusted input) into the loader's
+/// [`SmbiosConfig`](openvmm_defs::config::SmbiosConfig).
+///
+/// An absent message or absent field falls through to the loader's built-in
+/// default identity. The system UUID defaults to the all-zero GUID when unset.
+fn smbios_config_from_proto(
+    proto: Option<vmservice::SmbiosConfig>,
+) -> anyhow::Result<openvmm_defs::config::SmbiosConfig> {
+    let vmservice::SmbiosConfig { bios, system } = proto.unwrap_or_default();
+
+    let vmservice::smbios_config::Bios {
+        vendor,
+        version: bios_version,
+        release_date,
+        release,
+    } = bios.unwrap_or_default();
+    let release = release
+        .map(|r| {
+            let major = u8::try_from(r.major).context("smbios bios release major out of range")?;
+            let minor = u8::try_from(r.minor).context("smbios bios release minor out of range")?;
+            anyhow::Ok((major, minor))
+        })
+        .transpose()?;
+
+    let vmservice::smbios_config::System {
+        manufacturer,
+        product_name,
+        version: system_version,
+        serial_number,
+        sku_number,
+        family,
+        uuid,
+    } = system.unwrap_or_default();
+    let uuid = match uuid {
+        Some(uuid) => uuid.parse::<Guid>().context("invalid smbios system uuid")?,
+        None => Guid::ZERO,
+    };
+
+    Ok(openvmm_defs::config::SmbiosConfig {
+        bios: openvmm_defs::config::SmbiosBiosOverrides {
+            vendor,
+            version: bios_version,
+            release_date,
+            release,
+        },
+        system: openvmm_defs::config::SmbiosSystemOverrides {
+            manufacturer,
+            product_name,
+            version: system_version,
+            serial_number,
+            sku_number,
+            family,
+            uuid,
+        },
+    })
 }
 
 /// Convert a ttrpc `PortConfig` (untrusted input) into a `HostPortConfig`,

--- a/openvmm/openvmm_entry/src/ttrpc/mod.rs
+++ b/openvmm/openvmm_entry/src/ttrpc/mod.rs
@@ -1506,20 +1506,30 @@ fn smbios_config_from_proto(
         None => Guid::ZERO,
     };
 
+    // Match the CLI parser, which rejects empty values. An explicitly provided
+    // empty string is ambiguous — UEFI omits the blob while the direct loader
+    // clears the field — so reject it rather than silently pick one behavior.
+    fn reject_empty(field: &str, value: Option<String>) -> anyhow::Result<Option<String>> {
+        if value.as_deref() == Some("") {
+            anyhow::bail!("smbios {field} must not be empty if specified");
+        }
+        Ok(value)
+    }
+
     Ok(openvmm_defs::config::SmbiosConfig {
         bios: openvmm_defs::config::SmbiosBiosOverrides {
-            vendor,
-            version: bios_version,
-            release_date,
+            vendor: reject_empty("bios vendor", vendor)?,
+            version: reject_empty("bios version", bios_version)?,
+            release_date: reject_empty("bios release date", release_date)?,
             release,
         },
         system: openvmm_defs::config::SmbiosSystemOverrides {
-            manufacturer,
-            product_name,
-            version: system_version,
-            serial_number,
-            sku_number,
-            family,
+            manufacturer: reject_empty("system manufacturer", manufacturer)?,
+            product_name: reject_empty("system product", product_name)?,
+            version: reject_empty("system version", system_version)?,
+            serial_number: reject_empty("system serial", serial_number)?,
+            sku_number: reject_empty("system sku", sku_number)?,
+            family: reject_empty("system family", family)?,
             uuid,
         },
     })

--- a/openvmm/openvmm_ttrpc_vmservice/src/vmservice.proto
+++ b/openvmm/openvmm_ttrpc_vmservice/src/vmservice.proto
@@ -572,6 +572,11 @@ message VMConfig {
     // Actions to take on guest power events. Each unset action uses its
     // default.
     GuestPowerActions guest_power_actions = 12;
+
+    // SMBIOS (DMI) identity overrides. Applied to whichever boot type is
+    // selected; note that PCAT boot honors only the system UUID and serial
+    // number.
+    SMBIOSConfig smbios_config = 13;
 }
 
 // WindowsOptions contains virtual machine configurations that are only present on a Windows host.
@@ -593,6 +598,53 @@ message SerialConfig {
 
 message HVSocketConfig {
     string path = 1;
+}
+
+// SMBIOS (DMI) identity overrides, grouped by SMBIOS structure type to mirror
+// the `type=N` grouping of the OpenVMM `--smbios` CLI option. Each unset field
+// falls through to the loader's default identity.
+message SMBIOSConfig {
+    // SMBIOS Type 0 (BIOS Information) overrides.
+    message BIOS {
+        // System BIOS Major/Minor Release (e.g. 4.1). Presence of this message
+        // sets the release; both components are supplied together.
+        message Release {
+            uint32 major = 1;
+            uint32 minor = 2;
+        }
+
+        // BIOS vendor string.
+        optional string vendor = 1;
+        // BIOS version string.
+        optional string version = 2;
+        // BIOS release date string.
+        optional string release_date = 3;
+        // System BIOS Major/Minor Release. Absent => loader default.
+        Release release = 4;
+    }
+
+    // SMBIOS Type 1 (System Information) overrides.
+    message System {
+        // System manufacturer string.
+        optional string manufacturer = 1;
+        // System product name string.
+        optional string product_name = 2;
+        // System version string.
+        optional string version = 3;
+        // System serial number string.
+        optional string serial_number = 4;
+        // System SKU number string.
+        optional string sku_number = 5;
+        // System family string.
+        optional string family = 6;
+        // System UUID (the VM's BIOS GUID).
+        optional string uuid = 7; // GUID
+    }
+
+    // Type 0 (BIOS Information) overrides.
+    BIOS bios = 1;
+    // Type 1 (System Information) overrides.
+    System system = 2;
 }
 
 message CreateVMRequest {

--- a/openvmm/openvmm_ttrpc_vmservice/src/vmservice.proto
+++ b/openvmm/openvmm_ttrpc_vmservice/src/vmservice.proto
@@ -532,6 +532,11 @@ message VMConfig {
     // Actions to take on guest power events. Each unset action uses its
     // default.
     GuestPowerActions guest_power_actions = 12;
+
+    // SMBIOS (DMI) identity overrides. Applied to whichever boot type is
+    // selected; note that PCAT boot honors only the system UUID and serial
+    // number.
+    SMBIOSConfig smbios_config = 13;
 }
 
 // WindowsOptions contains virtual machine configurations that are only present on a Windows host.
@@ -553,6 +558,53 @@ message SerialConfig {
 
 message HVSocketConfig {
     string path = 1;
+}
+
+// SMBIOS (DMI) identity overrides, grouped by SMBIOS structure type to mirror
+// the `type=N` grouping of the OpenVMM `--smbios` CLI option. Each unset field
+// falls through to the loader's default identity.
+message SMBIOSConfig {
+    // SMBIOS Type 0 (BIOS Information) overrides.
+    message BIOS {
+        // System BIOS Major/Minor Release (e.g. 4.1). Presence of this message
+        // sets the release; both components are supplied together.
+        message Release {
+            uint32 major = 1;
+            uint32 minor = 2;
+        }
+
+        // BIOS vendor string.
+        optional string vendor = 1;
+        // BIOS version string.
+        optional string version = 2;
+        // BIOS release date string.
+        optional string release_date = 3;
+        // System BIOS Major/Minor Release. Absent => loader default.
+        Release release = 4;
+    }
+
+    // SMBIOS Type 1 (System Information) overrides.
+    message System {
+        // System manufacturer string.
+        optional string manufacturer = 1;
+        // System product name string.
+        optional string product_name = 2;
+        // System version string.
+        optional string version = 3;
+        // System serial number string.
+        optional string serial_number = 4;
+        // System SKU number string.
+        optional string sku_number = 5;
+        // System family string.
+        optional string family = 6;
+        // System UUID (the VM's BIOS GUID).
+        optional string uuid = 7; // GUID
+    }
+
+    // Type 0 (BIOS Information) overrides.
+    BIOS bios = 1;
+    // Type 1 (System Information) overrides.
+    System system = 2;
 }
 
 message CreateVMRequest {

--- a/petri/Cargo.toml
+++ b/petri/Cargo.toml
@@ -37,6 +37,7 @@ netvsp_resources.workspace = true
 nvme_resources.workspace = true
 scsidisk_resources.workspace = true
 serial_core.workspace = true
+smbios_defs.workspace = true
 serial_16550_resources.workspace = true
 serial_socket.workspace = true
 storvsp_resources.workspace = true

--- a/petri/src/vm/openvmm/construct.rs
+++ b/petri/src/vm/openvmm/construct.rs
@@ -916,6 +916,7 @@ impl PetriVmConfigSetupCore<'_> {
                     enable_serial: self.enable_serial,
                     isolation: openvmm_defs::config::LinuxIsolationConfig::None,
                     boot_mode: openvmm_defs::config::LinuxDirectBootMode::Acpi,
+                    smbios: Default::default(),
                 }
             }
             (
@@ -933,6 +934,7 @@ impl PetriVmConfigSetupCore<'_> {
                     firmware,
                     boot_order: DEFAULT_PCAT_BOOT_ORDER,
                     hibernation_enabled: self.hibernation_enabled,
+                    smbios: Box::new(openvmm_defs::config::SmbiosConfig::default()),
                 }
             }
             (
@@ -972,7 +974,13 @@ impl PetriVmConfigSetupCore<'_> {
                     enable_vpci_boot: *enable_vpci_boot,
                     uefi_console_mode: Some(openvmm_defs::config::UefiConsoleMode::Com1),
                     default_boot_always_attempt: *default_boot_always_attempt,
-                    bios_guid: Guid::new_random(),
+                    smbios: Box::new(openvmm_defs::config::SmbiosConfig {
+                        system: openvmm_defs::config::SmbiosSystemOverrides {
+                            uuid: Guid::new_random(),
+                            ..Default::default()
+                        },
+                        ..Default::default()
+                    }),
                     enable_vmbus: !self.no_vmbus,
                     force_dma_bounce: *force_dma_bounce,
                     enable_hv: !self.no_hv,
@@ -1204,6 +1212,7 @@ impl PetriVmConfigSetupCore<'_> {
                 }
             },
             force_dma_bounce_enabled: *force_dma_bounce,
+            smbios: Default::default(),
         };
 
         Ok((ged, guest_request_send))

--- a/petri/src/vm/openvmm/construct.rs
+++ b/petri/src/vm/openvmm/construct.rs
@@ -909,6 +909,7 @@ impl PetriVmConfigSetupCore<'_> {
                     cmdline,
                     enable_serial: self.enable_serial,
                     boot_mode: openvmm_defs::config::LinuxDirectBootMode::Acpi,
+                    smbios: Default::default(),
                 }
             }
             (
@@ -925,6 +926,7 @@ impl PetriVmConfigSetupCore<'_> {
                 LoadMode::Pcat {
                     firmware,
                     boot_order: DEFAULT_PCAT_BOOT_ORDER,
+                    smbios: Box::new(openvmm_defs::config::SmbiosConfig::default()),
                 }
             }
             (
@@ -960,7 +962,13 @@ impl PetriVmConfigSetupCore<'_> {
                     enable_vpci_boot: *enable_vpci_boot,
                     uefi_console_mode: Some(openvmm_defs::config::UefiConsoleMode::Com1),
                     default_boot_always_attempt: *default_boot_always_attempt,
-                    bios_guid: Guid::new_random(),
+                    smbios: Box::new(openvmm_defs::config::SmbiosConfig {
+                        system: openvmm_defs::config::SmbiosSystemOverrides {
+                            uuid: Guid::new_random(),
+                            ..Default::default()
+                        },
+                        ..Default::default()
+                    }),
                     enable_vmbus: !self.no_vmbus,
                     force_dma_bounce: *force_dma_bounce,
                 }
@@ -1189,6 +1197,7 @@ impl PetriVmConfigSetupCore<'_> {
                 }
             },
             force_dma_bounce_enabled: *force_dma_bounce,
+            smbios: Default::default(),
         };
 
         Ok((ged, guest_request_send))

--- a/petri/src/vm/openvmm/modify.rs
+++ b/petri/src/vm/openvmm/modify.rs
@@ -84,6 +84,32 @@ impl PetriVmConfigOpenVmm {
         self
     }
 
+    /// Override the SMBIOS identity delivered to the guest, regardless of how
+    /// the VM is loaded.
+    ///
+    /// For OpenHCL the identity is forwarded to the paravisor over the Guest
+    /// Emulation Transport (GET), which synthesizes the guest's DMI tables from
+    /// it. For direct OpenVMM boot (Linux direct, UEFI, or PCAT) it is applied
+    /// to the loader's SMBIOS config. Each load path honors only the subset of
+    /// fields it can express and fails closed on the rest.
+    pub fn with_smbios(mut self, f: impl FnOnce(&mut smbios_defs::SmbiosConfig)) -> Self {
+        if self.resources.properties.is_openhcl {
+            let ged = self.ged.as_mut().expect("OpenHCL config must have a GED.");
+            f(&mut ged.smbios);
+        } else {
+            let smbios = match &mut self.config.load_mode {
+                LoadMode::Linux { smbios, .. }
+                | LoadMode::Uefi { smbios, .. }
+                | LoadMode::Pcat { smbios, .. } => &mut **smbios,
+                LoadMode::Igvm { .. } | LoadMode::None => {
+                    panic!("SMBIOS configuration is not supported for this load mode.")
+                }
+            };
+            f(smbios);
+        }
+        self
+    }
+
     /// Enable a synthnic for the VM.
     ///
     /// Uses a mana emulator and the paravisor if a paravisor is present.

--- a/vm/devices/firmware/firmware_pcat/src/lib.rs
+++ b/vm/devices/firmware/firmware_pcat/src/lib.rs
@@ -56,6 +56,14 @@ pub mod config {
     use vm_topology::processor::ProcessorTopology;
     use vm_topology::processor::x86::X86Topology;
 
+    /// Maximum number of bytes of a variable-length SMBIOS string (e.g. the
+    /// system serial number) that the config port can deliver to the BIOS ROM.
+    ///
+    /// The port returns each string in eight 4-byte chunks (`read_count % 8`),
+    /// so any bytes beyond this are never read by the guest and would be
+    /// silently truncated.
+    pub const SMBIOS_STRING_MAX_LEN: usize = 8 * 4;
+
     /// Subset of SMBIOS v2.4 CPU Information structure.
     #[derive(Debug, Inspect)]
     #[expect(missing_docs)] // self-explanatory fields
@@ -258,6 +266,12 @@ pub enum PcatBiosDeviceInitError {
     InvalidRomSize(u64),
     #[error("error mapping ROM")]
     Rom(#[source] std::io::Error),
+    #[error("SMBIOS {field} of {len} bytes exceeds the config port's {max}-byte limit")]
+    SmbiosStringTooLong {
+        field: &'static str,
+        len: usize,
+        max: usize,
+    },
 }
 
 impl PcatBiosDevice {
@@ -277,6 +291,17 @@ impl PcatBiosDevice {
         } = runtime_deps;
 
         let initial_generation_id = config.initial_generation_id;
+
+        // The config port delivers each variable-length SMBIOS string in
+        // fixed-size chunks; reject an over-long serial rather than silently
+        // truncating what the guest sees.
+        if config.smbios.system_serial_number.len() > config::SMBIOS_STRING_MAX_LEN {
+            return Err(PcatBiosDeviceInitError::SmbiosStringTooLong {
+                field: "system serial number",
+                len: config.smbios.system_serial_number.len(),
+                max: config::SMBIOS_STRING_MAX_LEN,
+            });
+        }
 
         if config.chipset_low_mmio.is_empty() || config.chipset_high_mmio.is_empty() {
             return Err(PcatBiosDeviceInitError::IncorrectMmioHoles);

--- a/vm/devices/firmware/smbios_defs/Cargo.toml
+++ b/vm/devices/firmware/smbios_defs/Cargo.toml
@@ -2,19 +2,13 @@
 # Licensed under the MIT License.
 
 [package]
-name = "get_resources"
+name = "smbios_defs"
 edition.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-smbios_defs.workspace = true
-
-vm_resource.workspace = true
-vmgs_resources.workspace = true
+guid = { workspace = true, features = ["mesh"] }
 mesh.workspace = true
-inspect.workspace = true
-
-thiserror.workspace = true
 
 [lints]
 workspace = true

--- a/vm/devices/firmware/smbios_defs/src/lib.rs
+++ b/vm/devices/firmware/smbios_defs/src/lib.rs
@@ -1,0 +1,65 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Shared SMBIOS (DMI) identity configuration.
+//!
+//! These types describe the SMBIOS identity overrides a host can apply to a
+//! guest. They live in their own crate so that both the OpenVMM configuration
+//! (`openvmm_defs`) and the Guest Emulation Transport resources
+//! (`get_resources`) can share a single representation rather than each
+//! defining a near-duplicate type.
+//!
+//! Each string field is an override: `None` means "use the loader/firmware's
+//! built-in default identity". The default string literals themselves live with
+//! the code that builds the tables (e.g. the OpenVMM and OpenHCL direct
+//! loaders), not here, so the defaults are defined in a single place.
+
+use guid::Guid;
+use mesh::MeshPayload;
+
+/// SMBIOS (DMI) identity configuration overrides.
+///
+/// Grouped by SMBIOS structure type to mirror the borrowed table view in the
+/// loader: one sub-struct per type.
+#[derive(Debug, Clone, Default, MeshPayload)]
+pub struct SmbiosConfig {
+    /// Type 0 (BIOS Information) overrides.
+    pub bios: SmbiosBiosOverrides,
+    /// Type 1 (System Information) overrides.
+    pub system: SmbiosSystemOverrides,
+}
+
+/// SMBIOS Type 0 (BIOS Information) overrides. `None` = use the loader default.
+#[derive(Debug, Clone, Default, MeshPayload)]
+pub struct SmbiosBiosOverrides {
+    /// BIOS vendor string.
+    pub vendor: Option<String>,
+    /// BIOS version string.
+    pub version: Option<String>,
+    /// BIOS release date string.
+    pub release_date: Option<String>,
+    /// System BIOS Major/Minor Release (`release=MAJOR.MINOR`).
+    pub release: Option<(u8, u8)>,
+}
+
+/// SMBIOS Type 1 (System Information) overrides. `None` string fields use the
+/// loader default; `uuid` is concrete (generated per-VM at runtime, `Guid::ZERO`
+/// by default).
+#[derive(Debug, Clone, Default, MeshPayload)]
+pub struct SmbiosSystemOverrides {
+    /// System manufacturer string.
+    pub manufacturer: Option<String>,
+    /// System product name string.
+    pub product_name: Option<String>,
+    /// System version string.
+    pub version: Option<String>,
+    /// System serial number string.
+    pub serial_number: Option<String>,
+    /// System SKU number string.
+    pub sku_number: Option<String>,
+    /// System family string.
+    pub family: Option<String>,
+    /// System UUID (the VM's BIOS GUID). Stored as raw mixed-endian EFI GUID
+    /// bytes when delivered to the guest.
+    pub uuid: Guid,
+}

--- a/vm/devices/get/get_resources/src/lib.rs
+++ b/vm/devices/get/get_resources/src/lib.rs
@@ -97,6 +97,8 @@ pub mod ged {
         pub efi_diagnostics_log_level: EfiDiagnosticsLogLevelType,
         /// Force UEFI to bounce-buffer all DMA traffic.
         pub force_dma_bounce_enabled: bool,
+        /// SMBIOS identity overrides delivered to the guest firmware.
+        pub smbios: smbios_defs::SmbiosConfig,
     }
 
     /// The firmware and chipset configuration for the guest.

--- a/vm/devices/get/get_resources/src/lib.rs
+++ b/vm/devices/get/get_resources/src/lib.rs
@@ -99,6 +99,8 @@ pub mod ged {
         pub force_dma_bounce_enabled: bool,
         /// Enable hibernation.
         pub enable_hibernation: bool,
+        /// SMBIOS identity overrides delivered to the guest firmware.
+        pub smbios: smbios_defs::SmbiosConfig,
     }
 
     /// The firmware and chipset configuration for the guest.

--- a/vm/devices/get/guest_emulation_device/Cargo.toml
+++ b/vm/devices/get/guest_emulation_device/Cargo.toml
@@ -12,6 +12,7 @@ test_utilities = ["dep:disklayer_ram", "dep:pal_async", "dep:parking_lot"]
 [dependencies]
 get_protocol.workspace = true
 get_resources.workspace = true
+smbios_defs.workspace = true
 test_igvm_agent_lib.workspace = true
 
 disk_backend.workspace = true

--- a/vm/devices/get/guest_emulation_device/src/lib.rs
+++ b/vm/devices/get/guest_emulation_device/src/lib.rs
@@ -115,6 +115,8 @@ enum Error {
     TestIgvmAgent(#[source] test_igvm_agent_lib::Error),
     #[error("failed to write to shared memory")]
     SharedMemoryWriteFailed(#[source] guestmem::GuestMemoryError),
+    #[error("SMBIOS field `{0}` cannot be configured over the paravisor GET path")]
+    UnsupportedSmbiosField(&'static str),
 }
 
 impl From<task_control::Cancelled> for Error {
@@ -167,6 +169,9 @@ pub struct GuestConfig {
     pub efi_diagnostics_log_level: EfiDiagnosticsLogLevelType,
     /// Force UEFI to bounce-buffer all DMA traffic.
     pub force_dma_bounce_enabled: bool,
+    /// SMBIOS identity overrides.
+    #[inspect(skip)]
+    pub smbios: smbios_defs::SmbiosConfig,
 }
 
 #[derive(Debug, Clone, Inspect)]
@@ -1263,6 +1268,44 @@ impl<T: RingMem + Unpin> GedChannel<T> {
         &mut self,
         state: &mut GuestEmulationDevice,
     ) -> Result<(), Error> {
+        // The paravisor GET path only carries the SMBIOS *system* (Type 1)
+        // identity. BIOS (Type 0) overrides have no wire representation and the
+        // paravisor's direct loader builds Type 0 from its own defaults, so
+        // fail closed rather than silently dropping a requested override
+        // (mirrors the UEFI load path's handling).
+        let smbios_defs::SmbiosBiosOverrides {
+            vendor,
+            version,
+            release_date,
+            release,
+        } = &state.config.smbios.bios;
+        if vendor.is_some() {
+            return Err(Error::UnsupportedSmbiosField("BIOS vendor"));
+        }
+        if version.is_some() {
+            return Err(Error::UnsupportedSmbiosField("BIOS version"));
+        }
+        if release_date.is_some() {
+            return Err(Error::UnsupportedSmbiosField("BIOS release date"));
+        }
+        if release.is_some() {
+            return Err(Error::UnsupportedSmbiosField("BIOS release"));
+        }
+
+        // Destructure the Type 1 (System) overrides so that every field is
+        // explicitly forwarded below; adding a field to `SmbiosSystemOverrides`
+        // is then a compile error here until it is wired into the DPS payload,
+        // rather than being silently dropped.
+        let smbios_defs::SmbiosSystemOverrides {
+            manufacturer: system_manufacturer,
+            product_name: system_product_name,
+            version: system_version,
+            serial_number: system_serial_number,
+            sku_number: system_sku_number,
+            family: system_family,
+            uuid: system_uuid,
+        } = &state.config.smbios.system;
+
         let vpci_boot_enabled;
         let enable_firmware_debugging;
         let disable_frontpage;
@@ -1327,8 +1370,9 @@ impl<T: RingMem + Unpin> GedChannel<T> {
                 bios_guid: if state.test_gsp_by_id {
                     guid::guid!("2b701019-2816-4a85-9692-3981f1af4423")
                 } else {
-                    Default::default()
+                    *system_uuid
                 },
+                serial_number: system_serial_number.clone().unwrap_or_default(),
                 ..Default::default()
             },
             v2: get_protocol::dps_json::HclDevicePlatformSettingsV2 {
@@ -1350,7 +1394,14 @@ impl<T: RingMem + Unpin> GedChannel<T> {
                     vpci_instance_filter: None,
                     num_lock_enabled: false,
                     pcat_boot_device_order,
-                    smbios: Default::default(),
+                    smbios: get_protocol::dps_json::HclDevicePlatformSettingsV2StaticSmbios {
+                        system_manufacturer: system_manufacturer.clone().unwrap_or_default(),
+                        system_product_name: system_product_name.clone().unwrap_or_default(),
+                        system_version: system_version.clone().unwrap_or_default(),
+                        system_sku_number: system_sku_number.clone().unwrap_or_default(),
+                        system_family: system_family.clone().unwrap_or_default(),
+                        ..Default::default()
+                    },
                     watchdog_enabled: false,
                     always_relay_host_mmio: false,
                     imc_enabled: false,

--- a/vm/devices/get/guest_emulation_device/src/lib.rs
+++ b/vm/devices/get/guest_emulation_device/src/lib.rs
@@ -115,6 +115,8 @@ enum Error {
     TestIgvmAgent(#[source] test_igvm_agent_lib::Error),
     #[error("failed to write to shared memory")]
     SharedMemoryWriteFailed(#[source] guestmem::GuestMemoryError),
+    #[error("SMBIOS field `{0}` cannot be configured over the paravisor GET path")]
+    UnsupportedSmbiosField(&'static str),
 }
 
 impl From<task_control::Cancelled> for Error {
@@ -169,6 +171,9 @@ pub struct GuestConfig {
     pub efi_diagnostics_log_level: EfiDiagnosticsLogLevelType,
     /// Force UEFI to bounce-buffer all DMA traffic.
     pub force_dma_bounce_enabled: bool,
+    /// SMBIOS identity overrides.
+    #[inspect(skip)]
+    pub smbios: smbios_defs::SmbiosConfig,
 }
 
 #[derive(Debug, Clone, Inspect)]
@@ -1303,6 +1308,44 @@ impl<T: RingMem + Unpin> GedChannel<T> {
         &mut self,
         state: &mut GuestEmulationDevice,
     ) -> Result<(), Error> {
+        // The paravisor GET path only carries the SMBIOS *system* (Type 1)
+        // identity. BIOS (Type 0) overrides have no wire representation and the
+        // paravisor's direct loader builds Type 0 from its own defaults, so
+        // fail closed rather than silently dropping a requested override
+        // (mirrors the UEFI load path's handling).
+        let smbios_defs::SmbiosBiosOverrides {
+            vendor,
+            version,
+            release_date,
+            release,
+        } = &state.config.smbios.bios;
+        if vendor.is_some() {
+            return Err(Error::UnsupportedSmbiosField("BIOS vendor"));
+        }
+        if version.is_some() {
+            return Err(Error::UnsupportedSmbiosField("BIOS version"));
+        }
+        if release_date.is_some() {
+            return Err(Error::UnsupportedSmbiosField("BIOS release date"));
+        }
+        if release.is_some() {
+            return Err(Error::UnsupportedSmbiosField("BIOS release"));
+        }
+
+        // Destructure the Type 1 (System) overrides so that every field is
+        // explicitly forwarded below; adding a field to `SmbiosSystemOverrides`
+        // is then a compile error here until it is wired into the DPS payload,
+        // rather than being silently dropped.
+        let smbios_defs::SmbiosSystemOverrides {
+            manufacturer: system_manufacturer,
+            product_name: system_product_name,
+            version: system_version,
+            serial_number: system_serial_number,
+            sku_number: system_sku_number,
+            family: system_family,
+            uuid: system_uuid,
+        } = &state.config.smbios.system;
+
         let (
             vpci_boot_enabled,
             enable_firmware_debugging,
@@ -1363,8 +1406,9 @@ impl<T: RingMem + Unpin> GedChannel<T> {
                 bios_guid: if state.test_gsp_by_id {
                     guid::guid!("2b701019-2816-4a85-9692-3981f1af4423")
                 } else {
-                    Default::default()
+                    *system_uuid
                 },
+                serial_number: system_serial_number.clone().unwrap_or_default(),
                 ..Default::default()
             },
             v2: get_protocol::dps_json::HclDevicePlatformSettingsV2 {
@@ -1386,7 +1430,14 @@ impl<T: RingMem + Unpin> GedChannel<T> {
                     vpci_instance_filter: None,
                     num_lock_enabled: false,
                     pcat_boot_device_order,
-                    smbios: Default::default(),
+                    smbios: get_protocol::dps_json::HclDevicePlatformSettingsV2StaticSmbios {
+                        system_manufacturer: system_manufacturer.clone().unwrap_or_default(),
+                        system_product_name: system_product_name.clone().unwrap_or_default(),
+                        system_version: system_version.clone().unwrap_or_default(),
+                        system_sku_number: system_sku_number.clone().unwrap_or_default(),
+                        system_family: system_family.clone().unwrap_or_default(),
+                        ..Default::default()
+                    },
                     watchdog_enabled: false,
                     always_relay_host_mmio: false,
                     imc_enabled: false,

--- a/vm/devices/get/guest_emulation_device/src/resolver.rs
+++ b/vm/devices/get/guest_emulation_device/src/resolver.rs
@@ -215,6 +215,7 @@ impl AsyncResolveResource<VmbusDeviceHandleKind, GuestEmulationDeviceHandle>
                     }
                 },
                 force_dma_bounce_enabled: resource.force_dma_bounce_enabled,
+                smbios: resource.smbios,
             },
             halt,
             resource.firmware_event_send,

--- a/vm/devices/get/guest_emulation_device/src/resolver.rs
+++ b/vm/devices/get/guest_emulation_device/src/resolver.rs
@@ -217,6 +217,7 @@ impl AsyncResolveResource<VmbusDeviceHandleKind, GuestEmulationDeviceHandle>
                     }
                 },
                 force_dma_bounce_enabled: resource.force_dma_bounce_enabled,
+                smbios: resource.smbios,
             },
             halt,
             resource.firmware_event_send,

--- a/vm/devices/get/guest_emulation_device/src/test_utilities.rs
+++ b/vm/devices/get/guest_emulation_device/src/test_utilities.rs
@@ -264,6 +264,7 @@ pub fn create_host_channel(
         hardware_sealing_policy: Default::default(),
         efi_diagnostics_log_level: Default::default(),
         force_dma_bounce_enabled: false,
+        smbios: Default::default(),
     };
 
     let halt_reason = Arc::new(Mutex::new(None));

--- a/vm/devices/get/guest_emulation_device/src/test_utilities.rs
+++ b/vm/devices/get/guest_emulation_device/src/test_utilities.rs
@@ -265,6 +265,7 @@ pub fn create_host_channel(
         hardware_sealing_policy: Default::default(),
         efi_diagnostics_log_level: Default::default(),
         force_dma_bounce_enabled: false,
+        smbios: Default::default(),
     };
 
     let halt_reason = Arc::new(Mutex::new(None));

--- a/vm/devices/get/guest_emulation_transport/src/api.rs
+++ b/vm/devices/get/guest_emulation_transport/src/api.rs
@@ -48,19 +48,21 @@ pub mod platform_settings {
     /// All available SMBIOS related config.
     #[derive(Debug, Inspect)]
     pub struct Smbios {
-        pub serial_number: Vec<u8>,
-        pub base_board_serial_number: Vec<u8>,
-        pub chassis_serial_number: Vec<u8>,
-        pub chassis_asset_tag: Vec<u8>,
+        pub serial_number: String,
+        pub base_board_serial_number: String,
+        pub chassis_serial_number: String,
+        pub chassis_asset_tag: String,
 
-        pub system_manufacturer: Vec<u8>,
-        pub system_product_name: Vec<u8>,
-        pub system_version: Vec<u8>,
-        pub system_sku_number: Vec<u8>,
-        pub system_family: Vec<u8>,
-        pub bios_lock_string: Vec<u8>,
-        pub memory_device_serial_number: Vec<u8>,
+        pub system_manufacturer: String,
+        pub system_product_name: String,
+        pub system_version: String,
+        pub system_sku_number: String,
+        pub system_family: String,
+        pub bios_lock_string: String,
+        pub memory_device_serial_number: String,
 
+        // These two arrive base64-encoded as raw bytes in the DPS JSON, so they
+        // are kept as `Vec<u8>` rather than forcing a UTF-8 conversion.
         pub processor_manufacturer: Vec<u8>,
         pub processor_version: Vec<u8>,
         pub processor_id: u64,

--- a/vm/devices/get/guest_emulation_transport/src/client.rs
+++ b/vm/devices/get/guest_emulation_transport/src/client.rs
@@ -213,23 +213,18 @@ impl GuestEmulationTransportClient {
 
         Ok(platform_settings::DevicePlatformSettings {
             smbios: platform_settings::Smbios {
-                serial_number: json.v1.serial_number.into(),
-                base_board_serial_number: json.v1.base_board_serial_number.into(),
-                chassis_serial_number: json.v1.chassis_serial_number.into(),
-                chassis_asset_tag: json.v1.chassis_asset_tag.into(),
+                serial_number: json.v1.serial_number,
+                base_board_serial_number: json.v1.base_board_serial_number,
+                chassis_serial_number: json.v1.chassis_serial_number,
+                chassis_asset_tag: json.v1.chassis_asset_tag,
 
-                system_manufacturer: json.v2.r#static.smbios.system_manufacturer.into(),
-                system_product_name: json.v2.r#static.smbios.system_product_name.into(),
-                system_version: json.v2.r#static.smbios.system_version.into(),
-                system_sku_number: json.v2.r#static.smbios.system_sku_number.into(),
-                system_family: json.v2.r#static.smbios.system_family.into(),
-                bios_lock_string: json.v2.r#static.smbios.bios_lock_string.into(),
-                memory_device_serial_number: json
-                    .v2
-                    .r#static
-                    .smbios
-                    .memory_device_serial_number
-                    .into(),
+                system_manufacturer: json.v2.r#static.smbios.system_manufacturer,
+                system_product_name: json.v2.r#static.smbios.system_product_name,
+                system_version: json.v2.r#static.smbios.system_version,
+                system_sku_number: json.v2.r#static.smbios.system_sku_number,
+                system_family: json.v2.r#static.smbios.system_family,
+                bios_lock_string: json.v2.r#static.smbios.bios_lock_string,
+                memory_device_serial_number: json.v2.r#static.smbios.memory_device_serial_number,
                 processor_manufacturer: json.v2.dynamic.smbios.processor_manufacturer,
                 processor_version: json.v2.dynamic.smbios.processor_version,
                 processor_id: json.v2.dynamic.smbios.processor_id,

--- a/vmm_tests/vmm_tests/tests/tests/multiarch.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch.rs
@@ -5,6 +5,7 @@
 
 use anyhow::Context;
 use futures::StreamExt;
+use guid::Guid;
 use petri::EfiDiagnosticsLogLevel;
 use petri::MemoryConfig;
 use petri::PetriHaltReason;
@@ -163,15 +164,20 @@ async fn boot_no_vmbus(config: PetriVmBuilder<OpenVmmPetriBackend>) -> anyhow::R
 }
 
 /// Verify that the Linux direct loader synthesizes SMBIOS (DMI) tables so the
-/// guest can read `/sys/class/dmi/id/*`. The two architectures exercise
-/// different delivery paths for the same `_SM3_` entry point: on x86 the kernel
-/// brute-force scans the F-segment `[0xF0000, 0x100000)` for the anchor, while
-/// the aarch64 ACPI-mode kernel discovers it only via the SMBIOS3 EFI
-/// configuration-table entry. There is no configuration surface yet, so the
-/// guest reads the fixed default OpenVMM identity.
+/// guest can read `/sys/class/dmi/id/*`. Covers x86_64 (F-segment scan) and
+/// aarch64 ACPI-mode (EFI configuration table) delivery.
 #[vmm_test(openvmm_linux_direct_x64, openvmm_linux_direct_aarch64)]
 async fn smbios_dmi(config: PetriVmBuilder<OpenVmmPetriBackend>) -> anyhow::Result<()> {
-    let (vm, agent) = config.run().await?;
+    // A fixed, non-default UUID so the round-trip through the SMBIOS Type 1
+    // table is meaningfully exercised (the all-zero default would not catch a
+    // byte-order bug, and a nil UUID is treated as "not present" by Linux so
+    // `product_uuid` would not even be exposed).
+    const TEST_UUID: Guid = guid::guid!("12345678-9abc-def0-1234-56789abcdef0");
+
+    let (vm, agent) = config
+        .modify_backend(|b| b.with_smbios(|smbios| smbios.system.uuid = TEST_UUID))
+        .run()
+        .await?;
 
     let sh = agent.unix_shell();
 
@@ -187,9 +193,204 @@ async fn smbios_dmi(config: PetriVmBuilder<OpenVmmPetriBackend>) -> anyhow::Resu
         .context("reading product_name")?;
     assert_eq!(product_name.trim(), "OpenVMM Virtual Machine");
 
-    // NOTE: the default identity uses a nil UUID, which the Linux kernel treats
-    // as "not present" (see `dmi_save_uuid`), so `/sys/class/dmi/id/product_uuid`
-    // is not created and is intentionally not checked here.
+    let product_uuid = sh
+        .read_file("/sys/class/dmi/id/product_uuid")
+        .await
+        .context("reading product_uuid")?;
+    // SMBIOS (>= 2.6) stores the UUID's first three fields little-endian, and
+    // Linux formats `product_uuid` with `%pUl` (little-endian) accordingly.
+    // Our `Guid`'s in-memory byte layout is the same little-endian SMBIOS
+    // layout, so its `Display` output is exactly what the kernel prints — no
+    // byte-swap.
+    assert_eq!(
+        product_uuid.trim().to_ascii_lowercase(),
+        TEST_UUID.to_string()
+    );
+
+    agent.power_off().await?;
+    vm.wait_for_clean_teardown().await?;
+    Ok(())
+}
+
+/// Verify that on UEFI boot the `type=1` (System Information) SMBIOS overrides
+/// are emitted as UEFI config blobs, consumed by the firmware, and reflected in
+/// the guest's `/sys/class/dmi/id/*`. This exercises the firmware-blob path
+/// (`add_smbios_blobs`), which is distinct from the direct loader's
+/// table-building path covered by `smbios_dmi`. Every Type 1 field the firmware
+/// exposes is overridden so the full blob set is validated.
+#[vmm_test(
+    openvmm_uefi_x64(vhd(ubuntu_2404_server_x64)),
+    openvmm_uefi_aarch64(vhd(ubuntu_2404_server_aarch64))
+)]
+async fn smbios_dmi_uefi(config: PetriVmBuilder<OpenVmmPetriBackend>) -> anyhow::Result<()> {
+    const MANUFACTURER: &str = "Contoso";
+    const PRODUCT: &str = "Contoso Virtual Machine";
+    const VERSION: &str = "9.8.7";
+    const SERIAL: &str = "SN-0123456789";
+    const SKU: &str = "SKU-CONTOSO-42";
+    const FAMILY: &str = "Contoso VM Family";
+    // A fixed, non-default UUID so the BiosGuid round-trip is meaningfully
+    // exercised (the all-zero default would not catch a byte-order bug).
+    const UUID: Guid = guid::guid!("0fedcba9-8765-4321-0fed-cba987654321");
+
+    let (vm, agent) = config
+        .modify_backend(|b| {
+            b.with_smbios(|smbios| {
+                let system = &mut smbios.system;
+                system.manufacturer = Some(MANUFACTURER.to_string());
+                system.product_name = Some(PRODUCT.to_string());
+                system.version = Some(VERSION.to_string());
+                system.serial_number = Some(SERIAL.to_string());
+                system.sku_number = Some(SKU.to_string());
+                system.family = Some(FAMILY.to_string());
+                system.uuid = UUID;
+            })
+        })
+        .run()
+        .await?;
+
+    let sh = agent.unix_shell();
+
+    // World-readable DMI attributes (mode 0444).
+    let sys_vendor = cmd!(sh, "cat /sys/class/dmi/id/sys_vendor")
+        .read()
+        .await
+        .context("reading sys_vendor")?;
+    assert_eq!(sys_vendor.trim(), MANUFACTURER);
+
+    let product_name = cmd!(sh, "cat /sys/class/dmi/id/product_name")
+        .read()
+        .await
+        .context("reading product_name")?;
+    assert_eq!(product_name.trim(), PRODUCT);
+
+    let product_version = cmd!(sh, "cat /sys/class/dmi/id/product_version")
+        .read()
+        .await
+        .context("reading product_version")?;
+    assert_eq!(product_version.trim(), VERSION);
+
+    let product_sku = cmd!(sh, "cat /sys/class/dmi/id/product_sku")
+        .read()
+        .await
+        .context("reading product_sku")?;
+    assert_eq!(product_sku.trim(), SKU);
+
+    let product_family = cmd!(sh, "cat /sys/class/dmi/id/product_family")
+        .read()
+        .await
+        .context("reading product_family")?;
+    assert_eq!(product_family.trim(), FAMILY);
+
+    // `product_serial` and `product_uuid` are root-only (mode 0400) on the
+    // Ubuntu guest, so read them with sudo.
+    let product_serial = cmd!(sh, "sudo cat /sys/class/dmi/id/product_serial")
+        .read()
+        .await
+        .context("reading product_serial")?;
+    assert_eq!(product_serial.trim(), SERIAL);
+
+    let product_uuid = cmd!(sh, "sudo cat /sys/class/dmi/id/product_uuid")
+        .read()
+        .await
+        .context("reading product_uuid")?;
+    // SMBIOS (>= 2.6) stores the UUID's first three fields little-endian, and
+    // Linux formats `product_uuid` with `%pUl` (little-endian) accordingly.
+    // Our `Guid`'s in-memory byte layout is the same little-endian SMBIOS
+    // layout, so its `Display` output is exactly what the kernel prints — no
+    // byte-swap.
+    assert_eq!(product_uuid.trim().to_ascii_lowercase(), UUID.to_string());
+    agent.power_off().await?;
+    vm.wait_for_clean_teardown().await?;
+    Ok(())
+}
+
+/// Verify that the SMBIOS identity a host forwards to an OpenHCL paravisor over
+/// the Guest Emulation Transport (GET) reaches the VTL0 guest's DMI. The
+/// paravisor's Linux direct loader builds the SMBIOS tables from the
+/// host-provided `DevicePlatformSettings`, so this exercises the full
+/// host -> GET -> paravisor -> guest path — distinct from `smbios_dmi` (OpenVMM
+/// builds the tables directly) and `smbios_dmi_uefi` (UEFI firmware builds
+/// them). Every host-forwarded Type 1 field is overridden so the whole chain is
+/// validated.
+#[vmm_test(openvmm_openhcl_linux_direct_x64)]
+async fn smbios_dmi_openhcl(config: PetriVmBuilder<OpenVmmPetriBackend>) -> anyhow::Result<()> {
+    const MANUFACTURER: &str = "Contoso";
+    const PRODUCT: &str = "Contoso Virtual Machine";
+    const VERSION: &str = "9.8.7";
+    const SERIAL: &str = "SN-OPENHCL-123";
+    const SKU: &str = "SKU-CONTOSO-42";
+    const FAMILY: &str = "Contoso VM Family";
+    // A fixed, non-default UUID so the BiosGuid round-trip through GET is
+    // meaningfully exercised (the all-zero default would not catch a byte-order
+    // bug, and a nil UUID is treated as "not present" by Linux so `product_uuid`
+    // would not even be exposed).
+    const UUID: Guid = guid::guid!("0fedcba9-8765-4321-0fed-cba987654321");
+
+    let (vm, agent) = config
+        .modify_backend(|b| {
+            b.with_smbios(|smbios| {
+                let system = &mut smbios.system;
+                system.manufacturer = Some(MANUFACTURER.to_string());
+                system.product_name = Some(PRODUCT.to_string());
+                system.version = Some(VERSION.to_string());
+                system.serial_number = Some(SERIAL.to_string());
+                system.sku_number = Some(SKU.to_string());
+                system.family = Some(FAMILY.to_string());
+                system.uuid = UUID;
+            })
+        })
+        .run()
+        .await?;
+
+    let sh = agent.unix_shell();
+
+    let sys_vendor = sh
+        .read_file("/sys/class/dmi/id/sys_vendor")
+        .await
+        .context("reading sys_vendor")?;
+    assert_eq!(sys_vendor.trim(), MANUFACTURER);
+
+    let product_name = sh
+        .read_file("/sys/class/dmi/id/product_name")
+        .await
+        .context("reading product_name")?;
+    assert_eq!(product_name.trim(), PRODUCT);
+
+    let product_version = sh
+        .read_file("/sys/class/dmi/id/product_version")
+        .await
+        .context("reading product_version")?;
+    assert_eq!(product_version.trim(), VERSION);
+
+    let product_sku = sh
+        .read_file("/sys/class/dmi/id/product_sku")
+        .await
+        .context("reading product_sku")?;
+    assert_eq!(product_sku.trim(), SKU);
+
+    let product_family = sh
+        .read_file("/sys/class/dmi/id/product_family")
+        .await
+        .context("reading product_family")?;
+    assert_eq!(product_family.trim(), FAMILY);
+
+    let product_serial = sh
+        .read_file("/sys/class/dmi/id/product_serial")
+        .await
+        .context("reading product_serial")?;
+    assert_eq!(product_serial.trim(), SERIAL);
+
+    let product_uuid = sh
+        .read_file("/sys/class/dmi/id/product_uuid")
+        .await
+        .context("reading product_uuid")?;
+    // SMBIOS (>= 2.6) stores the UUID's first three fields little-endian, and
+    // Linux formats `product_uuid` with `%pUl` (little-endian) accordingly.
+    // Our `Guid`'s in-memory byte layout is the same little-endian SMBIOS
+    // layout, so its `Display` output is exactly what the kernel prints — no
+    // byte-swap.
+    assert_eq!(product_uuid.trim().to_ascii_lowercase(), UUID.to_string());
 
     agent.power_off().await?;
     vm.wait_for_clean_teardown().await?;

--- a/vmm_tests/vmm_tests/tests/tests/multiarch.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch.rs
@@ -307,47 +307,44 @@ async fn smbios_dmi_uefi(config: PetriVmBuilder<OpenVmmPetriBackend>) -> anyhow:
 
     let sh = agent.unix_shell();
 
-    // World-readable DMI attributes (mode 0444).
-    let sys_vendor = cmd!(sh, "cat /sys/class/dmi/id/sys_vendor")
-        .read()
+    let sys_vendor = sh
+        .read_file("/sys/class/dmi/id/sys_vendor")
         .await
         .context("reading sys_vendor")?;
     assert_eq!(sys_vendor.trim(), MANUFACTURER);
 
-    let product_name = cmd!(sh, "cat /sys/class/dmi/id/product_name")
-        .read()
+    let product_name = sh
+        .read_file("/sys/class/dmi/id/product_name")
         .await
         .context("reading product_name")?;
     assert_eq!(product_name.trim(), PRODUCT);
 
-    let product_version = cmd!(sh, "cat /sys/class/dmi/id/product_version")
-        .read()
+    let product_version = sh
+        .read_file("/sys/class/dmi/id/product_version")
         .await
         .context("reading product_version")?;
     assert_eq!(product_version.trim(), VERSION);
 
-    let product_sku = cmd!(sh, "cat /sys/class/dmi/id/product_sku")
-        .read()
+    let product_sku = sh
+        .read_file("/sys/class/dmi/id/product_sku")
         .await
         .context("reading product_sku")?;
     assert_eq!(product_sku.trim(), SKU);
 
-    let product_family = cmd!(sh, "cat /sys/class/dmi/id/product_family")
-        .read()
+    let product_family = sh
+        .read_file("/sys/class/dmi/id/product_family")
         .await
         .context("reading product_family")?;
     assert_eq!(product_family.trim(), FAMILY);
 
-    // `product_serial` and `product_uuid` are root-only (mode 0400) on the
-    // Ubuntu guest, so read them with sudo.
-    let product_serial = cmd!(sh, "sudo cat /sys/class/dmi/id/product_serial")
-        .read()
+    let product_serial = sh
+        .read_file("/sys/class/dmi/id/product_serial")
         .await
         .context("reading product_serial")?;
     assert_eq!(product_serial.trim(), SERIAL);
 
-    let product_uuid = cmd!(sh, "sudo cat /sys/class/dmi/id/product_uuid")
-        .read()
+    let product_uuid = sh
+        .read_file("/sys/class/dmi/id/product_uuid")
         .await
         .context("reading product_uuid")?;
     // SMBIOS (>= 2.6) stores the UUID's first three fields little-endian, and

--- a/vmm_tests/vmm_tests/tests/tests/multiarch.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch.rs
@@ -5,6 +5,7 @@
 
 use anyhow::Context;
 use futures::StreamExt;
+use guid::Guid;
 use petri::EfiDiagnosticsLogLevel;
 use petri::MemoryConfig;
 use petri::PetriHaltReason;
@@ -219,15 +220,20 @@ async fn boot_no_hv_uefi_aarch64_tcg(
 }
 
 /// Verify that the Linux direct loader synthesizes SMBIOS (DMI) tables so the
-/// guest can read `/sys/class/dmi/id/*`. The two architectures exercise
-/// different delivery paths for the same `_SM3_` entry point: on x86 the kernel
-/// brute-force scans the F-segment `[0xF0000, 0x100000)` for the anchor, while
-/// the aarch64 ACPI-mode kernel discovers it only via the SMBIOS3 EFI
-/// configuration-table entry. There is no configuration surface yet, so the
-/// guest reads the fixed default OpenVMM identity.
+/// guest can read `/sys/class/dmi/id/*`. Covers x86_64 (F-segment scan) and
+/// aarch64 ACPI-mode (EFI configuration table) delivery.
 #[vmm_test(openvmm_linux_direct_x64, openvmm_linux_direct_aarch64)]
 async fn smbios_dmi(config: PetriVmBuilder<OpenVmmPetriBackend>) -> anyhow::Result<()> {
-    let (vm, agent) = config.run().await?;
+    // A fixed, non-default UUID so the round-trip through the SMBIOS Type 1
+    // table is meaningfully exercised (the all-zero default would not catch a
+    // byte-order bug, and a nil UUID is treated as "not present" by Linux so
+    // `product_uuid` would not even be exposed).
+    const TEST_UUID: Guid = guid::guid!("12345678-9abc-def0-1234-56789abcdef0");
+
+    let (vm, agent) = config
+        .modify_backend(|b| b.with_smbios(|smbios| smbios.system.uuid = TEST_UUID))
+        .run()
+        .await?;
 
     let sh = agent.unix_shell();
 
@@ -243,9 +249,204 @@ async fn smbios_dmi(config: PetriVmBuilder<OpenVmmPetriBackend>) -> anyhow::Resu
         .context("reading product_name")?;
     assert_eq!(product_name.trim(), "OpenVMM Virtual Machine");
 
-    // NOTE: the default identity uses a nil UUID, which the Linux kernel treats
-    // as "not present" (see `dmi_save_uuid`), so `/sys/class/dmi/id/product_uuid`
-    // is not created and is intentionally not checked here.
+    let product_uuid = sh
+        .read_file("/sys/class/dmi/id/product_uuid")
+        .await
+        .context("reading product_uuid")?;
+    // SMBIOS (>= 2.6) stores the UUID's first three fields little-endian, and
+    // Linux formats `product_uuid` with `%pUl` (little-endian) accordingly.
+    // Our `Guid`'s in-memory byte layout is the same little-endian SMBIOS
+    // layout, so its `Display` output is exactly what the kernel prints — no
+    // byte-swap.
+    assert_eq!(
+        product_uuid.trim().to_ascii_lowercase(),
+        TEST_UUID.to_string()
+    );
+
+    agent.power_off().await?;
+    vm.wait_for_clean_teardown().await?;
+    Ok(())
+}
+
+/// Verify that on UEFI boot the `type=1` (System Information) SMBIOS overrides
+/// are emitted as UEFI config blobs, consumed by the firmware, and reflected in
+/// the guest's `/sys/class/dmi/id/*`. This exercises the firmware-blob path
+/// (`add_smbios_blobs`), which is distinct from the direct loader's
+/// table-building path covered by `smbios_dmi`. Every Type 1 field the firmware
+/// exposes is overridden so the full blob set is validated.
+#[vmm_test(
+    openvmm_uefi_x64(vhd(ubuntu_2404_server_x64)),
+    openvmm_uefi_aarch64(vhd(ubuntu_2404_server_aarch64))
+)]
+async fn smbios_dmi_uefi(config: PetriVmBuilder<OpenVmmPetriBackend>) -> anyhow::Result<()> {
+    const MANUFACTURER: &str = "Contoso";
+    const PRODUCT: &str = "Contoso Virtual Machine";
+    const VERSION: &str = "9.8.7";
+    const SERIAL: &str = "SN-0123456789";
+    const SKU: &str = "SKU-CONTOSO-42";
+    const FAMILY: &str = "Contoso VM Family";
+    // A fixed, non-default UUID so the BiosGuid round-trip is meaningfully
+    // exercised (the all-zero default would not catch a byte-order bug).
+    const UUID: Guid = guid::guid!("0fedcba9-8765-4321-0fed-cba987654321");
+
+    let (vm, agent) = config
+        .modify_backend(|b| {
+            b.with_smbios(|smbios| {
+                let system = &mut smbios.system;
+                system.manufacturer = Some(MANUFACTURER.to_string());
+                system.product_name = Some(PRODUCT.to_string());
+                system.version = Some(VERSION.to_string());
+                system.serial_number = Some(SERIAL.to_string());
+                system.sku_number = Some(SKU.to_string());
+                system.family = Some(FAMILY.to_string());
+                system.uuid = UUID;
+            })
+        })
+        .run()
+        .await?;
+
+    let sh = agent.unix_shell();
+
+    // World-readable DMI attributes (mode 0444).
+    let sys_vendor = cmd!(sh, "cat /sys/class/dmi/id/sys_vendor")
+        .read()
+        .await
+        .context("reading sys_vendor")?;
+    assert_eq!(sys_vendor.trim(), MANUFACTURER);
+
+    let product_name = cmd!(sh, "cat /sys/class/dmi/id/product_name")
+        .read()
+        .await
+        .context("reading product_name")?;
+    assert_eq!(product_name.trim(), PRODUCT);
+
+    let product_version = cmd!(sh, "cat /sys/class/dmi/id/product_version")
+        .read()
+        .await
+        .context("reading product_version")?;
+    assert_eq!(product_version.trim(), VERSION);
+
+    let product_sku = cmd!(sh, "cat /sys/class/dmi/id/product_sku")
+        .read()
+        .await
+        .context("reading product_sku")?;
+    assert_eq!(product_sku.trim(), SKU);
+
+    let product_family = cmd!(sh, "cat /sys/class/dmi/id/product_family")
+        .read()
+        .await
+        .context("reading product_family")?;
+    assert_eq!(product_family.trim(), FAMILY);
+
+    // `product_serial` and `product_uuid` are root-only (mode 0400) on the
+    // Ubuntu guest, so read them with sudo.
+    let product_serial = cmd!(sh, "sudo cat /sys/class/dmi/id/product_serial")
+        .read()
+        .await
+        .context("reading product_serial")?;
+    assert_eq!(product_serial.trim(), SERIAL);
+
+    let product_uuid = cmd!(sh, "sudo cat /sys/class/dmi/id/product_uuid")
+        .read()
+        .await
+        .context("reading product_uuid")?;
+    // SMBIOS (>= 2.6) stores the UUID's first three fields little-endian, and
+    // Linux formats `product_uuid` with `%pUl` (little-endian) accordingly.
+    // Our `Guid`'s in-memory byte layout is the same little-endian SMBIOS
+    // layout, so its `Display` output is exactly what the kernel prints — no
+    // byte-swap.
+    assert_eq!(product_uuid.trim().to_ascii_lowercase(), UUID.to_string());
+    agent.power_off().await?;
+    vm.wait_for_clean_teardown().await?;
+    Ok(())
+}
+
+/// Verify that the SMBIOS identity a host forwards to an OpenHCL paravisor over
+/// the Guest Emulation Transport (GET) reaches the VTL0 guest's DMI. The
+/// paravisor's Linux direct loader builds the SMBIOS tables from the
+/// host-provided `DevicePlatformSettings`, so this exercises the full
+/// host -> GET -> paravisor -> guest path — distinct from `smbios_dmi` (OpenVMM
+/// builds the tables directly) and `smbios_dmi_uefi` (UEFI firmware builds
+/// them). Every host-forwarded Type 1 field is overridden so the whole chain is
+/// validated.
+#[vmm_test(openvmm_openhcl_linux_direct_x64)]
+async fn smbios_dmi_openhcl(config: PetriVmBuilder<OpenVmmPetriBackend>) -> anyhow::Result<()> {
+    const MANUFACTURER: &str = "Contoso";
+    const PRODUCT: &str = "Contoso Virtual Machine";
+    const VERSION: &str = "9.8.7";
+    const SERIAL: &str = "SN-OPENHCL-123";
+    const SKU: &str = "SKU-CONTOSO-42";
+    const FAMILY: &str = "Contoso VM Family";
+    // A fixed, non-default UUID so the BiosGuid round-trip through GET is
+    // meaningfully exercised (the all-zero default would not catch a byte-order
+    // bug, and a nil UUID is treated as "not present" by Linux so `product_uuid`
+    // would not even be exposed).
+    const UUID: Guid = guid::guid!("0fedcba9-8765-4321-0fed-cba987654321");
+
+    let (vm, agent) = config
+        .modify_backend(|b| {
+            b.with_smbios(|smbios| {
+                let system = &mut smbios.system;
+                system.manufacturer = Some(MANUFACTURER.to_string());
+                system.product_name = Some(PRODUCT.to_string());
+                system.version = Some(VERSION.to_string());
+                system.serial_number = Some(SERIAL.to_string());
+                system.sku_number = Some(SKU.to_string());
+                system.family = Some(FAMILY.to_string());
+                system.uuid = UUID;
+            })
+        })
+        .run()
+        .await?;
+
+    let sh = agent.unix_shell();
+
+    let sys_vendor = sh
+        .read_file("/sys/class/dmi/id/sys_vendor")
+        .await
+        .context("reading sys_vendor")?;
+    assert_eq!(sys_vendor.trim(), MANUFACTURER);
+
+    let product_name = sh
+        .read_file("/sys/class/dmi/id/product_name")
+        .await
+        .context("reading product_name")?;
+    assert_eq!(product_name.trim(), PRODUCT);
+
+    let product_version = sh
+        .read_file("/sys/class/dmi/id/product_version")
+        .await
+        .context("reading product_version")?;
+    assert_eq!(product_version.trim(), VERSION);
+
+    let product_sku = sh
+        .read_file("/sys/class/dmi/id/product_sku")
+        .await
+        .context("reading product_sku")?;
+    assert_eq!(product_sku.trim(), SKU);
+
+    let product_family = sh
+        .read_file("/sys/class/dmi/id/product_family")
+        .await
+        .context("reading product_family")?;
+    assert_eq!(product_family.trim(), FAMILY);
+
+    let product_serial = sh
+        .read_file("/sys/class/dmi/id/product_serial")
+        .await
+        .context("reading product_serial")?;
+    assert_eq!(product_serial.trim(), SERIAL);
+
+    let product_uuid = sh
+        .read_file("/sys/class/dmi/id/product_uuid")
+        .await
+        .context("reading product_uuid")?;
+    // SMBIOS (>= 2.6) stores the UUID's first three fields little-endian, and
+    // Linux formats `product_uuid` with `%pUl` (little-endian) accordingly.
+    // Our `Guid`'s in-memory byte layout is the same little-endian SMBIOS
+    // layout, so its `Display` output is exactly what the kernel prints — no
+    // byte-swap.
+    assert_eq!(product_uuid.trim().to_ascii_lowercase(), UUID.to_string());
 
     agent.power_off().await?;
     vm.wait_for_clean_teardown().await?;

--- a/vmm_tests/vmm_tests/tests/tests/ttrpc.rs
+++ b/vmm_tests/vmm_tests/tests/tests/ttrpc.rs
@@ -340,6 +340,29 @@ async fn test_ttrpc_interface(
             )
         };
 
+        // Exercise SMBIOS identity overrides on iteration 0, where pipette
+        // is available to read back the guest's DMI.
+        let smbios_config = (i == 0).then(|| vmservice::SmbiosConfig {
+            bios: Some(vmservice::smbios_config::Bios {
+                vendor: Some(SMBIOS_BIOS_VENDOR.to_string()),
+                version: Some(SMBIOS_BIOS_VERSION.to_string()),
+                release_date: Some(SMBIOS_BIOS_DATE.to_string()),
+                release: Some(vmservice::smbios_config::bios::Release {
+                    major: SMBIOS_BIOS_RELEASE_MAJOR,
+                    minor: SMBIOS_BIOS_RELEASE_MINOR,
+                }),
+            }),
+            system: Some(vmservice::smbios_config::System {
+                manufacturer: Some(SMBIOS_SYS_MANUFACTURER.to_string()),
+                product_name: Some(SMBIOS_SYS_PRODUCT.to_string()),
+                version: Some(SMBIOS_SYS_VERSION.to_string()),
+                serial_number: Some(SMBIOS_SYS_SERIAL.to_string()),
+                sku_number: Some(SMBIOS_SYS_SKU.to_string()),
+                family: Some(SMBIOS_SYS_FAMILY.to_string()),
+                uuid: Some(SMBIOS_SYS_UUID.to_string()),
+            }),
+        });
+
         client
             .call()
             .start(
@@ -400,6 +423,7 @@ async fn test_ttrpc_interface(
                         hvsocket_config: (i == 0).then(|| vmservice::HvSocketConfig {
                             path: hvsocket_path.to_string_lossy().to_string(),
                         }),
+                        smbios_config,
                         ..Default::default()
                     }),
                     log_id: String::new(),
@@ -559,6 +583,7 @@ async fn test_ttrpc_interface(
                     )
                     .await?;
                     validate_pcie_config(&agent).await?;
+                    validate_smbios(&agent).await?;
                     agent.power_off().await?;
                 }
 
@@ -1075,6 +1100,53 @@ fn file_disk(path: &Path) -> vmservice::DiskBackend {
             direct: false,
         })),
     }
+}
+
+const SMBIOS_BIOS_VENDOR: &str = "Contoso BIOS";
+const SMBIOS_BIOS_VERSION: &str = "1.2.3";
+const SMBIOS_BIOS_DATE: &str = "01/01/2026";
+const SMBIOS_BIOS_RELEASE_MAJOR: u32 = 4;
+const SMBIOS_BIOS_RELEASE_MINOR: u32 = 1;
+const SMBIOS_SYS_MANUFACTURER: &str = "Contoso";
+const SMBIOS_SYS_PRODUCT: &str = "Contoso Virtual Machine";
+const SMBIOS_SYS_VERSION: &str = "9.8.7";
+const SMBIOS_SYS_SERIAL: &str = "SN-0123456789";
+const SMBIOS_SYS_SKU: &str = "SKU-CONTOSO-42";
+const SMBIOS_SYS_FAMILY: &str = "Contoso VM Family";
+const SMBIOS_SYS_UUID: &str = "12345678-9abc-def0-1234-56789abcdef0";
+
+async fn validate_smbios(agent: &pipette_client::PipetteClient) -> anyhow::Result<()> {
+    for (file, expected) in [
+        ("bios_vendor", SMBIOS_BIOS_VENDOR),
+        ("bios_version", SMBIOS_BIOS_VERSION),
+        ("bios_date", SMBIOS_BIOS_DATE),
+        ("sys_vendor", SMBIOS_SYS_MANUFACTURER),
+        ("product_name", SMBIOS_SYS_PRODUCT),
+        ("product_version", SMBIOS_SYS_VERSION),
+        ("product_serial", SMBIOS_SYS_SERIAL),
+        ("product_sku", SMBIOS_SYS_SKU),
+        ("product_family", SMBIOS_SYS_FAMILY),
+        ("product_uuid", SMBIOS_SYS_UUID),
+    ] {
+        let actual = String::from_utf8(agent.read_file(format!("/sys/class/dmi/id/{file}")).await?)
+            .with_context(|| format!("dmi id {file} is not UTF-8"))?;
+        anyhow::ensure!(
+            actual.trim() == expected,
+            "dmi id {file}: expected {expected:?}, got {:?}",
+            actual.trim()
+        );
+    }
+
+    let bios_release = String::from_utf8(agent.read_file("/sys/class/dmi/id/bios_release").await?)
+        .context("dmi id bios_release is not UTF-8")?;
+    let expected = format!("{SMBIOS_BIOS_RELEASE_MAJOR}.{SMBIOS_BIOS_RELEASE_MINOR}");
+    anyhow::ensure!(
+        bios_release.trim() == expected,
+        "dmi id bios_release: expected {expected:?}, got {:?}",
+        bios_release.trim()
+    );
+
+    Ok(())
 }
 
 async fn validate_pcie_config(agent: &pipette_client::PipetteClient) -> anyhow::Result<()> {

--- a/vmm_tests/vmm_tests/tests/tests/ttrpc.rs
+++ b/vmm_tests/vmm_tests/tests/tests/ttrpc.rs
@@ -341,6 +341,29 @@ fn test_ttrpc_interface(
                 )
             };
 
+            // Exercise SMBIOS identity overrides on iteration 0, where pipette
+            // is available to read back the guest's DMI (see `validate_smbios`).
+            let smbios_config = (i == 0).then(|| vmservice::SmbiosConfig {
+                bios: Some(vmservice::smbios_config::Bios {
+                    vendor: Some(SMBIOS_BIOS_VENDOR.to_string()),
+                    version: Some(SMBIOS_BIOS_VERSION.to_string()),
+                    release_date: Some(SMBIOS_BIOS_DATE.to_string()),
+                    release: Some(vmservice::smbios_config::bios::Release {
+                        major: SMBIOS_BIOS_RELEASE_MAJOR,
+                        minor: SMBIOS_BIOS_RELEASE_MINOR,
+                    }),
+                }),
+                system: Some(vmservice::smbios_config::System {
+                    manufacturer: Some(SMBIOS_SYS_MANUFACTURER.to_string()),
+                    product_name: Some(SMBIOS_SYS_PRODUCT.to_string()),
+                    version: Some(SMBIOS_SYS_VERSION.to_string()),
+                    serial_number: Some(SMBIOS_SYS_SERIAL.to_string()),
+                    sku_number: Some(SMBIOS_SYS_SKU.to_string()),
+                    family: Some(SMBIOS_SYS_FAMILY.to_string()),
+                    uuid: Some(SMBIOS_SYS_UUID.to_string()),
+                }),
+            });
+
             client
                 .call()
                 .start(
@@ -401,6 +424,7 @@ fn test_ttrpc_interface(
                             hvsocket_config: (i == 0).then(|| vmservice::HvSocketConfig {
                                 path: hvsocket_path.to_string_lossy().to_string(),
                             }),
+                            smbios_config,
                             ..Default::default()
                         }),
                         log_id: String::new(),
@@ -562,6 +586,7 @@ fn test_ttrpc_interface(
                         )
                         .await?;
                         validate_pcie_config(&agent).await?;
+                        validate_smbios(&agent).await?;
                         agent.power_off().await?;
                     }
 
@@ -1080,6 +1105,69 @@ fn file_disk(path: &Path) -> vmservice::DiskBackend {
             direct: false,
         })),
     }
+}
+
+// SMBIOS (DMI) identity overrides applied on iteration 0 of the main test and
+// validated in the guest by `validate_smbios`.
+const SMBIOS_BIOS_VENDOR: &str = "Contoso BIOS";
+const SMBIOS_BIOS_VERSION: &str = "1.2.3";
+const SMBIOS_BIOS_DATE: &str = "01/01/2026";
+const SMBIOS_BIOS_RELEASE_MAJOR: u32 = 4;
+const SMBIOS_BIOS_RELEASE_MINOR: u32 = 1;
+const SMBIOS_SYS_MANUFACTURER: &str = "Contoso";
+const SMBIOS_SYS_PRODUCT: &str = "Contoso Virtual Machine";
+const SMBIOS_SYS_VERSION: &str = "9.8.7";
+const SMBIOS_SYS_SERIAL: &str = "SN-0123456789";
+const SMBIOS_SYS_SKU: &str = "SKU-CONTOSO-42";
+const SMBIOS_SYS_FAMILY: &str = "Contoso VM Family";
+// A fixed, non-default UUID: the all-zero default would not catch a byte-order
+// bug, and Linux treats a nil UUID as "not present" so `product_uuid` would not
+// even be exposed.
+const SMBIOS_SYS_UUID: &str = "12345678-9abc-def0-1234-56789abcdef0";
+
+/// Validate that the SMBIOS identity overrides passed to `CreateVm` on
+/// iteration 0 are reflected in the guest's `/sys/class/dmi/id/*`.
+async fn validate_smbios(agent: &pipette_client::PipetteClient) -> anyhow::Result<()> {
+    let sh = agent.unix_shell();
+    for (file, expected) in [
+        ("bios_vendor", SMBIOS_BIOS_VENDOR),
+        ("bios_version", SMBIOS_BIOS_VERSION),
+        ("bios_date", SMBIOS_BIOS_DATE),
+        ("sys_vendor", SMBIOS_SYS_MANUFACTURER),
+        ("product_name", SMBIOS_SYS_PRODUCT),
+        ("product_version", SMBIOS_SYS_VERSION),
+        ("product_serial", SMBIOS_SYS_SERIAL),
+        ("product_sku", SMBIOS_SYS_SKU),
+        ("product_family", SMBIOS_SYS_FAMILY),
+        // The kernel formats `product_uuid` little-endian (`%pUl`); a `Guid`'s
+        // Display output already matches that layout, so compare directly.
+        ("product_uuid", SMBIOS_SYS_UUID),
+    ] {
+        let actual = sh
+            .read_file(format!("/sys/class/dmi/id/{file}"))
+            .await
+            .with_context(|| format!("reading dmi id {file}"))?;
+        anyhow::ensure!(
+            actual.trim() == expected,
+            "dmi id {file}: expected {expected:?}, got {:?}",
+            actual.trim()
+        );
+    }
+
+    // `bios_release` is the SMBIOS Type 0 System BIOS Major/Minor Release,
+    // exposed by Linux as "MAJOR.MINOR".
+    let bios_release = sh
+        .read_file("/sys/class/dmi/id/bios_release")
+        .await
+        .context("reading dmi id bios_release")?;
+    let want = format!("{SMBIOS_BIOS_RELEASE_MAJOR}.{SMBIOS_BIOS_RELEASE_MINOR}");
+    anyhow::ensure!(
+        bios_release.trim() == want,
+        "dmi id bios_release: expected {want:?}, got {:?}",
+        bios_release.trim()
+    );
+
+    Ok(())
 }
 
 async fn validate_pcie_config(agent: &pipette_client::PipetteClient) -> anyhow::Result<()> {


### PR DESCRIPTION
OpenVMM previously reported a fixed, hard-coded SMBIOS identity to guests, with no way to customize what appears under /sys/class/dmi/id/. The PCAT path in particular shipped obviously bogus placeholder serial numbers and GUID. This adds the ability to present a chosen vendor, product, UUID, and related identity fields to the guest, exposed both through a new `--smbios` CLI option and through the ttrpc VM service so RPC callers can configure it at CreateVm time.

The CLI option follows QEMU's `-smbios type=N,key=value` syntax and key names so it is familiar and scriptable; the proto mirrors the same type=N grouping with an SMBIOSConfig message. Overrides apply across all three boot paths: Linux direct boot, UEFI, and PCAT. On UEFI and PCAT the firmware builds the tables, so only the fields the firmware can honor are accepted and any unsupported override is rejected with an error rather than silently ignored. Unset keys fall back to the loader's built-in default identity, and the system UUID defaults to the all-zero GUID (with `uuid=random` available to request a fresh per-VM GUID).

Identity is now sourced from a single VM BIOS GUID, so a guest reports the same product_uuid whether booted via UEFI or direct boot. The shared configuration types live in a new `smbios_defs` crate so that both the OpenVMM configuration and the Guest Emulation Transport reference one representation instead of near-duplicate definitions, and the same overrides flow through OpenHCL's GET/GED path to its direct-boot loader.

Guide docs and vmm/ttrpc tests are updated to cover the new option.