### PR TITLE
1.8: sidecar: Add a spin lock around serial output (#3928)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7524,6 +7524,7 @@ dependencies = [
  "minimal_rt",
  "minimal_rt_build",
  "sidecar_defs",
+ "spin",
  "x86defs",
  "zerocopy",
 ]

--- a/openhcl/minimal_rt/src/arch/x86_64/serial.rs
+++ b/openhcl/minimal_rt/src/arch/x86_64/serial.rs
@@ -94,7 +94,7 @@ impl<T: IoAccess> Serial<T> {
     }
 
     /// Create an instance without calling init.
-    pub fn new(io: T) -> Self {
+    pub const fn new(io: T) -> Self {
         Self { io }
     }
 

--- a/openhcl/sidecar/Cargo.toml
+++ b/openhcl/sidecar/Cargo.toml
@@ -19,6 +19,7 @@ minimal_rt.workspace = true
 hvdef.workspace = true
 memory_range.workspace = true
 sidecar_defs.workspace = true
+spin.workspace = true
 x86defs.workspace = true
 
 arrayvec.workspace = true

--- a/openhcl/sidecar/src/arch/x86_64/mod.rs
+++ b/openhcl/sidecar/src/arch/x86_64/mod.rs
@@ -170,6 +170,7 @@ static mut VSM_CAPABILITIES: hvdef::HvRegisterVsmCapabilities =
     hvdef::HvRegisterVsmCapabilities::new();
 static AFTER_INIT: AtomicBool = AtomicBool::new(false);
 static ENABLE_LOG: AtomicBool = AtomicBool::new(false);
+static SERIAL: spin::Mutex<Serial<InstrIoAccess>> = spin::Mutex::new(Serial::new(InstrIoAccess));
 
 macro_rules! log {
     () => {};
@@ -188,13 +189,14 @@ use minimal_rt::arch::InstrIoAccess;
 
 fn log_fmt(args: core::fmt::Arguments<'_>) {
     if ENABLE_LOG.load(Acquire) {
+        let mut serial = SERIAL.lock();
         if AFTER_INIT.load(Acquire) {
             // SAFETY: `hv_vp_index` is not being concurrently modified.
             // TODO: improve how per-VP globals work.
             let vp_index = unsafe { &*addr_space::globals() }.hv_vp_index;
-            let _ = writeln!(Serial::new(InstrIoAccess), "sidecar#{vp_index}: {}", args);
+            let _ = writeln!(serial, "sidecar#{vp_index}: {}", args);
         } else {
-            let _ = writeln!(Serial::new(InstrIoAccess), "sidecar: {}", args);
+            let _ = writeln!(serial, "sidecar: {}", args);
         }
     }
 }
@@ -209,7 +211,13 @@ fn panic(panic: &core::panic::PanicInfo<'_>) -> ! {
     };
     minimal_rt::enlightened_panic::report(*b"SIDECARK", panic, stack_va_to_pa);
     if !AFTER_INIT.load(Acquire) {
-        let _ = writeln!(Serial::new(InstrIoAccess), "{panic}");
+        if let Some(mut serial) = SERIAL.try_lock() {
+            let _ = writeln!(serial, "{panic}");
+        } else {
+            // We may have panicked while holding the lock, so trying to acquire it may deadlock.
+            // Best effort, we can't guarantee no tearing but print the message anyways.
+            let _ = writeln!(Serial::new(InstrIoAccess), "{panic}");
+        }
     }
     minimal_rt::arch::fault();
 }
@@ -312,7 +320,6 @@ fn eoi() {
 #[cfg_attr(not(minimal_rt), expect(dead_code))]
 extern "C" fn irq_handler() {
     eoi();
-    log!("irq");
 }
 
 #[cfg_attr(not(minimal_rt), expect(dead_code))]


### PR DESCRIPTION
Backport of #3928 to `release/1.8.2607`.

The cherry-pick of d503c2996d30 applied cleanly onto `release/1.8.2607` with no conflicts and no manual edits.

Original PR: #3928

---
*This backport PR was created by an AI agent (GitHub Copilot) on behalf of @smalis-msft.*