### PR TITLE
flowey: build xflowey with light optimization

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 [alias]
-xflowey = "run -p flowey_hvlite -- pipeline run"
+xflowey = "run -p flowey_hvlite --profile light -- pipeline run"
 xtask = "run -p xtask --profile light --"
 
 [env]

--- a/flowey/flowey_cli/src/cli/regen.rs
+++ b/flowey/flowey_cli/src/cli/regen.rs
@@ -58,7 +58,8 @@ impl Regen {
                         let sh = xshell::Shell::new()?;
                         sh.change_dir(&working_dir);
                         #[expect(clippy::disallowed_macros)]
-                        xshell::cmd!(sh, "cargo build -p {bin_name} {quiet...}").run()?;
+                        xshell::cmd!(sh, "cargo build -p {bin_name} --profile light {quiet...}")
+                            .run()?;
                     }
 
                     // find the built flowey
@@ -69,7 +70,7 @@ impl Regen {
                                 .unwrap_or("target"),
                         )
                         .join(std::env::var("CARGO_BUILD_TARGET").as_deref().unwrap_or(""))
-                        .join("debug")
+                        .join("light")
                         .join(&exe_name);
 
                     if !bin.exists() {

--- a/flowey/flowey_hvlite/src/pipelines/mod.rs
+++ b/flowey/flowey_hvlite/src/pipelines/mod.rs
@@ -57,7 +57,15 @@ impl IntoPipeline for OpenvmmPipelines {
         match self {
             OpenvmmPipelines::Regen { args } => {
                 let status = std::process::Command::new("cargo")
-                    .args(["run", "-p", "flowey_hvlite", "--", "regen"])
+                    .args([
+                        "run",
+                        "-p",
+                        "flowey_hvlite",
+                        "--profile",
+                        "light",
+                        "--",
+                        "regen",
+                    ])
                     .args(args)
                     .spawn()?
                     .wait()?;


### PR DESCRIPTION
Generating the six checked-in pipelines takes 1.88 seconds with an unoptimized Flowey binary, compared with 246 milliseconds using the light profile. Incremental compilation is also slightly faster at 0.96 seconds instead of 1.12 seconds.

Use the existing light profile for xflowey and its nested regeneration invocations. This retains debug assertions while substantially reducing pipeline generation time.