### PR TITLE
loader/uefi: fix uefi enlightened snp cpuid page generation (#3965)

### DIFF
--- a/vm/loader/src/uefi/mod.rs
+++ b/vm/loader/src/uefi/mod.rs
@@ -849,7 +849,7 @@ pub mod x86_64 {
             .enumerate()
         {
             cpuid_page.cpuid_leaf_info[i].eax_in = required_leaf.eax;
-            cpuid_page.cpuid_leaf_info[i].eax_out = required_leaf.ecx;
+            cpuid_page.cpuid_leaf_info[i].ecx_in = required_leaf.ecx;
             cpuid_page.count += 1;
         }
 


### PR DESCRIPTION
Clean cherry pick of PR #3965

This seemed to have been a bug forever, but this configuration is not well tested. Now matches what we do for openhcl in paravisor.rs.
