### PR TITLE
1.8: virt_whp: Add orderings to scan_irr to fix stuck interrupts (#3945)

### DIFF
--- a/vmm_core/virt_whp/src/apic.rs
+++ b/vmm_core/virt_whp/src/apic.rs
@@ -416,7 +416,9 @@ impl WhpProcessor<'_> {
                 break;
             }
 
-            let scan_irr = self.vplc(vtl).scan_irr.swap(false, Ordering::Relaxed);
+            // Pair with `wake_for_apic` so the IRR staged before its release
+            // publication is visible before scanning.
+            let scan_irr = self.vplc(vtl).scan_irr.swap(false, Ordering::Acquire);
             let vtl_state = &mut self.state.vtls[vtl];
             if let Some(lapic) = &mut vtl_state.lapic {
                 let work = lapic.apic.scan(&mut self.state.vmtime, scan_irr);

--- a/vmm_core/virt_whp/src/lib.rs
+++ b/vmm_core/virt_whp/src/lib.rs
@@ -478,7 +478,10 @@ impl<'a> WhpVpRef<'a> {
 
     #[cfg(guest_arch = "x86_64")]
     fn wake_for_apic(&self, vtl: Vtl) {
-        self.vplc(vtl).scan_irr.store(true, Ordering::Relaxed);
+        // Publish the staged IRR before the wake. The APIC only wakes on the
+        // first transition to pending, so missing this publication can strand
+        // an interrupt with no later wake to rescan it.
+        self.vplc(vtl).scan_irr.store(true, Ordering::Release);
         self.wake();
     }
 


### PR DESCRIPTION
Backport of #3945 to `release/1.8.2607`.

The cherry-pick of 5f02833a44d0 applied cleanly onto `release/1.8.2607` with no conflicts and no manual edits.

Original PR: #3945

---
*This backport PR was created by an AI agent (GitHub Copilot) on behalf of @smalis-msft.*