### PR TITLE
1.8: pipette: Windows shutdown improvements (#3930)

### DIFF
--- a/petri/pipette/src/agent.rs
+++ b/petri/pipette/src/agent.rs
@@ -223,11 +223,14 @@ async fn handle_request(
                         #[cfg(not(windows))]
                         timer.sleep(Duration::from_millis(250)).await;
                         loop {
-                            if let Err(err) = crate::shutdown::handle_shutdown(request) {
-                                tracing::error!(
-                                    error = err.as_ref() as &dyn std::error::Error,
-                                    "failed to shut down"
-                                );
+                            match crate::shutdown::handle_shutdown(request) {
+                                Ok(()) => break,
+                                Err(err) => {
+                                    tracing::error!(
+                                        error = err.as_ref() as &dyn std::error::Error,
+                                        "failed to shut down"
+                                    );
+                                }
                             }
                             timer.sleep(Duration::from_secs(5)).await;
                             tracing::warn!("still waiting to shut down, trying again");

--- a/petri/pipette/src/winsvc.rs
+++ b/petri/pipette/src/winsvc.rs
@@ -58,7 +58,7 @@ async fn service_main_inner(
     let mut send = Some(send);
     let event_handler = move |control_event| match control_event {
         service::ServiceControl::Interrogate => ServiceControlHandlerResult::NoError,
-        service::ServiceControl::Stop => {
+        service::ServiceControl::Stop | service::ServiceControl::Shutdown => {
             let _ = send.take();
             ServiceControlHandlerResult::NoError
         }
@@ -71,7 +71,8 @@ async fn service_main_inner(
             .set_service_status(service::ServiceStatus {
                 service_type: service::ServiceType::OWN_PROCESS,
                 current_state,
-                controls_accepted: service::ServiceControlAccept::STOP,
+                controls_accepted: service::ServiceControlAccept::STOP
+                    | service::ServiceControlAccept::SHUTDOWN,
                 exit_code: service::ServiceExitCode::Win32(0),
                 checkpoint: 0,
                 wait_hint: Duration::ZERO,
@@ -104,7 +105,8 @@ async fn service_main_inner(
         .set_service_status(service::ServiceStatus {
             service_type: service::ServiceType::OWN_PROCESS,
             current_state: service::ServiceState::Stopped,
-            controls_accepted: service::ServiceControlAccept::STOP,
+            controls_accepted: service::ServiceControlAccept::STOP
+                | service::ServiceControlAccept::SHUTDOWN,
             exit_code: service::ServiceExitCode::Win32(exit_code),
             checkpoint: 0,
             wait_hint: Duration::ZERO,


### PR DESCRIPTION
Backport of #3930 to `release/1.8.2607`.

The cherry-pick of d5c8cb543c41 applied cleanly onto `release/1.8.2607` with no conflicts and no manual edits.

Original PR: #3930

---
*This backport PR was created by an AI agent (GitHub Copilot) on behalf of @smalis-msft.*