### PR TITLE
1.8: virt_kvm: Fix synic message delivery check (#4016)

### DIFF
--- a/vmm_core/virt_kvm/src/arch/x86_64/mod.rs
+++ b/vmm_core/virt_kvm/src/arch/x86_64/mod.rs
@@ -905,7 +905,7 @@ impl KvmProcessor<'_> {
 
     /// Tries to deliver any pending synic messages for a VP.
     fn try_deliver_synic_messages(&mut self) -> Option<VmTime> {
-        if !self.scontrol.enabled() && self.simp.enabled() {
+        if !(self.scontrol.enabled() && self.simp.enabled()) {
             return None;
         }
         self.inner


### PR DESCRIPTION
Backport of #4016 to `release/1.8.2607`.

The cherry-pick of 6babb9c578ba applied cleanly onto `release/1.8.2607` with no conflicts and no manual edits.

Original PR: #4016

---
*This backport PR was created by an AI agent (GitHub Copilot) on behalf of @smalis-msft.*