### PR TITLE
openvmm: define the product version in the workspace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5625,7 +5625,7 @@ dependencies = [
 
 [[package]]
 name = "openvmm"
-version = "0.0.0"
+version = "0.1.0-dev"
 dependencies = [
  "crypto",
  "embed-resource",
@@ -5760,7 +5760,7 @@ dependencies = [
 
 [[package]]
 name = "openvmm_entry"
-version = "0.0.0"
+version = "0.1.0-dev"
 dependencies = [
  "anyhow",
  "build_rs_guest_arch",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5625,7 +5625,7 @@ dependencies = [
 
 [[package]]
 name = "openvmm"
-version = "0.1.0-dev"
+version = "0.1.0"
 dependencies = [
  "crypto",
  "embed-resource",
@@ -5760,7 +5760,7 @@ dependencies = [
 
 [[package]]
 name = "openvmm_entry"
-version = "0.1.0-dev"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "build_rs_guest_arch",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,14 @@ exclude = [
 [workspace.package]
 rust-version = "1.95"
 edition = "2024"
+# The canonical OpenVMM version, and the source of truth for the version a
+# release is cut at. Bump this, then tag; a release tag must match it.
+#
+# The `-dev` suffix marks a tree that is working towards the next release
+# rather than sitting at one, so a build from `main` cannot be mistaken for a
+# released binary. Releasing drops the suffix; the following commit restores it
+# on the next version.
+version = "0.1.0-dev"
 
 [workspace.dependencies]
 xtask_fuzz = { path = "xtask/xtask_fuzz" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,14 +69,9 @@ exclude = [
 [workspace.package]
 rust-version = "1.95"
 edition = "2024"
-# The canonical OpenVMM version, and the source of truth for the version a
-# release is cut at. Bump this, then tag; a release tag must match it.
-#
-# The `-dev` suffix marks a tree that is working towards the next release
-# rather than sitting at one, so a build from `main` cannot be mistaken for a
-# released binary. Releasing drops the suffix; the following commit restores it
-# on the next version.
-version = "0.1.0-dev"
+# The canonical OpenVMM version. It remains at the most recently released
+# version until a reviewed pull request selects the next release.
+version = "0.1.0"
 
 [workspace.dependencies]
 xtask_fuzz = { path = "xtask/xtask_fuzz" }

--- a/openvmm/openvmm/Cargo.toml
+++ b/openvmm/openvmm/Cargo.toml
@@ -3,6 +3,8 @@
 
 [package]
 name = "openvmm"
+version.workspace = true
+publish = false
 edition.workspace = true
 rust-version.workspace = true
 

--- a/openvmm/openvmm/build.rs
+++ b/openvmm/openvmm/build.rs
@@ -18,10 +18,21 @@ fn main() {
         println!("cargo:rerun-if-env-changed=OPENVMM_PATCH");
         println!("cargo:rerun-if-env-changed=OPENVMM_REVISION");
 
+        // Default to the crate version so that the version Windows reports in
+        // the file properties and the one `openvmm --version` prints cannot
+        // disagree. The `OPENVMM_*` vars still win, which is how a build
+        // pipeline stamps its own build number in. There is no crate
+        // equivalent of the fourth component, so it stays 0 unless set.
         let parse_u16 = |s: String| s.parse::<u16>().unwrap_or(0);
-        let major = std::env::var("OPENVMM_MAJOR").map(parse_u16).unwrap_or(0);
-        let minor = std::env::var("OPENVMM_MINOR").map(parse_u16).unwrap_or(0);
-        let patch = std::env::var("OPENVMM_PATCH").map(parse_u16).unwrap_or(0);
+        let component = |var: &str, from_crate_version: &str| {
+            std::env::var(var)
+                .or_else(|_| std::env::var(from_crate_version))
+                .map(parse_u16)
+                .unwrap_or(0)
+        };
+        let major = component("OPENVMM_MAJOR", "CARGO_PKG_VERSION_MAJOR");
+        let minor = component("OPENVMM_MINOR", "CARGO_PKG_VERSION_MINOR");
+        let patch = component("OPENVMM_PATCH", "CARGO_PKG_VERSION_PATCH");
         let revision = std::env::var("OPENVMM_REVISION")
             .map(parse_u16)
             .unwrap_or(0);

--- a/openvmm/openvmm_entry/Cargo.toml
+++ b/openvmm/openvmm_entry/Cargo.toml
@@ -3,6 +3,8 @@
 
 [package]
 name = "openvmm_entry"
+version.workspace = true
+publish = false
 edition.workspace = true
 rust-version.workspace = true
 

--- a/openvmm/openvmm_entry/src/cli_args.rs
+++ b/openvmm/openvmm_entry/src/cli_args.rs
@@ -138,11 +138,30 @@ pub struct NumaDistanceCli {
     pub distance: u8,
 }
 
+/// Version reported by `--version`.
+///
+/// `OPENVMM_PKGVERSION` lets whoever builds the binary stamp their own build
+/// identity in, the way QEMU's `-Dpkgversion` and cloud-hypervisor's
+/// `CH_EXTRA_VERSION` do. Distributions use this so a bug report names the
+/// build it came from and not just the upstream version. It is read at compile
+/// time, so a build that does not set it reports the plain crate version. An
+/// empty value is treated as unset, since build systems routinely pass through
+/// an undefined variable as `""` and reporting an empty version is worse than
+/// ignoring the override.
+const VERSION: &str = match option_env!("OPENVMM_PKGVERSION") {
+    Some(v) if !v.is_empty() => v,
+    _ => env!("CARGO_PKG_VERSION"),
+};
+
 /// OpenVMM virtual machine monitor.
 ///
 /// This is not yet a stable interface and may change radically between
 /// versions.
 #[derive(Parser)]
+// `name` is set explicitly because the version and help output otherwise
+// report `CARGO_PKG_NAME`, which is the crate holding this parser
+// (`openvmm_entry`) rather than the binary a user actually invoked.
+#[command(name = "openvmm", version = VERSION)]
 pub struct Options {
     /// processor count
     #[clap(short = 'p', long, value_name = "COUNT", default_value = "1")]
@@ -3391,6 +3410,19 @@ mod tests {
 
     use std::path::Path;
     use test_with_tracing::test;
+
+    /// `--version` is only meaningful if `openvmm_entry` actually carries a
+    /// version. Cargo silently defaults a crate with no `version` to `0.0.0`,
+    /// and the house-rules lint that normally *strips* `version` merely permits
+    /// one here -- it cannot require it. So if the `version.workspace = true`
+    /// line were dropped from Cargo.toml, every build would keep succeeding and
+    /// the binary would quietly report `0.0.0`. This is the only thing that
+    /// would notice.
+    #[test]
+    fn version_is_not_the_cargo_default() {
+        assert_ne!(env!("CARGO_PKG_VERSION"), "0.0.0");
+        assert!(!VERSION.is_empty());
+    }
 
     #[test]
     fn test_parse_rpc() {

--- a/vm/vmgs/vmgstool/Cargo.toml
+++ b/vm/vmgs/vmgstool/Cargo.toml
@@ -4,6 +4,7 @@
 [package]
 name = "vmgstool"
 version = "2.1.0"
+publish = false
 edition.workspace = true
 rust-version.workspace = true
 

--- a/xtask/src/tasks/fmt/lints/package_info.rs
+++ b/xtask/src/tasks/fmt/lints/package_info.rs
@@ -12,6 +12,11 @@
 //! from newcomers (does the version field mean anything? do we use it for
 //! semver internally?).
 //!
+//! The exceptions in [`VERSION_EXCEPTIONS`] are the crates where the version is
+//! *not* meaningless, because something outside the crate reads it. Those
+//! crates lose the publishing protection described above, so each one sets
+//! `publish = false` explicitly instead.
+//!
 //! The [authors][] field is optional, is not really used anywhere anymore, and
 //! just creates confusion.
 //!
@@ -27,8 +32,26 @@ use toml_edit::DocumentMut;
 use toml_edit::Item;
 use toml_edit::Table;
 
-/// List of packages that are allowed to have a version
-static VERSION_EXCEPTIONS: &[&str] = &["vmgstool"];
+/// List of packages that are allowed to have a version.
+///
+/// Each of these must also set `publish = false`, since carrying a version
+/// forfeits the implicit publishing protection described at the module level.
+///
+/// `vmgstool` publishes a versioned binary, and its release tag is built from
+/// the version in its manifest.
+///
+/// `openvmm` and `openvmm_entry` carry the workspace version because OpenVMM is
+/// released as a source archive that packagers build. The version has to travel
+/// inside the source, since a packager builds long after any pipeline that
+/// could have supplied it, and from a tree with no git history to recover it
+/// from. Both are read: `openvmm_entry` holds the command line parser, so its
+/// version is what `openvmm --version` reports, and `openvmm`'s build script
+/// stamps its version into the Windows VERSIONINFO resource.
+///
+/// If this list grows much past a handful, replace it with a
+/// `package.metadata.xtask.house-rules` opt-in, the way `excluded-from-workspace`
+/// below already works -- keeping the policy next to the crate it applies to.
+static VERSION_EXCEPTIONS: &[&str] = &["openvmm", "openvmm_entry", "vmgstool"];
 
 pub struct PackageInfo;
 


### PR DESCRIPTION
OpenVMM needs one product version that travels in the source tree, because the release artifact is source that another party builds later without Git history.

This change:

- defines the canonical version in `[workspace.package]`;
- has the `openvmm` and `openvmm_entry` crates inherit it;
- reports it through `openvmm --version` and Windows VERSIONINFO;
- retains the most recently released version until a reviewed PR selects the next release;
- preserves `OPENVMM_PKGVERSION` for builders that need to identify their own package;
- extends the house-rules lint to allow only the crates that intentionally carry versions.

This is the first independently reviewable change in the source-release series. It does not add Git probing, release automation, or archive assembly.
