### PR TITLE
1.8: flowey: Fail with a non-zero exit code when local vmm test runs fail (#3956)

### DIFF
--- a/flowey/flowey_lib_hvlite/src/_jobs/local_build_and_run_nextest_vmm_tests.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/local_build_and_run_nextest_vmm_tests.rs
@@ -989,7 +989,7 @@ impl SimpleFlowNode for Node {
                 if results.all_tests_passed {
                     log::info!("all tests passed!");
                 } else {
-                    log::error!("encountered test failures.");
+                    anyhow::bail!("encountered test failures.")
                 }
 
                 Ok(())


### PR DESCRIPTION
Backport of #3956 to `release/1.8.2607`.

The cherry-pick of 5e8dfd10a54b applied cleanly onto `release/1.8.2607` with no conflicts and no manual edits.

Original PR: #3956

---
*This backport PR was created by an AI agent (GitHub Copilot) on behalf of @smalis-msft.*