### PR TITLE
virt_whp: Add a 1 second periodic unstick timer

### DIFF
--- a/vmm_core/virt_whp/src/apic.rs
+++ b/vmm_core/virt_whp/src/apic.rs
@@ -14,6 +14,7 @@ use crate::WhpPartitionInner;
 use crate::WhpProcessor;
 use crate::WhpResultExt;
 use crate::WhpVpRef;
+use hvdef::HvInternalActivityRegister;
 use hvdef::HvVtlEntryReason;
 use hvdef::HvX64PendingEventReg0;
 use hvdef::HvX64PendingInterruptionRegister;
@@ -34,6 +35,31 @@ use vmcore::vmtime::VmTimeAccess;
 use whp::get_registers;
 use whp::set_registers;
 use x86defs::RFlags;
+use x86defs::apic::Svr;
+
+/// Returns the highest set vector in an APIC bitmap register.
+fn top_vector(bits: &[u32; 8]) -> Option<u8> {
+    bits.iter()
+        .enumerate()
+        .rev()
+        .find_map(|(i, &v)| (v != 0).then(|| i as u8 * 32 + (31 - v.leading_zeros() as u8)))
+}
+
+/// Returns whether the APIC page has a request pending that outranks both the
+/// in-service and task priorities, i.e. one the hypervisor should inject as
+/// soon as the VP runs.
+fn apic_interrupt_ready(apic: &vp::ApicRegisters) -> bool {
+    if !Svr::from(apic.svr).enable() {
+        return false;
+    }
+    // Vectors below 16 are invalid, which also skips IRR bit 2, the
+    // hypervisor's non-architectural NMI-pending bit.
+    let Some(irr) = top_vector(&apic.irr).filter(|&v| v >= 16) else {
+        return false;
+    };
+    let isr = top_vector(&apic.isr).unwrap_or(0);
+    irr >> 4 > (isr >> 4).max((apic.tpr >> 4) as u8)
+}
 
 impl WhpPartitionInner {
     pub fn lint(&self, vp_index: VpIndex, vtl: Vtl, index: usize) {
@@ -447,6 +473,49 @@ impl WhpProcessor<'_> {
             .is_some_and(|lapic| self.state.halted || lapic.startup_suspend);
 
         !halted
+    }
+
+    /// TEMPORARY HACK WORKAROUND FOR HYPERVISOR BUG
+    /// Clears the hypervisor's halt state for `vtl` if its offloaded APIC has an
+    /// interrupt that should already have woken the VP.
+    pub(crate) fn unhalt_for_pending_interrupt(&mut self, vtl: Vtl) {
+        if self.state.vtls.lapic(vtl).is_some() {
+            // The VMM-emulated APIC injects pending interrupts itself.
+            return;
+        }
+
+        let whp = self.vp.whp(vtl);
+        let (activity, rflags) = get_registers!(
+            whp,
+            [
+                whp::Register64::InternalActivityState,
+                whp::Register64::Rflags
+            ]
+        )
+        .unwrap();
+
+        let activity = HvInternalActivityRegister::from(activity);
+        if activity.startup_suspend()
+            || !(activity.halt_suspend() || activity.idle_suspend())
+            || !RFlags::from(rflags).interrupt_enable()
+        {
+            return;
+        }
+
+        let apic = vp::ApicRegisters::from_page(&whp.get_apic().unwrap());
+        if !apic_interrupt_ready(&apic) {
+            return;
+        }
+
+        tracing::warn!(?vtl, "unhalting vp for pending apic interrupt");
+        whp.set_register(
+            whp::Register64::InternalActivityState,
+            activity
+                .with_halt_suspend(false)
+                .with_idle_suspend(false)
+                .into(),
+        )
+        .unwrap();
     }
 
     #[must_use]

--- a/vmm_core/virt_whp/src/apic.rs
+++ b/vmm_core/virt_whp/src/apic.rs
@@ -452,22 +452,82 @@ impl WhpProcessor<'_> {
     /// HACK: TEMPORARY HACK WORKAROUND FOR HYPERVISOR BUG
     ///
     /// The hypervisor can leave a VP halted with an interrupt pending in its
-    /// offloaded APIC and nothing left to wake it. Clearing and then setting
-    /// RFLAGS.IF forces the hypervisor to reevaluate interrupt delivery, which
-    /// unhalts the VP if an interrupt really is pending.
-    pub(crate) fn poke_interrupt_flag(&mut self, vtl: Vtl) {
+    /// offloaded APIC and nothing left to wake it: every path that reevaluates
+    /// the halt is gated on bookkeeping that is stale in this state, so the
+    /// vector sitting in the IRR is never noticed. Poking guest registers (e.g.
+    /// RFLAGS) does not help, since the rescan they trigger is gated on that
+    /// same stale bookkeeping.
+    ///
+    /// If the VP is halted with an interrupt that really should have been
+    /// delivered, reassert that vector. Asserting an interrupt unconditionally
+    /// generates work for the VP, and runs the same path a fresh interrupt
+    /// would, which reevaluates the halt. The IRR bit is already set, so this
+    /// does not deliver an extra interrupt to the guest.
+    pub(crate) fn unstick_halted_vp(&mut self, vtl: Vtl) {
         let whp = self.vp.whp(vtl);
-        let rflags = RFlags::from(whp.get_register(whp::Register64::Rflags).unwrap());
-        if !rflags.interrupt_enable() {
-            return;
-        }
-        whp.set_register(
-            whp::Register64::Rflags,
-            rflags.with_interrupt_enable(false).into(),
+        let (activity, rflags) = get_registers!(
+            whp,
+            [
+                whp::Register64::InternalActivityState,
+                whp::Register64::Rflags,
+            ]
         )
         .unwrap();
-        whp.set_register(whp::Register64::Rflags, rflags.into())
-            .unwrap();
+
+        // Only a halted VP can be stuck this way.
+        if !hvdef::HvInternalActivityRegister::from(activity).halt_suspend() {
+            return;
+        }
+
+        // A VP halted with interrupts disabled is meant to stay that way (e.g.
+        // an offlined CPU), so leave it alone.
+        if !RFlags::from(rflags).interrupt_enable() {
+            return;
+        }
+
+        // Find the highest priority pending interrupt. It is only deliverable
+        // if its priority class is above the processor priority, which also
+        // filters out the non-architectural NMI pending bit that the hypervisor
+        // keeps in IRR vector 2.
+        let apic = vp::ApicRegisters::from_page(&whp.get_apic().unwrap());
+        let Some(vector) =
+            apic.irr.iter().enumerate().rev().find_map(|(i, &word)| {
+                (word != 0).then(|| i as u32 * 32 + 31 - word.leading_zeros())
+            })
+        else {
+            return;
+        };
+        if vector >> 4 <= apic.ppr >> 4 {
+            return;
+        }
+
+        tracelimit::warn_ratelimited!(
+            vp = self.vp.index.index(),
+            ?vtl,
+            vector,
+            "hypervisor left vp halted with a deliverable interrupt, reasserting it"
+        );
+
+        // Match the trigger mode to the TMR bit so that reasserting does not
+        // change it.
+        let trigger = if apic.tmr[(vector / 32) as usize] & (1 << (vector % 32)) != 0 {
+            whp::abi::WHvX64InterruptTriggerModeLevel
+        } else {
+            whp::abi::WHvX64InterruptTriggerModeEdge
+        };
+        if let Err(err) = self.vp.partition.vtlp(vtl).whp.interrupt(
+            whp::abi::WHvX64InterruptTypeFixed,
+            whp::abi::WHvX64InterruptDestinationModePhysical,
+            trigger,
+            self.inner.vp_info.apic_id,
+            vector,
+        ) {
+            tracelimit::error_ratelimited!(
+                error = &err as &dyn std::error::Error,
+                vector,
+                "failed to reassert interrupt"
+            );
+        }
     }
 
     #[must_use]

--- a/vmm_core/virt_whp/src/apic.rs
+++ b/vmm_core/virt_whp/src/apic.rs
@@ -14,7 +14,6 @@ use crate::WhpPartitionInner;
 use crate::WhpProcessor;
 use crate::WhpResultExt;
 use crate::WhpVpRef;
-use hvdef::HvInternalActivityRegister;
 use hvdef::HvVtlEntryReason;
 use hvdef::HvX64PendingEventReg0;
 use hvdef::HvX64PendingInterruptionRegister;
@@ -35,31 +34,6 @@ use vmcore::vmtime::VmTimeAccess;
 use whp::get_registers;
 use whp::set_registers;
 use x86defs::RFlags;
-use x86defs::apic::Svr;
-
-/// Returns the highest set vector in an APIC bitmap register.
-fn top_vector(bits: &[u32; 8]) -> Option<u8> {
-    bits.iter()
-        .enumerate()
-        .rev()
-        .find_map(|(i, &v)| (v != 0).then(|| i as u8 * 32 + (31 - v.leading_zeros() as u8)))
-}
-
-/// Returns whether the APIC page has a request pending that outranks both the
-/// in-service and task priorities, i.e. one the hypervisor should inject as
-/// soon as the VP runs.
-fn apic_interrupt_ready(apic: &vp::ApicRegisters) -> bool {
-    if !Svr::from(apic.svr).enable() {
-        return false;
-    }
-    // Vectors below 16 are invalid, which also skips IRR bit 2, the
-    // hypervisor's non-architectural NMI-pending bit.
-    let Some(irr) = top_vector(&apic.irr).filter(|&v| v >= 16) else {
-        return false;
-    };
-    let isr = top_vector(&apic.isr).unwrap_or(0);
-    irr >> 4 > (isr >> 4).max((apic.tpr >> 4) as u8)
-}
 
 impl WhpPartitionInner {
     pub fn lint(&self, vp_index: VpIndex, vtl: Vtl, index: usize) {
@@ -477,62 +451,23 @@ impl WhpProcessor<'_> {
 
     /// HACK: TEMPORARY HACK WORKAROUND FOR HYPERVISOR BUG
     ///
-    /// Workaround for a hypervisor bug: clears the halt state for `vtl` if its
-    /// offloaded APIC has an interrupt that should already have woken the VP.
-    ///
-    /// The hypervisor's wake-from-halt is driven by the SynIC work summary, not
-    /// by the APIC IRR: `SynicpEvaluateWakeFromHalt` only unhalts if processing
-    /// the pending work summary produces a deliverable interrupt, and
-    /// `StdApicHandleHalt` only re-evaluates on `HLT` if the work summary is
-    /// non-empty or the hardware reports a pending virtual interrupt. So a
-    /// request that lands in the IRR while it is blocked by TPR/ISR, and whose
-    /// scan-IRR work bit is consumed at that point, leaves nothing to re-scan
-    /// once the guest lowers TPR and halts. The VP then sleeps forever with a
-    /// deliverable IRR bit set. (`inject_extint` forces the VP out of halt for
-    /// the same reason.)
-    ///
-    /// Clearing the halt bits is enough to recover: once the VP runs, the
-    /// hardware APIC delivers the pending request.
-
-    pub(crate) fn unhalt_for_pending_interrupt(&mut self, vtl: Vtl) {
-        if self.state.vtls.lapic(vtl).is_some() {
-            // The VMM-emulated APIC injects pending interrupts itself, and the
-            // hypervisor rejects this register for min-APIC partitions.
-            return;
-        }
-
+    /// The hypervisor can leave a VP halted with an interrupt pending in its
+    /// offloaded APIC and nothing left to wake it. Clearing and then setting
+    /// RFLAGS.IF forces the hypervisor to reevaluate interrupt delivery, which
+    /// unhalts the VP if an interrupt really is pending.
+    pub(crate) fn poke_interrupt_flag(&mut self, vtl: Vtl) {
         let whp = self.vp.whp(vtl);
-        let (activity, rflags) = get_registers!(
-            whp,
-            [
-                whp::Register64::InternalActivityState,
-                whp::Register64::Rflags
-            ]
-        )
-        .unwrap();
-
-        let activity = HvInternalActivityRegister::from(activity);
-        if activity.startup_suspend()
-            || !(activity.halt_suspend() || activity.idle_suspend())
-            || !RFlags::from(rflags).interrupt_enable()
-        {
+        let rflags = RFlags::from(whp.get_register(whp::Register64::Rflags).unwrap());
+        if !rflags.interrupt_enable() {
             return;
         }
-
-        let apic = vp::ApicRegisters::from_page(&whp.get_apic().unwrap());
-        if !apic_interrupt_ready(&apic) {
-            return;
-        }
-
-        tracing::warn!(?vtl, "unhalting vp for pending apic interrupt");
         whp.set_register(
-            whp::Register64::InternalActivityState,
-            activity
-                .with_halt_suspend(false)
-                .with_idle_suspend(false)
-                .into(),
+            whp::Register64::Rflags,
+            rflags.with_interrupt_enable(false).into(),
         )
         .unwrap();
+        whp.set_register(whp::Register64::Rflags, rflags.into())
+            .unwrap();
     }
 
     #[must_use]

--- a/vmm_core/virt_whp/src/apic.rs
+++ b/vmm_core/virt_whp/src/apic.rs
@@ -475,7 +475,7 @@ impl WhpProcessor<'_> {
         !halted
     }
 
-    /// TEMPORARY HACK WORKAROUND FOR HYPERVISOR BUG
+    /// HACK: TEMPORARY HACK WORKAROUND FOR HYPERVISOR BUG
     /// Clears the hypervisor's halt state for `vtl` if its offloaded APIC has an
     /// interrupt that should already have woken the VP.
     pub(crate) fn unhalt_for_pending_interrupt(&mut self, vtl: Vtl) {

--- a/vmm_core/virt_whp/src/apic.rs
+++ b/vmm_core/virt_whp/src/apic.rs
@@ -476,11 +476,28 @@ impl WhpProcessor<'_> {
     }
 
     /// HACK: TEMPORARY HACK WORKAROUND FOR HYPERVISOR BUG
-    /// Clears the hypervisor's halt state for `vtl` if its offloaded APIC has an
-    /// interrupt that should already have woken the VP.
+    ///
+    /// Workaround for a hypervisor bug: clears the halt state for `vtl` if its
+    /// offloaded APIC has an interrupt that should already have woken the VP.
+    ///
+    /// The hypervisor's wake-from-halt is driven by the SynIC work summary, not
+    /// by the APIC IRR: `SynicpEvaluateWakeFromHalt` only unhalts if processing
+    /// the pending work summary produces a deliverable interrupt, and
+    /// `StdApicHandleHalt` only re-evaluates on `HLT` if the work summary is
+    /// non-empty or the hardware reports a pending virtual interrupt. So a
+    /// request that lands in the IRR while it is blocked by TPR/ISR, and whose
+    /// scan-IRR work bit is consumed at that point, leaves nothing to re-scan
+    /// once the guest lowers TPR and halts. The VP then sleeps forever with a
+    /// deliverable IRR bit set. (`inject_extint` forces the VP out of halt for
+    /// the same reason.)
+    ///
+    /// Clearing the halt bits is enough to recover: once the VP runs, the
+    /// hardware APIC delivers the pending request.
+
     pub(crate) fn unhalt_for_pending_interrupt(&mut self, vtl: Vtl) {
         if self.state.vtls.lapic(vtl).is_some() {
-            // The VMM-emulated APIC injects pending interrupts itself.
+            // The VMM-emulated APIC injects pending interrupts itself, and the
+            // hypervisor rejects this register for min-APIC partitions.
             return;
         }
 

--- a/vmm_core/virt_whp/src/lib.rs
+++ b/vmm_core/virt_whp/src/lib.rs
@@ -229,6 +229,7 @@ struct RunState {
     vtls: RunStateVtls,
     #[inspect(mut)]
     halted: bool,
+    unhalt_check_vmtime: Option<VmTimeAccess>,
     exits: vp::ExitStats,
     vmtime: VmTimeAccess,
 }
@@ -325,6 +326,7 @@ impl RunState {
             ref mut crash_msg_len,
             ref mut vtls,
             ref mut halted,
+            unhalt_check_vmtime: _,
             exits: _,
             vtl2_wakeup_vmtime: _,
             vmtime: _,
@@ -1035,6 +1037,12 @@ impl ProtoPartition for WhpProtoPartition<'_> {
                         .vmtime
                         .access(format!("vtl2-wakeup-{}", vp.index.index()))
                 });
+                let unhalt_check_vmtime =
+                    matches!(partition.inner.vtl0.lapic, LocalApicKind::Offloaded).then(|| {
+                        self.config
+                            .vmtime
+                            .access(format!("apic-unhalt-{}", vp.index.index()))
+                    });
                 WhpProcessorBinder {
                     partition: partition.inner.clone(),
                     index: vp.index,
@@ -1046,6 +1054,7 @@ impl ProtoPartition for WhpProtoPartition<'_> {
                         crash_msg_address: None,
                         crash_msg_len: None,
                         halted: false,
+                        unhalt_check_vmtime,
                         vtls: RunStateVtls {
                             vtl0: PerVtlRunState::new(
                                 &partition.inner.vtl0.lapic,

--- a/vmm_core/virt_whp/src/lib.rs
+++ b/vmm_core/virt_whp/src/lib.rs
@@ -1037,12 +1037,13 @@ impl ProtoPartition for WhpProtoPartition<'_> {
                         .vmtime
                         .access(format!("vtl2-wakeup-{}", vp.index.index()))
                 });
-                let unhalt_check_vmtime =
-                    matches!(partition.inner.vtl0.lapic, LocalApicKind::Offloaded).then(|| {
-                        self.config
-                            .vmtime
-                            .access(format!("apic-unhalt-{}", vp.index.index()))
-                    });
+                let unhalt_check_vmtime = (cfg!(guest_arch = "x86_64")
+                    && matches!(partition.inner.vtl0.lapic, LocalApicKind::Offloaded))
+                .then(|| {
+                    self.config
+                        .vmtime
+                        .access(format!("apic-unhalt-{}", vp.index.index()))
+                });
                 WhpProcessorBinder {
                     partition: partition.inner.clone(),
                     index: vp.index,

--- a/vmm_core/virt_whp/src/vp.rs
+++ b/vmm_core/virt_whp/src/vp.rs
@@ -339,7 +339,8 @@ impl<'a> WhpProcessor<'a> {
                 // HACK: TEMPORARY HACK WORKAROUND FOR HYPERVISOR BUG
                 // The hypervisor can leave a VP halted with an interrupt
                 // pending in its offloaded APIC, with nothing left to wake it,
-                // so periodically poke RFLAGS.IF to force a reevaluation.
+                // so periodically check for that state and force the VP out of
+                // it.
                 #[cfg(guest_arch = "x86_64")]
                 {
                     const UNHALT_CHECK_PERIOD: std::time::Duration =
@@ -350,10 +351,20 @@ impl<'a> WhpProcessor<'a> {
                         .unhalt_check_vmtime
                         .as_mut()
                         .is_some_and(|vmtime| {
-                            vmtime.set_timeout_if_before(
-                                vmtime.now().wrapping_add(UNHALT_CHECK_PERIOD),
-                            );
-                            vmtime.poll_timeout(cx).is_ready()
+                            // Rearm in a loop: polling clears the timeout when
+                            // it fires, and the VP may block in the hypervisor
+                            // indefinitely before this runs again, leaving
+                            // nothing to wake it.
+                            let mut expired = false;
+                            loop {
+                                vmtime.set_timeout_if_before(
+                                    vmtime.now().wrapping_add(UNHALT_CHECK_PERIOD),
+                                );
+                                if vmtime.poll_timeout(cx).is_pending() {
+                                    break expired;
+                                }
+                                expired = true;
+                            }
                         });
 
                     if expired {
@@ -362,7 +373,7 @@ impl<'a> WhpProcessor<'a> {
                             .runnable_vtls
                             .highest_set()
                             .expect("no runnable vtls");
-                        self.poke_interrupt_flag(vtl);
+                        self.unstick_halted_vp(vtl);
                     }
                 }
 

--- a/vmm_core/virt_whp/src/vp.rs
+++ b/vmm_core/virt_whp/src/vp.rs
@@ -336,7 +336,7 @@ impl<'a> WhpProcessor<'a> {
                 // Process the user-mode APIC, waiting for interrupts if halted.
                 let ready = self.process_apic(dev);
 
-                // TEMPORARY HACK WORKAROUND FOR HYPERVISOR BUG
+                // HACK: TEMPORARY HACK WORKAROUND FOR HYPERVISOR BUG
                 // The hypervisor can leave a VP halted with an interrupt
                 // pending in its offloaded APIC, with nothing left to wake it,
                 // so poll for that case periodically.
@@ -356,8 +356,9 @@ impl<'a> WhpProcessor<'a> {
                         });
 
                     if expired {
-                        let vtl = self.state.runnable_vtls.highest_set().unwrap();
-                        self.unhalt_for_pending_interrupt(vtl);
+                        let _vtl = self.state.runnable_vtls.highest_set().unwrap();
+                        #[cfg(guest_arch = "x86_64")]
+                        self.unhalt_for_pending_interrupt(_vtl);
                     }
                 }
 

--- a/vmm_core/virt_whp/src/vp.rs
+++ b/vmm_core/virt_whp/src/vp.rs
@@ -336,6 +336,31 @@ impl<'a> WhpProcessor<'a> {
                 // Process the user-mode APIC, waiting for interrupts if halted.
                 let ready = self.process_apic(dev);
 
+                // TEMPORARY HACK WORKAROUND FOR HYPERVISOR BUG
+                // The hypervisor can leave a VP halted with an interrupt
+                // pending in its offloaded APIC, with nothing left to wake it,
+                // so poll for that case periodically.
+                {
+                    const UNHALT_CHECK_PERIOD: std::time::Duration =
+                        std::time::Duration::from_secs(1);
+
+                    let expired = self
+                        .state
+                        .unhalt_check_vmtime
+                        .as_mut()
+                        .is_some_and(|vmtime| {
+                            vmtime.set_timeout_if_before(
+                                vmtime.now().wrapping_add(UNHALT_CHECK_PERIOD),
+                            );
+                            vmtime.poll_timeout(cx).is_ready()
+                        });
+
+                    if expired {
+                        let vtl = self.state.runnable_vtls.highest_set().unwrap();
+                        self.unhalt_for_pending_interrupt(vtl);
+                    }
+                }
+
                 // Arm the timer.
                 if self.state.vmtime.poll_timeout(cx).is_ready() {
                     // The timer has already expired. Yield once to allow other

--- a/vmm_core/virt_whp/src/vp.rs
+++ b/vmm_core/virt_whp/src/vp.rs
@@ -339,7 +339,8 @@ impl<'a> WhpProcessor<'a> {
                 // HACK: TEMPORARY HACK WORKAROUND FOR HYPERVISOR BUG
                 // The hypervisor can leave a VP halted with an interrupt
                 // pending in its offloaded APIC, with nothing left to wake it,
-                // so poll for that case periodically.
+                // so periodically poke RFLAGS.IF to force a reevaluation.
+                #[cfg(guest_arch = "x86_64")]
                 {
                     const UNHALT_CHECK_PERIOD: std::time::Duration =
                         std::time::Duration::from_secs(1);
@@ -356,9 +357,12 @@ impl<'a> WhpProcessor<'a> {
                         });
 
                     if expired {
-                        let _vtl = self.state.runnable_vtls.highest_set().unwrap();
-                        #[cfg(guest_arch = "x86_64")]
-                        self.unhalt_for_pending_interrupt(_vtl);
+                        let vtl = self
+                            .state
+                            .runnable_vtls
+                            .highest_set()
+                            .expect("no runnable vtls");
+                        self.poke_interrupt_flag(vtl);
                     }
                 }
 


### PR DESCRIPTION
We've recently discovered what appears to be a hypervisor bug, that can leave a guest stranded despite a pending interrupt. While debugging and fixing that is ongoing, add a workaround here: A periodic 1 second timer that checks for this condition and manually unsticks the VP when it is found. Hopefully this lets us keep moving and gets rid of a bunch of test flakiness.