### PR TITLE
1.8: kmsg: Extra validation on usecs (#3931)

### DIFF
--- a/support/kmsg/src/lib.rs
+++ b/support/kmsg/src/lib.rs
@@ -185,7 +185,12 @@ impl<'a> SyslogParsedEntry<'a> {
         let s = s.strip_prefix('[')?;
         let (secs, s) = s.trim_start().split_once('.')?;
         let (usecs, s) = s.split_once(']')?;
-        let time = Duration::new(secs.parse().ok()?, usecs.parse::<u32>().ok()? * 1000);
+        let secs = secs.parse().ok()?;
+        let usecs = usecs.parse::<u32>().ok()?;
+        if usecs >= 1_000_000 {
+            return None;
+        }
+        let time = Duration::new(secs, usecs * 1000);
 
         Some(SyslogParsedEntry {
             _facility: facility,


### PR DESCRIPTION
Backport of #3931 to `release/1.8.2607`.

The cherry-pick of 9e9c1a7df0b1 applied cleanly onto `release/1.8.2607` with no conflicts and no manual edits.

Original PR: #3931

---
*This backport PR was created by an AI agent (GitHub Copilot) on behalf of @smalis-msft.*