### PR TITLE
openhcl_boot: derive the hw id chunk size from the page size

### DIFF
--- a/openhcl/openhcl_boot/src/hypercall.rs
+++ b/openhcl/openhcl_boot/src/hypercall.rs
@@ -387,7 +387,8 @@ impl HvCall {
         };
 
         // Split the call up to avoid exceeding the hypercall input/output size limits.
-        const MAX_PER_CALL: usize = 512;
+        const HEADER_SIZE: usize = size_of::<hvdef::hypercall::GetVpIndexFromApicId>();
+        const MAX_PER_CALL: usize = (HV_PAGE_SIZE as usize - HEADER_SIZE) / size_of::<HwId>();
 
         for hw_ids in hw_ids.chunks(MAX_PER_CALL) {
             // PANIC: Infallable, since the hypercall header is less than the size of a page
@@ -396,10 +397,8 @@ impl HvCall {
                 .unwrap();
             // PANIC: Infallable, since the hypercall parameters are chunked to be less
             // than the remaining size (after the header) of the input page.
-            // todo: This is *not true* for aarch64, where the hw_ids are u64s. Tracked via
-            // https://github.com/microsoft/openvmm/issues/745
             hw_ids
-                .write_to_prefix(&mut Self::input_page().buffer[header.as_bytes().len()..])
+                .write_to_prefix(&mut Self::input_page().buffer[HEADER_SIZE..])
                 .unwrap();
 
             // SAFETY: The input header and rep slice are the correct types for this hypercall.


### PR DESCRIPTION
`get_vp_index_from_hw_id` chunks hardware IDs at a hardcoded 512 per call, but the input page carries a 16-byte `GetVpIndexFromApicId` header, leaving 4080 bytes. On aarch64 `HwId` is a `u64`, so a 512-element chunk needs 4096 bytes, `write_to_prefix` returns `Err` and the `unwrap` panics. The `todo` above that line tracked this against this issue

one correction to the issue text: the panic starts at 511 CPUs, not 512. The estimate of `8 * 512 == 4096` did not count the header, so the last chunk that still fits is 510

this computes the limit from the page size, the header and `size_of::<HwId>()` the way `accept_vtl2_pages` and `apply_vtl2_protections` in the same file already do, giving 510 on aarch64 and 1020 on x86_64. Both fit the output page (`n * 4` bytes) and the 12-bit rep count field. The offset now uses the same `HEADER_SIZE` constant as the chunk limit, matching `set_register` and `get_register`, so the two can no longer drift apart

verified the constants by compiling `openhcl_boot` for both targets with a temporary const assertion, and checked the arithmetic against zerocopy directly: 510 `u64`s fit the 4080-byte tail, 511 do not

Fixes #745
