### PR TITLE
openvmm: identify checkout builds by revision

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5625,7 +5625,7 @@ dependencies = [
 
 [[package]]
 name = "openvmm"
-version = "0.0.0"
+version = "0.1.0-dev"
 dependencies = [
  "crypto",
  "embed-resource",
@@ -5760,7 +5760,7 @@ dependencies = [
 
 [[package]]
 name = "openvmm_entry"
-version = "0.0.0"
+version = "0.1.0-dev"
 dependencies = [
  "anyhow",
  "build_rs_guest_arch",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5635,6 +5635,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "openvmm_build_info"
+version = "0.1.0-dev"
+
+[[package]]
 name = "openvmm_core"
 version = "0.0.0"
 dependencies = [
@@ -5801,6 +5805,7 @@ dependencies = [
  "net_tap",
  "netvsp_resources",
  "nvme_resources",
+ "openvmm_build_info",
  "openvmm_defs",
  "openvmm_helpers",
  "openvmm_pcat_locator",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5636,7 +5636,7 @@ dependencies = [
 
 [[package]]
 name = "openvmm_build_info"
-version = "0.1.0-dev"
+version = "0.1.0"
 
 [[package]]
 name = "openvmm_core"
@@ -5764,7 +5764,7 @@ dependencies = [
 
 [[package]]
 name = "openvmm_entry"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "anyhow",
  "build_rs_guest_arch",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5625,7 +5625,7 @@ dependencies = [
 
 [[package]]
 name = "openvmm"
-version = "0.1.0-dev"
+version = "0.1.0"
 dependencies = [
  "crypto",
  "embed-resource",
@@ -5760,7 +5760,7 @@ dependencies = [
 
 [[package]]
 name = "openvmm_entry"
-version = "0.1.0-dev"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "build_rs_guest_arch",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,14 @@ exclude = [
 [workspace.package]
 rust-version = "1.95"
 edition = "2024"
+# The canonical OpenVMM version, and the source of truth for the version a
+# release is cut at. Bump this, then tag; a release tag must match it.
+#
+# The `-dev` suffix marks a tree that is working towards the next release
+# rather than sitting at one, so a build from `main` cannot be mistaken for a
+# released binary. Releasing drops the suffix; the following commit restores it
+# on the next version.
+version = "0.1.0-dev"
 
 [workspace.dependencies]
 xtask_fuzz = { path = "xtask/xtask_fuzz" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,14 +69,9 @@ exclude = [
 [workspace.package]
 rust-version = "1.95"
 edition = "2024"
-# The canonical OpenVMM version, and the source of truth for the version a
-# release is cut at. Bump this, then tag; a release tag must match it.
-#
-# The `-dev` suffix marks a tree that is working towards the next release
-# rather than sitting at one, so a build from `main` cannot be mistaken for a
-# released binary. Releasing drops the suffix; the following commit restores it
-# on the next version.
-version = "0.1.0-dev"
+# The canonical OpenVMM version. It remains at the most recently released
+# version until a reviewed pull request selects the next release.
+version = "0.1.0"
 
 [workspace.dependencies]
 xtask_fuzz = { path = "xtask/xtask_fuzz" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,6 +80,8 @@ xtask_fuzz = { path = "xtask/xtask_fuzz" }
 opentmk_protocol = { path = "opentmk_protocol" }
 opentmk_disk = { path = "opentmk/opentmk_disk" }
 
+openvmm_build_info = { path = "openvmm/openvmm_build_info" }
+
 flowey = { path = "flowey/flowey" }
 flowey_cli = { path = "flowey/flowey_cli" }
 flowey_core = { path = "flowey/flowey_core" }

--- a/openvmm/openvmm/Cargo.toml
+++ b/openvmm/openvmm/Cargo.toml
@@ -3,6 +3,8 @@
 
 [package]
 name = "openvmm"
+version.workspace = true
+publish = false
 edition.workspace = true
 rust-version.workspace = true
 

--- a/openvmm/openvmm/build.rs
+++ b/openvmm/openvmm/build.rs
@@ -18,10 +18,21 @@ fn main() {
         println!("cargo:rerun-if-env-changed=OPENVMM_PATCH");
         println!("cargo:rerun-if-env-changed=OPENVMM_REVISION");
 
+        // Default to the crate version so that the version Windows reports in
+        // the file properties and the one `openvmm --version` prints cannot
+        // disagree. The `OPENVMM_*` vars still win, which is how a build
+        // pipeline stamps its own build number in. There is no crate
+        // equivalent of the fourth component, so it stays 0 unless set.
         let parse_u16 = |s: String| s.parse::<u16>().unwrap_or(0);
-        let major = std::env::var("OPENVMM_MAJOR").map(parse_u16).unwrap_or(0);
-        let minor = std::env::var("OPENVMM_MINOR").map(parse_u16).unwrap_or(0);
-        let patch = std::env::var("OPENVMM_PATCH").map(parse_u16).unwrap_or(0);
+        let component = |var: &str, from_crate_version: &str| {
+            std::env::var(var)
+                .or_else(|_| std::env::var(from_crate_version))
+                .map(parse_u16)
+                .unwrap_or(0)
+        };
+        let major = component("OPENVMM_MAJOR", "CARGO_PKG_VERSION_MAJOR");
+        let minor = component("OPENVMM_MINOR", "CARGO_PKG_VERSION_MINOR");
+        let patch = component("OPENVMM_PATCH", "CARGO_PKG_VERSION_PATCH");
         let revision = std::env::var("OPENVMM_REVISION")
             .map(parse_u16)
             .unwrap_or(0);

--- a/openvmm/openvmm_build_info/Cargo.toml
+++ b/openvmm/openvmm_build_info/Cargo.toml
@@ -1,0 +1,12 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+[package]
+name = "openvmm_build_info"
+version.workspace = true
+publish = false
+edition.workspace = true
+rust-version.workspace = true
+
+[lints]
+workspace = true

--- a/openvmm/openvmm_build_info/build.rs
+++ b/openvmm/openvmm_build_info/build.rs
@@ -1,0 +1,100 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#![expect(missing_docs)]
+
+use std::path::Path;
+use std::process::Command;
+
+fn git(repo: &Path, args: &[&str]) -> Option<String> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(repo)
+        .args(args)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let stdout = String::from_utf8(output.stdout).ok()?;
+    let stdout = stdout.trim().to_owned();
+    (!stdout.is_empty()).then_some(stdout)
+}
+
+/// The commit this tree was built from, if it is a Git checkout at all.
+///
+/// A released source archive has no `.git`, and neither does the tree a
+/// packager extracts and builds. That is the expected case rather than an
+/// error, so this returns `None` instead of failing the build.
+fn revision(repo: &Path) -> Option<String> {
+    // Git searches parent directories, so an archive extracted inside an
+    // unrelated checkout would otherwise silently report *that* checkout's
+    // HEAD. Only trust the answer if the repository we found starts exactly
+    // where OpenVMM does.
+    let toplevel = git(repo, &["rev-parse", "--show-toplevel"])?;
+    if std::fs::canonicalize(&toplevel).ok()? != std::fs::canonicalize(repo).ok()? {
+        return None;
+    }
+    git(repo, &["rev-parse", "HEAD"])
+}
+
+/// Watch just enough of `.git` to notice HEAD moving.
+///
+/// This deliberately does not watch tracked files. Reporting whether the tree
+/// is dirty would mean emitting a `rerun-if-changed` for every file in the
+/// repository, which costs a stat of the whole tree on every single build. The
+/// revision on its own is worth two files; a dirty flag is not worth thousands.
+fn watch_head(repo: &Path) {
+    for path in ["HEAD", "packed-refs"] {
+        if let Some(path) = git(repo, &["rev-parse", "--git-path", path]) {
+            println!("cargo:rerun-if-changed={}", repo.join(path).display());
+        }
+    }
+    // On a branch, HEAD is a pointer; the commit changes when the ref it names
+    // does, which is a different file.
+    if let Some(head_ref) = git(repo, &["symbolic-ref", "HEAD"])
+        && let Some(path) = git(repo, &["rev-parse", "--git-path", &head_ref])
+    {
+        println!("cargo:rerun-if-changed={}", repo.join(path).display());
+    }
+}
+
+fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-env-changed=OPENVMM_PKGVERSION");
+
+    // The version is a committed fact, inherited from `[workspace.package]`.
+    // Git is consulted only to enrich it, never to determine it.
+    let product_version = env!("CARGO_PKG_VERSION");
+
+    let repo_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let revision = revision(&repo_root);
+    if revision.is_some() {
+        watch_head(&repo_root);
+    }
+
+    // `OPENVMM_PKGVERSION` lets whoever builds the binary stamp their own build
+    // identity in, the way QEMU's `-Dpkgversion` and cloud-hypervisor's
+    // `CH_EXTRA_VERSION` do, so a bug report names the build it came from. An
+    // empty value is treated as unset, since build systems routinely pass an
+    // undefined variable through as `""`.
+    let version = match std::env::var("OPENVMM_PKGVERSION") {
+        Ok(pkgversion) if !pkgversion.is_empty() => pkgversion,
+        _ => match &revision {
+            // Semver build metadata, so it orders identically to the plain
+            // version and a build from a checkout is never mistaken for one
+            // from the matching release archive.
+            Some(revision) => {
+                format!("{product_version}+g{}", &revision[..9.min(revision.len())])
+            }
+            None => product_version.to_owned(),
+        },
+    };
+
+    println!("cargo:rustc-env=OPENVMM_VERSION={version}");
+    println!("cargo:rustc-env=OPENVMM_PRODUCT_VERSION={product_version}");
+    println!(
+        "cargo:rustc-env=OPENVMM_REVISION={}",
+        revision.unwrap_or_default()
+    );
+}

--- a/openvmm/openvmm_build_info/build.rs
+++ b/openvmm/openvmm_build_info/build.rs
@@ -6,6 +6,12 @@
 use std::path::Path;
 use std::process::Command;
 
+/// Prefix of the Git tag naming an OpenVMM release.
+///
+/// This is intentionally duplicated from the release tooling. Source consumers
+/// build this crate without that tooling, so build identity cannot depend on it.
+const RELEASE_TAG_PREFIX: &str = "openvmm-v";
+
 fn git(repo: &Path, args: &[&str]) -> Option<String> {
     let output = Command::new("git")
         .arg("-C")
@@ -21,6 +27,17 @@ fn git(repo: &Path, args: &[&str]) -> Option<String> {
     (!stdout.is_empty()).then_some(stdout)
 }
 
+fn git_repository_starts_at(repo: &Path) -> bool {
+    Command::new("git")
+        .arg("-C")
+        .arg(repo)
+        .args(["rev-parse", "--show-prefix"])
+        .output()
+        .is_ok_and(|output| {
+            output.status.success() && output.stdout.iter().all(u8::is_ascii_whitespace)
+        })
+}
+
 /// The commit this tree was built from, if it is a Git checkout at all.
 ///
 /// A released source archive has no `.git`, and neither does the tree a
@@ -31,11 +48,30 @@ fn revision(repo: &Path) -> Option<String> {
     // unrelated checkout would otherwise silently report *that* checkout's
     // HEAD. Only trust the answer if the repository we found starts exactly
     // where OpenVMM does.
-    let toplevel = git(repo, &["rev-parse", "--show-toplevel"])?;
-    if std::fs::canonicalize(&toplevel).ok()? != std::fs::canonicalize(repo).ok()? {
+    if !git_repository_starts_at(repo) {
         return None;
     }
     git(repo, &["rev-parse", "HEAD"])
+}
+
+/// Whether HEAD is the exact commit tagged for `version`.
+///
+/// A checkout without tags answers "no", which fails safely: it may report a
+/// release checkout as a development build, but never the reverse.
+fn at_release_tag(repo: &Path, version: &str) -> bool {
+    let Some(tags) = git(repo, &["tag", "--points-at", "HEAD"]) else {
+        return false;
+    };
+    let release_tag = format!("{RELEASE_TAG_PREFIX}{version}");
+    tags.lines().any(|tag| tag.trim() == release_tag)
+}
+
+/// Notice the release tag arriving after the tree was already built.
+fn watch_release_tag(repo: &Path, version: &str) {
+    let tag = format!("refs/tags/{RELEASE_TAG_PREFIX}{version}");
+    if let Some(path) = git(repo, &["rev-parse", "--git-path", &tag]) {
+        println!("cargo:rerun-if-changed={}", repo.join(path).display());
+    }
 }
 
 /// Watch just enough of `.git` to notice HEAD moving.
@@ -71,7 +107,9 @@ fn main() {
     let revision = revision(&repo_root);
     if revision.is_some() {
         watch_head(&repo_root);
+        watch_release_tag(&repo_root, product_version);
     }
+    let at_release_tag = revision.is_some() && at_release_tag(&repo_root, product_version);
 
     // `OPENVMM_PKGVERSION` lets whoever builds the binary stamp their own build
     // identity in, the way QEMU's `-Dpkgversion` and cloud-hypervisor's
@@ -84,10 +122,10 @@ fn main() {
             // Semver build metadata, so it orders identically to the plain
             // version and a build from a checkout is never mistaken for one
             // from the matching release archive.
-            Some(revision) => {
+            Some(revision) if !at_release_tag => {
                 format!("{product_version}+g{}", &revision[..9.min(revision.len())])
             }
-            None => product_version.to_owned(),
+            _ => product_version.to_owned(),
         },
     };
 

--- a/openvmm/openvmm_build_info/src/lib.rs
+++ b/openvmm/openvmm_build_info/src/lib.rs
@@ -1,0 +1,115 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! OpenVMM product version and source revision.
+//!
+//! The version is inherited from `[workspace.package]` in the root
+//! `Cargo.toml`, which is the source of truth for what a release is cut at. It
+//! therefore travels inside the source archive, and a packager building an
+//! extracted tree with no Git history still reports the right version. Git is
+//! consulted only to append the revision to a build made from a checkout.
+
+#![expect(missing_docs)]
+
+/// Version and source identity of this build.
+#[derive(Debug)]
+pub struct BuildInfo {
+    version: &'static str,
+    product_version: &'static str,
+    revision: &'static str,
+}
+
+impl BuildInfo {
+    pub const fn new() -> Self {
+        Self {
+            version: env!("OPENVMM_VERSION"),
+            product_version: env!("OPENVMM_PRODUCT_VERSION"),
+            revision: env!("OPENVMM_REVISION"),
+        }
+    }
+
+    /// The version to show a human, as reported by `openvmm --version`.
+    ///
+    /// This carries whatever enrichment was available at build time: a `+g`
+    /// revision suffix when built from a checkout, or a packager's own string
+    /// if they set `OPENVMM_PKGVERSION`.
+    pub const fn version(&self) -> &'static str {
+        self.version
+    }
+
+    /// The plain upstream version, with nothing appended and no override
+    /// applied.
+    ///
+    /// Use this rather than [`BuildInfo::version`] anywhere the value is
+    /// persisted or compared, since it is the only part that is guaranteed to
+    /// be an OpenVMM version and not a distribution's build string.
+    pub const fn product_version(&self) -> &'static str {
+        self.product_version
+    }
+
+    /// The commit this was built from, or empty if it was not built from a
+    /// checkout (a released source archive, for instance).
+    pub const fn scm_revision(&self) -> &'static str {
+        self.revision
+    }
+}
+
+impl Default for BuildInfo {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// Keep the build information easy to discover without a debugger, and without
+// running the binary at all.
+//
+// The static remains reachable through `get`, so `#[used]` is not required.
+//
+// UNSAFETY: `link_section` and `export_name` are unsafe attributes.
+#[expect(unsafe_code)]
+// SAFETY: These are custom metadata sections with no safety requirements.
+#[cfg_attr(target_os = "windows", unsafe(link_section = ".build_i"))]
+#[cfg_attr(target_vendor = "apple", unsafe(link_section = "__DATA,__build_info"))]
+#[cfg_attr(
+    not(any(target_os = "windows", target_vendor = "apple")),
+    unsafe(link_section = ".build_info")
+)]
+// SAFETY: This symbol is uniquely named for OpenVMM and has no runtime ABI.
+#[unsafe(export_name = "OPENVMM_BUILD_INFO")]
+static OPENVMM_BUILD_INFO: BuildInfo = BuildInfo::new();
+
+pub fn get() -> &'static BuildInfo {
+    // Prevent fat LTO from optimizing away the metadata static.
+    std::hint::black_box(&OPENVMM_BUILD_INFO)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The version is only meaningful if this crate actually carries one.
+    /// Cargo silently defaults a crate with no `version` to `0.0.0`, and the
+    /// house-rules lint that normally *strips* `version` merely permits one
+    /// here -- it cannot require it. So if `version.workspace = true` were
+    /// dropped from Cargo.toml, every build would keep succeeding and every
+    /// binary would quietly report `0.0.0`. This is the only thing that would
+    /// notice.
+    #[test]
+    fn product_version_is_not_the_cargo_default() {
+        assert_ne!(get().product_version(), "0.0.0");
+        assert!(!get().version().is_empty());
+    }
+
+    /// A revision is optional, but a partial one means the build script
+    /// mangled it.
+    #[test]
+    fn revision_is_a_full_object_id_or_absent() {
+        let revision = get().scm_revision();
+        assert!(
+            revision.is_empty()
+                || (matches!(revision.len(), 40 | 64)
+                    && revision.bytes().all(|b| b.is_ascii_hexdigit())),
+            "unexpected revision {revision:?}"
+        );
+    }
+}

--- a/openvmm/openvmm_build_info/src/lib.rs
+++ b/openvmm/openvmm_build_info/src/lib.rs
@@ -7,7 +7,8 @@
 //! `Cargo.toml`, which is the source of truth for what a release is cut at. It
 //! therefore travels inside the source archive, and a packager building an
 //! extracted tree with no Git history still reports the right version. Git is
-//! consulted only to append the revision to a build made from a checkout.
+//! consulted only to distinguish the exact release tag from any other checkout
+//! and append the revision to the latter.
 
 #![expect(missing_docs)]
 
@@ -31,8 +32,8 @@ impl BuildInfo {
     /// The version to show a human, as reported by `openvmm --version`.
     ///
     /// This carries whatever enrichment was available at build time: a `+g`
-    /// revision suffix when built from a checkout, or a packager's own string
-    /// if they set `OPENVMM_PKGVERSION`.
+    /// revision suffix for a checkout other than the exact release tag, or a
+    /// packager's own string if they set `OPENVMM_PKGVERSION`.
     pub const fn version(&self) -> &'static str {
         self.version
     }

--- a/openvmm/openvmm_entry/Cargo.toml
+++ b/openvmm/openvmm_entry/Cargo.toml
@@ -3,6 +3,8 @@
 
 [package]
 name = "openvmm_entry"
+version.workspace = true
+publish = false
 edition.workspace = true
 rust-version.workspace = true
 

--- a/openvmm/openvmm_entry/Cargo.toml
+++ b/openvmm/openvmm_entry/Cargo.toml
@@ -3,8 +3,6 @@
 
 [package]
 name = "openvmm_entry"
-version.workspace = true
-publish = false
 edition.workspace = true
 rust-version.workspace = true
 
@@ -20,6 +18,7 @@ chipset_device_worker_defs.workspace = true
 crypto.workspace = true
 cxl_spec.workspace = true
 debug_worker_defs.workspace = true
+openvmm_build_info.workspace = true
 vmotherboard.workspace = true
 diag_client.workspace = true
 memory_range.workspace = true

--- a/openvmm/openvmm_entry/src/cli_args.rs
+++ b/openvmm/openvmm_entry/src/cli_args.rs
@@ -138,21 +138,6 @@ pub struct NumaDistanceCli {
     pub distance: u8,
 }
 
-/// Version reported by `--version`.
-///
-/// `OPENVMM_PKGVERSION` lets whoever builds the binary stamp their own build
-/// identity in, the way QEMU's `-Dpkgversion` and cloud-hypervisor's
-/// `CH_EXTRA_VERSION` do. Distributions use this so a bug report names the
-/// build it came from and not just the upstream version. It is read at compile
-/// time, so a build that does not set it reports the plain crate version. An
-/// empty value is treated as unset, since build systems routinely pass through
-/// an undefined variable as `""` and reporting an empty version is worse than
-/// ignoring the override.
-const VERSION: &str = match option_env!("OPENVMM_PKGVERSION") {
-    Some(v) if !v.is_empty() => v,
-    _ => env!("CARGO_PKG_VERSION"),
-};
-
 /// OpenVMM virtual machine monitor.
 ///
 /// This is not yet a stable interface and may change radically between
@@ -161,7 +146,7 @@ const VERSION: &str = match option_env!("OPENVMM_PKGVERSION") {
 // `name` is set explicitly because the version and help output otherwise
 // report `CARGO_PKG_NAME`, which is the crate holding this parser
 // (`openvmm_entry`) rather than the binary a user actually invoked.
-#[command(name = "openvmm", version = VERSION)]
+#[command(name = "openvmm", version = openvmm_build_info::get().version())]
 pub struct Options {
     /// processor count
     #[clap(short = 'p', long, value_name = "COUNT", default_value = "1")]
@@ -3411,17 +3396,18 @@ mod tests {
     use std::path::Path;
     use test_with_tracing::test;
 
-    /// `--version` is only meaningful if `openvmm_entry` actually carries a
-    /// version. Cargo silently defaults a crate with no `version` to `0.0.0`,
-    /// and the house-rules lint that normally *strips* `version` merely permits
-    /// one here -- it cannot require it. So if the `version.workspace = true`
-    /// line were dropped from Cargo.toml, every build would keep succeeding and
-    /// the binary would quietly report `0.0.0`. This is the only thing that
-    /// would notice.
+    /// `--version` reports the resolved build identity rather than clap's
+    /// default, which would be the parser crate's own name and version.
     #[test]
-    fn version_is_not_the_cargo_default() {
-        assert_ne!(env!("CARGO_PKG_VERSION"), "0.0.0");
-        assert!(!VERSION.is_empty());
+    fn version_reports_build_info() {
+        let Err(error) = Options::try_parse_from(["openvmm", "--version"]) else {
+            panic!("--version unexpectedly parsed as runtime options");
+        };
+        assert_eq!(error.kind(), clap::error::ErrorKind::DisplayVersion);
+        assert_eq!(
+            error.to_string(),
+            format!("openvmm {}\n", openvmm_build_info::get().version())
+        );
     }
 
     #[test]

--- a/openvmm/openvmm_entry/src/cli_args.rs
+++ b/openvmm/openvmm_entry/src/cli_args.rs
@@ -138,11 +138,30 @@ pub struct NumaDistanceCli {
     pub distance: u8,
 }
 
+/// Version reported by `--version`.
+///
+/// `OPENVMM_PKGVERSION` lets whoever builds the binary stamp their own build
+/// identity in, the way QEMU's `-Dpkgversion` and cloud-hypervisor's
+/// `CH_EXTRA_VERSION` do. Distributions use this so a bug report names the
+/// build it came from and not just the upstream version. It is read at compile
+/// time, so a build that does not set it reports the plain crate version. An
+/// empty value is treated as unset, since build systems routinely pass through
+/// an undefined variable as `""` and reporting an empty version is worse than
+/// ignoring the override.
+const VERSION: &str = match option_env!("OPENVMM_PKGVERSION") {
+    Some(v) if !v.is_empty() => v,
+    _ => env!("CARGO_PKG_VERSION"),
+};
+
 /// OpenVMM virtual machine monitor.
 ///
 /// This is not yet a stable interface and may change radically between
 /// versions.
 #[derive(Parser)]
+// `name` is set explicitly because the version and help output otherwise
+// report `CARGO_PKG_NAME`, which is the crate holding this parser
+// (`openvmm_entry`) rather than the binary a user actually invoked.
+#[command(name = "openvmm", version = VERSION)]
 pub struct Options {
     /// processor count
     #[clap(short = 'p', long, value_name = "COUNT", default_value = "1")]
@@ -3391,6 +3410,19 @@ mod tests {
 
     use std::path::Path;
     use test_with_tracing::test;
+
+    /// `--version` is only meaningful if `openvmm_entry` actually carries a
+    /// version. Cargo silently defaults a crate with no `version` to `0.0.0`,
+    /// and the house-rules lint that normally *strips* `version` merely permits
+    /// one here -- it cannot require it. So if the `version.workspace = true`
+    /// line were dropped from Cargo.toml, every build would keep succeeding and
+    /// the binary would quietly report `0.0.0`. This is the only thing that
+    /// would notice.
+    #[test]
+    fn version_is_not_the_cargo_default() {
+        assert_ne!(env!("CARGO_PKG_VERSION"), "0.0.0");
+        assert!(!VERSION.is_empty());
+    }
 
     #[test]
     fn test_parse_rpc() {

--- a/openvmm/openvmm_entry/src/vm_controller.rs
+++ b/openvmm/openvmm_entry/src/vm_controller.rs
@@ -491,7 +491,7 @@ impl VmController {
         let manifest = openvmm_helpers::snapshot::SnapshotManifest {
             version: openvmm_helpers::snapshot::MANIFEST_VERSION,
             created_at: std::time::SystemTime::now().into(),
-            openvmm_version: env!("CARGO_PKG_VERSION").to_string(),
+            openvmm_version: openvmm_build_info::get().product_version().to_string(),
             memory_size_bytes: self.memory,
             vp_count: self.processors,
             page_size: crate::system_page_size(),

--- a/vm/vmgs/vmgstool/Cargo.toml
+++ b/vm/vmgs/vmgstool/Cargo.toml
@@ -4,6 +4,7 @@
 [package]
 name = "vmgstool"
 version = "2.1.0"
+publish = false
 edition.workspace = true
 rust-version.workspace = true
 

--- a/xtask/src/tasks/fmt/lints/package_info.rs
+++ b/xtask/src/tasks/fmt/lints/package_info.rs
@@ -12,6 +12,11 @@
 //! from newcomers (does the version field mean anything? do we use it for
 //! semver internally?).
 //!
+//! The exceptions in [`VERSION_EXCEPTIONS`] are the crates where the version is
+//! *not* meaningless, because something outside the crate reads it. Those
+//! crates lose the publishing protection described above, so each one sets
+//! `publish = false` explicitly instead.
+//!
 //! The [authors][] field is optional, is not really used anywhere anymore, and
 //! just creates confusion.
 //!
@@ -27,8 +32,26 @@ use toml_edit::DocumentMut;
 use toml_edit::Item;
 use toml_edit::Table;
 
-/// List of packages that are allowed to have a version
-static VERSION_EXCEPTIONS: &[&str] = &["vmgstool"];
+/// List of packages that are allowed to have a version.
+///
+/// Each of these must also set `publish = false`, since carrying a version
+/// forfeits the implicit publishing protection described at the module level.
+///
+/// `vmgstool` publishes a versioned binary, and its release tag is built from
+/// the version in its manifest.
+///
+/// `openvmm` and `openvmm_entry` carry the workspace version because OpenVMM is
+/// released as a source archive that packagers build. The version has to travel
+/// inside the source, since a packager builds long after any pipeline that
+/// could have supplied it, and from a tree with no git history to recover it
+/// from. Both are read: `openvmm_entry` holds the command line parser, so its
+/// version is what `openvmm --version` reports, and `openvmm`'s build script
+/// stamps its version into the Windows VERSIONINFO resource.
+///
+/// If this list grows much past a handful, replace it with a
+/// `package.metadata.xtask.house-rules` opt-in, the way `excluded-from-workspace`
+/// below already works -- keeping the policy next to the crate it applies to.
+static VERSION_EXCEPTIONS: &[&str] = &["openvmm", "openvmm_entry", "vmgstool"];
 
 pub struct PackageInfo;
 

--- a/xtask/src/tasks/fmt/lints/package_info.rs
+++ b/xtask/src/tasks/fmt/lints/package_info.rs
@@ -40,18 +40,18 @@ use toml_edit::Table;
 /// `vmgstool` publishes a versioned binary, and its release tag is built from
 /// the version in its manifest.
 ///
-/// `openvmm` and `openvmm_entry` carry the workspace version because OpenVMM is
+/// `openvmm_build_info` carries the workspace version because OpenVMM is
 /// released as a source archive that packagers build. The version has to travel
 /// inside the source, since a packager builds long after any pipeline that
 /// could have supplied it, and from a tree with no git history to recover it
-/// from. Both are read: `openvmm_entry` holds the command line parser, so its
-/// version is what `openvmm --version` reports, and `openvmm`'s build script
-/// stamps its version into the Windows VERSIONINFO resource.
+/// from. That crate turns it into what `openvmm --version` reports. `openvmm`
+/// carries it too, because its build script stamps the version into the Windows
+/// VERSIONINFO resource.
 ///
 /// If this list grows much past a handful, replace it with a
 /// `package.metadata.xtask.house-rules` opt-in, the way `excluded-from-workspace`
 /// below already works -- keeping the policy next to the crate it applies to.
-static VERSION_EXCEPTIONS: &[&str] = &["openvmm", "openvmm_entry", "vmgstool"];
+static VERSION_EXCEPTIONS: &[&str] = &["openvmm", "openvmm_build_info", "vmgstool"];
 
 pub struct PackageInfo;
 


### PR DESCRIPTION
Depends on #4132. Once that PR merges, this diff reduces to the Git-backed build identity.

This change adds `openvmm_build_info` and distinguishes source shapes without allowing a build variable to claim release status:

- ordinary checkouts report `<VERSION>+g<SHORT_SHA>`;
- an exact checkout carrying `openvmm-v<VERSION>` reports the plain version;
- an extracted source tree without Git metadata reports the plain version;
- `OPENVMM_PKGVERSION` remains an explicit builder-supplied custom identity;
- archives extracted inside an unrelated repository do not accidentally inherit that repository's revision;
- a checkout without tags fails safely toward development identity.

The committed workspace version remains the source of truth. Git enriches it but never determines it.
