### PR TITLE
1.8: soft_apic: Add some diagnostics (#4079)

### DIFF
--- a/vm/devices/pci/pci_core/src/capabilities/msix.rs
+++ b/vm/devices/pci/pci_core/src/capabilities/msix.rs
@@ -140,7 +140,9 @@ struct MsiInterruptInner {
     route: Option<MsiRoute>,
     pending: bool,
     enabled: bool,
+    #[inspect(hex)]
     address: u64,
+    #[inspect(hex)]
     data: u32,
 }
 
@@ -269,7 +271,10 @@ impl InspectMut for MsixMessageTableEntry {
             .hex("data", self.state.data)
             .hex("control", self.state.control)
             .field("enabled", self.state.control & 1 == 0)
-            .field("is_pending", self.check_is_pending(true));
+            .field("is_pending", self.check_is_pending(true))
+            // Delivery state, which can diverge from the table above (e.g. an
+            // interrupt latched while masked).
+            .field("msi", &self.msi);
     }
 }
 

--- a/vmm_core/virt/src/x86/apic_software_device.rs
+++ b/vmm_core/virt/src/x86/apic_software_device.rs
@@ -267,6 +267,14 @@ impl SignalMsi for ApicSoftwareDevice {
         if let Some(interrupt) = table.entries.get(index) {
             let target = interrupt.msi_params();
             self.target.signal_msi(None, target.address, target.data)
+        } else {
+            // A dropped MSI might leave the guest waiting forever for a device
+            // notification, so make it visible.
+            tracelimit::warn_ratelimited!(
+                address,
+                index,
+                "dropping MSI for unregistered interrupt"
+            );
         }
     }
 }


### PR DESCRIPTION
Backport of #4079 to `release/1.8.2607`.

The cherry-pick of 322aed5a2adc applied cleanly onto `release/1.8.2607` with no conflicts and no manual edits.

Original PR: #4079

---
*This backport PR was created by an AI agent (GitHub Copilot) on behalf of @smalis-msft.*