### PR TITLE
1.8: virt_whp: Fix missed ApicState in reset (#3984)

### DIFF
--- a/vmm_core/virt_whp/src/apic.rs
+++ b/vmm_core/virt_whp/src/apic.rs
@@ -738,7 +738,13 @@ impl ApicState {
 
 impl ApicState {
     pub fn reset(&mut self, is_bsp: bool) {
-        self.apic.reset();
-        self.startup_suspend = !is_bsp;
+        let Self {
+            apic,
+            startup_suspend,
+            nmi_pending,
+        } = self;
+        apic.reset();
+        *startup_suspend = !is_bsp;
+        *nmi_pending = false;
     }
 }


### PR DESCRIPTION
Backport of #3984 to `release/1.8.2607`.

The cherry-pick of 062f1e48c542 applied cleanly onto `release/1.8.2607` with no conflicts and no manual edits.

Original PR: #3984

---
*This backport PR was created by an AI agent (GitHub Copilot) on behalf of @smalis-msft.*