### PR TITLE
1.8: virt_kvm: Set flags to accept values in set_activity (#4014)

### DIFF
--- a/vmm_core/virt_kvm/src/arch/x86_64/vp_state.rs
+++ b/vmm_core/virt_kvm/src/arch/x86_64/vp_state.rs
@@ -309,7 +309,16 @@ impl AccessVpState for KvmVpStateAccess<'_, '_> {
     }
 
     fn set_activity(&mut self, value: &vp::Activity) -> Result<(), Self::Error> {
-        let state = match value.mp_state {
+        let vp::Activity {
+            mp_state,
+            nmi_pending,
+            nmi_masked,
+            interrupt_shadow,
+            pending_event,
+            pending_interruption,
+        } = *value;
+
+        let state = match mp_state {
             vp::MpState::Running => kvm::KVM_MP_STATE_RUNNABLE,
             vp::MpState::WaitForSipi => kvm::KVM_MP_STATE_INIT_RECEIVED,
             vp::MpState::Halted => kvm::KVM_MP_STATE_HALTED,
@@ -318,6 +327,14 @@ impl AccessVpState for KvmVpStateAccess<'_, '_> {
             }
         };
         self.kvm().set_mp_state(state)?;
+
+        let mut event_flags = 0;
+        if nmi_pending {
+            event_flags |= kvm::KVM_VCPUEVENT_VALID_NMI_PENDING;
+        }
+        if interrupt_shadow {
+            event_flags |= kvm::KVM_VCPUEVENT_VALID_SHADOW;
+        }
 
         let mut events = kvm::kvm_vcpu_events {
             exception: kvm::kvm_vcpu_events__bindgen_ty_1 {
@@ -331,22 +348,22 @@ impl AccessVpState for KvmVpStateAccess<'_, '_> {
                 injected: 0,
                 nr: 0,
                 soft: 0,
-                shadow: value.interrupt_shadow.into(),
+                shadow: interrupt_shadow.into(),
             },
             nmi: kvm::kvm_vcpu_events__bindgen_ty_3 {
                 injected: 0,
-                pending: value.nmi_pending.into(),
-                masked: value.nmi_masked.into(),
+                pending: nmi_pending.into(),
+                masked: nmi_masked.into(),
                 pad: 0,
             },
             sipi_vector: 0,
-            flags: 0,
+            flags: event_flags,
             exception_has_payload: 0,
             exception_payload: 0,
             ..Default::default()
         };
 
-        match value.pending_event {
+        match pending_event {
             Some(vp::PendingEvent::Exception {
                 vector,
                 error_code,
@@ -367,7 +384,7 @@ impl AccessVpState for KvmVpStateAccess<'_, '_> {
             None => {}
         }
 
-        match value.pending_interruption {
+        match pending_interruption {
             Some(vp::PendingInterruption::Exception { vector, error_code }) => {
                 events.exception.injected = true.into();
                 events.exception.nr = vector;


### PR DESCRIPTION
Backport of #4014 to `release/1.8.2607`.

The cherry-pick of b08a7c84e425 applied cleanly onto `release/1.8.2607` with no conflicts and no manual edits.

Original PR: #4014

---
*This backport PR was created by an AI agent (GitHub Copilot) on behalf of @smalis-msft.*