### PR TITLE
1.8: nvme: Quiet some noisy logs during vmm tests (#4070)

### DIFF
--- a/vm/devices/storage/nvme/src/workers/admin.rs
+++ b/vm/devices/storage/nvme/src/workers/admin.rs
@@ -521,7 +521,7 @@ impl AdminHandler {
                 let command = command?;
                 let opcode = spec::AdminOpcode(command.cdw0.opcode());
 
-                tracing::debug!(?opcode, ?command, "command");
+                tracing::trace!(?opcode, ?command, "command");
 
                 let result = match opcode {
                     spec::AdminOpcode::IDENTIFY => self
@@ -654,7 +654,7 @@ impl AdminHandler {
                 } else {
                     // Valid but inactive namespace: return a zero-filled
                     // structure (the buffer is already zeroed).
-                    tracing::debug!(nsid = command.nsid, "inactive namespace id");
+                    tracing::trace!(nsid = command.nsid, "inactive namespace id");
                 }
             }
             spec::Cns::DESCRIPTOR_NAMESPACE => {
@@ -666,7 +666,7 @@ impl AdminHandler {
                 } else {
                     // Valid but inactive namespace: return a zero-filled
                     // structure (the buffer is already zeroed).
-                    tracing::debug!(nsid = command.nsid, "inactive namespace id");
+                    tracing::trace!(nsid = command.nsid, "inactive namespace id");
                 }
             }
             spec::Cns::SPECIFIC_CONTROLLER_IO_COMMAND_SET => {

--- a/vm/devices/storage/nvme_test/src/workers/admin.rs
+++ b/vm/devices/storage/nvme_test/src/workers/admin.rs
@@ -847,7 +847,7 @@ impl AdminHandler {
                 } else {
                     // Valid but inactive namespace: return a zero-filled
                     // structure (the buffer is already zeroed).
-                    tracing::debug!(nsid = command.nsid, "inactive namespace id");
+                    tracing::trace!(nsid = command.nsid, "inactive namespace id");
                 }
             }
             spec::Cns::DESCRIPTOR_NAMESPACE => {
@@ -859,7 +859,7 @@ impl AdminHandler {
                 } else {
                     // Valid but inactive namespace: return a zero-filled
                     // structure (the buffer is already zeroed).
-                    tracing::debug!(nsid = command.nsid, "inactive namespace id");
+                    tracing::trace!(nsid = command.nsid, "inactive namespace id");
                 }
             }
             spec::Cns::SPECIFIC_CONTROLLER_IO_COMMAND_SET => {


### PR DESCRIPTION
Backport of #4070 to `release/1.8.2607`.

The cherry-pick of 89a26b1423f6 applied cleanly onto `release/1.8.2607` with no conflicts and no manual edits.

Original PR: #4070

---
*This backport PR was created by an AI agent (GitHub Copilot) on behalf of @smalis-msft.*