### PR TITLE
1.8: Repo: Audit powershell, use powershell_builder more (#4093)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1364,6 +1364,7 @@ dependencies = [
  "inspect_proto",
  "mesh_rpc",
  "pal_async",
+ "powershell_builder",
  "socket2",
  "thiserror 2.0.16",
  "unix_socket",
@@ -2273,6 +2274,7 @@ version = "0.0.0"
 dependencies = [
  "flowey",
  "home",
+ "powershell_builder",
  "rlimit",
  "roxmltree",
  "rustc-hash 2.1.1",
@@ -3649,6 +3651,7 @@ dependencies = [
  "mesh",
  "pal_async",
  "parking_lot",
+ "powershell_builder",
  "rustyline",
  "shell-words",
 ]

--- a/flowey/flowey_lib_common/Cargo.toml
+++ b/flowey/flowey_lib_common/Cargo.toml
@@ -10,6 +10,7 @@ rust-version.workspace = true
 flowey.workspace = true
 
 home.workspace = true
+powershell_builder.workspace = true
 roxmltree.workspace = true
 rustc-hash.workspace = true
 serde = { workspace = true, features = ["std"] }

--- a/flowey/flowey_lib_common/src/gen_cargo_nextest_run_cmd.rs
+++ b/flowey/flowey_lib_common/src/gen_cargo_nextest_run_cmd.rs
@@ -7,6 +7,7 @@ use crate::run_cargo_build::CargoBuildProfile;
 use crate::run_cargo_nextest_run::build_params;
 use flowey::node::prelude::*;
 use std::collections::BTreeMap;
+use std::ffi::OsStr;
 use std::ffi::OsString;
 
 flowey_request! {
@@ -484,40 +485,48 @@ impl RunKindDeps {
     }
 }
 
+impl CommandShell {
+    /// Quote a value as a literal for this shell. Single quotes suppress all
+    /// expansion, so `'` is the only character that needs escaping.
+    fn quote(&self, s: &OsStr) -> String {
+        match self {
+            CommandShell::Powershell => powershell_builder::quote_str(s)
+                .to_string_lossy()
+                .into_owned(),
+            CommandShell::Bash => format!("'{}'", s.to_string_lossy().replace('\'', r"'\''")),
+        }
+    }
+}
+
 impl std::fmt::Display for Script {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let quote_char = match self.shell {
-            CommandShell::Powershell => "\"",
-            CommandShell::Bash => "'",
-        };
-
         let env_string = match self.shell {
             CommandShell::Powershell => self
                 .env
                 .iter()
-                .map(|(k, v)| format!("$env:{k}=\"{v}\""))
+                .map(|(k, v)| format!("$env:{k}={}", self.shell.quote(OsStr::new(v))))
                 .collect::<Vec<_>>()
                 .join("\n"),
             CommandShell::Bash => self
                 .env
                 .iter()
-                .map(|(k, v)| format!("export {k}=\"{v}\""))
+                .map(|(k, v)| format!("export {k}={}", self.shell.quote(OsStr::new(v))))
                 .collect::<Vec<_>>()
                 .join("\n"),
         };
         writeln!(f, "{env_string}")?;
 
         for cmd in &self.commands {
-            let argv0_string = cmd.0.to_string_lossy();
+            let argv0_string = self.shell.quote(&cmd.0);
             let argv0_string = match self.shell {
-                CommandShell::Powershell => format!("&\"{argv0_string}\""),
-                CommandShell::Bash => format!("\"{argv0_string}\""),
+                CommandShell::Powershell => format!("&{argv0_string}"),
+                CommandShell::Bash => argv0_string,
             };
 
             let arg_string = {
                 cmd.1
                     .iter()
-                    .map(|v| format!("{quote_char}{}{quote_char}", v.to_string_lossy()))
+                    .map(|v| self.shell.quote(v))
                     .collect::<Vec<_>>()
                     .join(" ")
             };

--- a/flowey/flowey_lib_common/src/install_dotnet_cli.rs
+++ b/flowey/flowey_lib_common/src/install_dotnet_cli.rs
@@ -177,7 +177,7 @@ impl Node {
 
                                 flowey::shell_cmd!(
                                     rt,
-                                    "powershell -ExecutionPolicy Bypass -File {install_script_path}
+                                    "powershell -NoProfile -NonInteractive -ExecutionPolicy Bypass -File {install_script_path}
                                         -Channel {version}
                                         -InstallDir {install_dir}
                                         -NoPath

--- a/flowey/flowey_lib_common/src/install_git.rs
+++ b/flowey/flowey_lib_common/src/install_git.rs
@@ -79,7 +79,7 @@ impl FlowNodeWithConfig for Node {
                         },
                         FlowPlatform::Windows => {
                             if which::which("git.exe").is_err() {
-                                flowey::shell_cmd!(rt, "powershell.exe winget install --id Microsoft.Git --accept-source-agreements").run()?;
+                                flowey::shell_cmd!(rt, "powershell.exe -NoProfile -NonInteractive -Command winget install --id Microsoft.Git --accept-source-agreements").run()?;
                             }
 
                             rt.write(write_bin, &Some(crate::check_needs_relaunch::BinOrEnv::Bin("git".to_string())));

--- a/hyperv/tools/hypestv/Cargo.toml
+++ b/hyperv/tools/hypestv/Cargo.toml
@@ -15,6 +15,7 @@ inspect.workspace = true
 kmsg.workspace = true
 mesh.workspace = true
 pal_async.workspace = true
+powershell_builder.workspace = true
 
 anyhow.workspace = true
 clap = { workspace = true, features = ["wrap_help"] }

--- a/hyperv/tools/hypestv/src/windows/hyperv.rs
+++ b/hyperv/tools/hypestv/src/windows/hyperv.rs
@@ -4,6 +4,7 @@
 //! Functions for interacting with Hyper-V VMs.
 
 use anyhow::Context as _;
+use powershell_builder::PowerShellBuilder;
 
 /// Runs hcsdiag with the given arguments.
 pub fn run_hcsdiag(
@@ -37,23 +38,28 @@ pub fn hvc_output(
 ) -> anyhow::Result<String> {
     let mut cmd = std::process::Command::new("hvc.exe");
     f(&mut cmd);
-    let output = cmd.output().expect("failed to launch hvc");
+    let output = cmd.output().context("failed to launch hvc")?;
     if !output.status.success() {
         anyhow::bail!("hvc failed with exit code: {}", output.status);
     }
     String::from_utf8(output.stdout).context("output is not utf-8")
 }
 
+/// Runs a PowerShell script with the given arguments bound to its `param`
+/// block.
+///
+/// `script` is emitted verbatim and is therefore trusted; `args` are quoted
+/// and are not.
 pub fn powershell_script(script: &str, args: &[&str]) -> anyhow::Result<String> {
-    let mut cmd = std::process::Command::new("powershell.exe");
-    cmd.arg("-NoProfile")
-        .arg("-Command")
-        .arg(format!("&{{{script}}}"))
-        .args(
-            args.iter()
-                .map(|arg| format!("\"{}\"", arg.replace('`', "``").replace('"', "`\""))),
-        );
-    let output = cmd.output().expect("failed to launch powershell");
+    let mut cmdlet = PowerShellBuilder::new().cmdlet(format!("&{{{script}}}"));
+    for arg in args {
+        cmdlet = cmdlet.positional(arg);
+    }
+    let output = cmdlet
+        .finish()
+        .build()
+        .output()
+        .context("failed to launch powershell")?;
     if !output.status.success() {
         anyhow::bail!(
             "powershell failed:\n{}",

--- a/hyperv/tools/hypestv/src/windows/vm.rs
+++ b/hyperv/tools/hypestv/src/windows/vm.rs
@@ -213,7 +213,7 @@ impl Vm {
             VmCommand::Nmi { vtl } => {
                 powershell_script(
                     r#"
-                    param([string]$id, [int]$vtl)
+                    param([guid]$id, [int]$vtl)
                     $ErrorActionPreference = "Stop"
                     $vm = Get-CimInstance -namespace "root\virtualization\v2" -query "select * from Msvm_ComputerSystem where Name = '$id'"
                     $vm | Invoke-CimMethod -Name "InjectNonMaskableInterruptEx" -Arguments @{"Vtl" = $vtl}
@@ -316,7 +316,7 @@ impl Vm {
             ParavisorCommand::CommandLine { command_line: None } => {
                 let output = powershell_script(
                     r#"
-                    param([string]$id)
+                    param([guid]$id)
                     $ErrorActionPreference = "Stop"
                     $vm = Get-CimInstance -namespace "root\virtualization\v2" -query "select * from Msvm_ComputerSystem where Name = '$id'"
                     $vssd = $vm | Get-CimAssociatedInstance -ResultClass "Msvm_VirtualSystemSettingData" -Association "Msvm_SettingsDefineState"
@@ -332,7 +332,7 @@ impl Vm {
             } => {
                 let output = powershell_script(
                     r#"
-                    param([string]$id, [string]$command_line)
+                    param([guid]$id, [string]$command_line)
                     $ErrorActionPreference = "Stop"
                     $vm = Get-CimInstance -namespace "root\virtualization\v2" -query "select * from Msvm_ComputerSystem where Name = '$id'"
                     $vssd = $vm | Get-CimAssociatedInstance -ResultClass "Msvm_VirtualSystemSettingData" -Association "Msvm_SettingsDefineState"

--- a/openhcl/diag_client/Cargo.toml
+++ b/openhcl/diag_client/Cargo.toml
@@ -23,6 +23,7 @@ thiserror.workspace = true
 [target.'cfg(windows)'.dependencies]
 fs-err.workspace = true
 guid.workspace = true
+powershell_builder.workspace = true
 vmsocket.workspace = true
 windows-sys = { workspace = true, features = ["Win32_Networking_WinSock"] }
 

--- a/openhcl/diag_client/src/lib.rs
+++ b/openhcl/diag_client/src/lib.rs
@@ -38,6 +38,8 @@ pub mod hyperv {
     use pal_async::driver::Driver;
     use pal_async::socket::PolledSocket;
     use pal_async::timer::PolledTimer;
+    use powershell_builder::PowerShellBuilder;
+    use powershell_builder::RawVal;
     use std::fs::File;
     use std::io::Write;
     use std::process::Command;
@@ -112,21 +114,22 @@ pub mod hyperv {
     }
 
     fn query_vm_com_port(port: ComPortAccessInfo<'_>) -> anyhow::Result<String> {
-        let script = match port {
-            ComPortAccessInfo::NameAndPortNumber(vm, num) => {
-                format!(r#"$x = Get-VMComPort "{vm}" -Number {num} -ErrorAction Stop; $x.Path"#)
-            }
-            ComPortAccessInfo::IdAndPortNumber(id, num) => {
-                format!(
-                    r#"$x = Get-VMComPort -VMId "{id}" -Number {num} -ErrorAction Stop; $x.Path"#
-                )
-            }
+        let (vm_arg_name, vm_arg_value, num) = match port {
+            ComPortAccessInfo::NameAndPortNumber(vm, num) => ("VMName", vm.to_owned(), num),
+            ComPortAccessInfo::IdAndPortNumber(id, num) => ("VMId", id.to_string(), num),
             ComPortAccessInfo::PortPipePath(path) => return Ok(path.to_owned()),
         };
 
-        let output = Command::new("powershell.exe")
-            .arg("-NoProfile")
-            .arg(&script)
+        let output = PowerShellBuilder::new()
+            .cmdlet("Get-VMComPort")
+            .arg(vm_arg_name, vm_arg_value)
+            .arg("Number", num)
+            .arg("ErrorAction", RawVal::new("Stop"))
+            .pipeline()
+            .cmdlet("Select-Object")
+            .arg("ExpandProperty", "Path")
+            .finish()
+            .build()
             .output()
             .context("failed to query VM com port")?;
 

--- a/petri/src/vm/hyperv/powershell.rs
+++ b/petri/src/vm/hyperv/powershell.rs
@@ -674,14 +674,14 @@ pub async fn run_new_customvm(ps_mod: &Path, args: HyperVNewCustomVMArgs) -> any
                 },
             )| {
                 (
-                    format!("\"{vsid}\""),
+                    vsid,
                     ps::Value::new(ps::HashTable::new([
                         ("Vtl", ps::Value::new(target_vtl as u32)),
                         (
                             "Drives",
                             ps::Value::new(ps::HashTable::new(drives.into_iter().map(
                                 |(lun, HyperVDrive { disk, is_dvd })| {
-                                    (lun.to_string(), {
+                                    (lun, {
                                         let mut drive = vec![("Dvd", ps::Value::new(is_dvd))];
                                         if let Some(disk) = disk {
                                             drive.push(("DiskPath", ps::Value::new(disk)));
@@ -702,10 +702,10 @@ pub async fn run_new_customvm(ps_mod: &Path, args: HyperVNewCustomVMArgs) -> any
             ps::HashTable::new(args.ide_controllers.into_iter().map(
                 |(controller_number, drives)| {
                     (
-                        controller_number.to_string(),
+                        controller_number,
                         ps::Value::new(ps::HashTable::new(drives.into_iter().map(
                             |(lun, HyperVDrive { disk, is_dvd })| {
-                                (lun.to_string(), {
+                                (lun, {
                                     let mut drive = vec![("Dvd", ps::Value::new(is_dvd))];
                                     if let Some(disk) = disk {
                                         drive.push(("DiskPath", ps::Value::new(disk)));
@@ -747,7 +747,7 @@ pub async fn run_new_customvm(ps_mod: &Path, args: HyperVNewCustomVMArgs) -> any
                 actual
             );
             nvme_entries.push((
-                format!("\"{vsid}\""),
+                vsid,
                 ps::Value::new(ps::HashTable::new([
                     ("Vtl", ps::Value::new(target_vtl as u32)),
                     (
@@ -770,7 +770,7 @@ pub async fn run_new_customvm(ps_mod: &Path, args: HyperVNewCustomVMArgs) -> any
         Some(ps::HashTable::new(args.physical_nvme_devices.iter().map(
             |(vsid, dev)| {
                 (
-                    format!("\"{}\"", vsid),
+                    vsid,
                     ps::Value::new(ps::HashTable::new([
                         ("Vtl", ps::Value::new(dev.target_vtl as u32)),
                         ("Nsid", ps::Value::new(dev.nsid)),

--- a/petri/src/vm/hyperv/utilities.psm1
+++ b/petri/src/vm/hyperv/utilities.psm1
@@ -21,7 +21,7 @@ function Get-MsvmComputerSystem
         $Vm
     )
 
-    $vmid = $Vm.Id
+    $vmid = [guid]$Vm.Id
     $msvmComputerSystem = Get-CimInstance -namespace $ROOT_HYPER_V_NAMESPACE -query "select * from Msvm_ComputerSystem where Name = '$vmid'"
 
     if (-not $msvmComputerSystem)

--- a/support/powershell_builder/src/lib.rs
+++ b/support/powershell_builder/src/lib.rs
@@ -47,16 +47,21 @@ impl PowerShellBuilder {
     fn new_inner(program: &'static str) -> Self {
         PowerShellCmdletBuilder(Command::new(program))
             .flag("NoProfile")
+            .flag("NonInteractive")
             .flag("Command")
             .finish()
     }
 
     /// Start a new Cmdlet
+    ///
+    /// `cmdlet` is emitted verbatim and must be trusted input.
     pub fn cmdlet<S: AsRef<str>>(self, cmdlet: S) -> PowerShellCmdletBuilder {
         PowerShellCmdletBuilder(self.0).positional(RawVal::new(cmdlet.as_ref()))
     }
 
     /// Assign the output of the cmdlet to a variable
+    ///
+    /// `cmdlet` is emitted verbatim and must be trusted input.
     pub fn cmdlet_to_var<S: AsRef<str>>(
         self,
         cmdlet: S,
@@ -80,6 +85,8 @@ pub struct PowerShellCmdletBuilder(Command);
 
 impl PowerShellCmdletBuilder {
     /// Add a flag to the cmdlet
+    ///
+    /// `flag` is emitted verbatim and must be trusted input.
     pub fn flag<S: AsRef<OsStr>>(mut self, flag: S) -> Self {
         let mut arg = OsString::from("-");
         arg.push(flag);
@@ -112,6 +119,8 @@ impl PowerShellCmdletBuilder {
     }
 
     /// Add a named argument to the cmdlet
+    ///
+    /// `name` is emitted verbatim and must be trusted input; `value` is quoted.
     pub fn arg<S: AsRef<OsStr>, T: AsVal>(self, name: S, value: T) -> Self {
         self.flag(name).positional(value)
     }
@@ -171,13 +180,20 @@ impl<T: AsVal + ?Sized> AsVal for &T {
     }
 }
 
-/// wrap a string in quotes
+/// Quote a string as a PowerShell single-quoted string literal.
+///
+/// Single-quoted literals suppress all expansion (`$var`, `$(...)`, backtick
+/// escapes), so the only character that needs escaping is `'` itself, which is
+/// escaped by doubling it. Using double quotes here would allow any value
+/// containing `$(...)` to execute arbitrary PowerShell.
 pub fn quote_str(s: &OsStr) -> OsString {
-    let mut quoted = OsString::new();
-    quoted.push("\"");
-    // TODO: escape this properly.
-    quoted.push(s);
-    quoted.push("\"");
+    let mut quoted = OsString::from("'");
+    if let Some(s) = s.to_str() {
+        quoted.push(s.replace(r#"'"#, r#"''"#));
+    } else {
+        todo!("quote_str: non-UTF8 string {:?}", s);
+    }
+    quoted.push("'");
     quoted
 }
 
@@ -231,7 +247,10 @@ macro_rules! disp {
 
 disp!(u8, u16, u32, u64, i8, i16, i32, i64, f32, f64);
 
-/// A raw powershell value
+/// A raw, unquoted powershell value
+///
+/// The contents are emitted verbatim and are therefore trusted input. Never
+/// construct one from caller-supplied strings.
 pub struct RawVal<T>(T);
 
 impl<T: AsRef<OsStr>> RawVal<T> {
@@ -248,6 +267,8 @@ impl<T: AsRef<OsStr>> AsVal for RawVal<T> {
 }
 
 /// A powershell variable
+///
+/// The name is emitted verbatim and must be trusted input.
 pub struct Variable(String);
 
 impl Variable {
@@ -291,16 +312,19 @@ impl AsVal for Array {
 }
 
 /// A powershell hashtable
+///
+/// Keys are converted with [`AsVal`] just like values, so string keys are
+/// quoted and integer keys stay numeric.
 pub struct HashTable<K, V>(Vec<(K, V)>);
 
-impl<K: AsRef<str>, V: AsVal> HashTable<K, V> {
+impl<K: AsVal, V: AsVal> HashTable<K, V> {
     /// Create a new powershell hash table
     pub fn new(v: impl IntoIterator<Item = (K, V)>) -> Self {
         Self(v.into_iter().collect())
     }
 }
 
-impl<K: AsRef<str>, V: AsVal> AsVal for HashTable<K, V> {
+impl<K: AsVal, V: AsVal> AsVal for HashTable<K, V> {
     fn as_val(&self) -> impl '_ + AsRef<OsStr> {
         let mut args = OsString::new();
         args.push("@{");
@@ -309,7 +333,7 @@ impl<K: AsRef<str>, V: AsVal> AsVal for HashTable<K, V> {
             if !first {
                 args.push("; ");
             }
-            args.push(k.as_ref());
+            args.push(k.as_val());
             args.push("=");
             args.push(v.as_val());
             first = false;
@@ -319,7 +343,10 @@ impl<K: AsRef<str>, V: AsVal> AsVal for HashTable<K, V> {
     }
 }
 
-/// A powershell script
+/// A powershell script block
+///
+/// The contents are emitted verbatim and are therefore trusted input. Never
+/// construct one from caller-supplied strings.
 pub struct Script(String);
 
 impl Script {
@@ -332,5 +359,50 @@ impl Script {
 impl AsVal for Script {
     fn as_val(&self) -> impl '_ + AsRef<OsStr> {
         &self.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn val(v: impl AsVal) -> String {
+        v.as_val().as_ref().to_string_lossy().into_owned()
+    }
+
+    #[test]
+    fn quotes_are_literal() {
+        assert_eq!(val("hello"), "'hello'");
+        assert_eq!(val("with space"), "'with space'");
+        assert_eq!(val("it's"), "'it''s'");
+        assert_eq!(val(r"C:\path\to\file"), r"'C:\path\to\file'");
+    }
+
+    #[test]
+    fn no_expansion_or_escape() {
+        // `$`, `$(...)`, backticks and double quotes must all be inert.
+        assert_eq!(val("$(Get-Process)"), "'$(Get-Process)'");
+        assert_eq!(val("$env:PATH"), "'$env:PATH'");
+        assert_eq!(val("a`nb"), "'a`nb'");
+        assert_eq!(val(r#"a"b"#), r#"'a"b'"#);
+    }
+
+    #[test]
+    fn cannot_break_out_of_the_literal() {
+        assert_eq!(
+            val("x'; Remove-Item -Recurse C:\\; '"),
+            "'x''; Remove-Item -Recurse C:\\; '''"
+        );
+    }
+
+    #[test]
+    fn collections_quote_their_elements() {
+        assert_eq!(val(Array::new(["a'b", "c"])), "@('a''b'; 'c')");
+        assert_eq!(val(HashTable::new([("k", "v'w")])), "@{'k'='v''w'}");
+    }
+
+    #[test]
+    fn integer_hashtable_keys_stay_numeric() {
+        assert_eq!(val(HashTable::new([(0u32, "a")])), "@{0='a'}");
     }
 }


### PR DESCRIPTION
Backport of #4093 to `release/1.8.2607`.

The cherry-pick of 50f2923e3a32 applied cleanly onto `release/1.8.2607` with no conflicts and no manual edits.

Original PR: #4093

---
*This backport PR was created by an AI agent (GitHub Copilot) on behalf of @smalis-msft.*