### PR TITLE
consommé: Don't drop the connection when a stale SYN is received from the guest

### DIFF
--- a/vm/devices/net/net_consomme/consomme/src/tcp.rs
+++ b/vm/devices/net/net_consomme/consomme/src/tcp.rs
@@ -1331,7 +1331,7 @@ impl TcpConnectionInner {
 
     fn send_next(&mut self, sender: &mut Sender<'_, impl Client>, ack_policy: AckPolicy) {
         match self.state {
-            TcpState::Connecting => {}
+            TcpState::Connecting | TcpState::SynSent => {}
             TcpState::SynReceived => self.send_syn(sender, Some(self.rx_seq)),
             _ => self.send_data(sender, ack_policy),
         }
@@ -1562,6 +1562,41 @@ impl TcpConnectionInner {
         tcp: &TcpRepr<'_>,
     ) -> Result<bool, DropReason> {
         if tcp.control != TcpControl::Syn || tcp.segment_len() != 1 {
+            let ack_acceptable = tcp
+                .ack_number
+                .is_some_and(|ack| ack > self.tx_acked && ack <= self.tx_send);
+
+            if tcp.control == TcpControl::Rst {
+                if ack_acceptable {
+                    tracing::error!("connection reset while waiting for syn");
+                    self.last_close_reason = ConnectionCloseReason::PeerRst;
+                    return Ok(false);
+                }
+
+                return Ok(true);
+            }
+
+            if let Some(ack_number) = tcp.ack_number
+                && !ack_acceptable
+            {
+                // A rapidly reused tuple can refer to a stale connection. Reset that stale connection and
+                // retry the SYN.
+                tracelimit::warn_ratelimited!(
+                    src = %sender.ft.src,
+                    dst = %sender.ft.dst,
+                    "stale ACK while waiting for SYN, retrying connection"
+                );
+
+                sender.rst(ack_number, None);
+                self.stats.rsts_tx.increment();
+                self.tx_send = self.tx_acked;
+
+                // Retry as a fresh active-open SYN. There is no valid peer SYN
+                // sequence to acknowledge, so this must not be a SYN-ACK.
+                self.send_syn(sender, None);
+                return Ok(true);
+            }
+
             tracing::error!(?tcp.control, "invalid packet waiting for syn, drop connection");
             return Ok(false);
         }

--- a/vm/devices/net/net_consomme/consomme/src/tcp/tests.rs
+++ b/vm/devices/net/net_consomme/consomme/src/tcp/tests.rs
@@ -896,6 +896,152 @@ async fn test_tcp_bind_port_forward(driver: DefaultDriver) {
     assert_eq!(tcp.control, TcpControl::Syn);
 }
 
+/// Test that a stale ACK from a recently closed guest connection does not
+/// tear down a newly accepted port-forward connection using the same tuple.
+#[pal_async::async_test]
+async fn test_tcp_port_forward_recovers_from_stale_ack(driver: DefaultDriver) {
+    let mut consomme = Consomme::new(ConsommeParams::new().unwrap());
+    let mut client = TestClient::new(driver.clone());
+
+    let guest_mac = consomme.params_mut().client_mac;
+    let gateway_mac = consomme.params_mut().gateway_mac;
+    let guest_ip = consomme.params_mut().client_ip;
+    let guest_port = 7777;
+    let received = client.received_packets.clone();
+
+    let socket = Socket::new(Domain::IPV4, Type::STREAM, None).unwrap();
+    socket
+        .bind(&SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0).into())
+        .unwrap();
+    let host_addr = socket.local_addr().unwrap().as_socket().unwrap();
+
+    consomme
+        .access(&mut client)
+        .bind_tcp_port(socket, guest_port)
+        .expect("bind should succeed");
+
+    let connector = std::net::TcpStream::connect(host_addr).unwrap();
+    connector.set_nonblocking(true).unwrap();
+
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    let syn_packet = loop {
+        std::future::poll_fn(|cx| {
+            consomme.access(&mut client).poll(cx);
+            Poll::Ready(())
+        })
+        .await;
+
+        if let Some(packet) = received.lock().iter().find_map(|packet| {
+            TcpTestHarness::is_tcp_packet(packet)
+                .is_some_and(|tcp| tcp.control == TcpControl::Syn && tcp.dst_port == guest_port)
+                .then(|| packet.clone())
+        }) {
+            break packet;
+        }
+
+        assert!(
+            std::time::Instant::now() < deadline,
+            "timed out waiting for forwarded TCP SYN"
+        );
+        pal_async::timer::PolledTimer::new(&driver)
+            .sleep(std::time::Duration::from_millis(10))
+            .await;
+    };
+
+    let (syn_src_ip, _, syn) = parse_tcp_packet(&syn_packet);
+    received.lock().clear();
+
+    let stale_ack = TcpRepr {
+        src_port: guest_port,
+        dst_port: syn.src_port,
+        control: TcpControl::None,
+        seq_number: TcpSeqNumber(9000),
+        ack_number: Some(syn.seq_number),
+        window_len: 64240,
+        window_scale: None,
+        max_seg_size: None,
+        sack_permitted: false,
+        sack_ranges: [None, None, None],
+        timestamp: None,
+        payload: &[],
+    };
+    let mut buf = vec![0u8; 1514];
+    let len = build_tcp_packet(
+        &mut buf,
+        guest_mac,
+        gateway_mac,
+        guest_ip,
+        syn_src_ip,
+        &stale_ack,
+    );
+    consomme
+        .access(&mut client)
+        .send(&buf[..len], &ChecksumState::NONE)
+        .unwrap();
+
+    let retry_syn_packet = {
+        let packets = received.lock();
+        assert!(
+            packets.iter().any(|packet| {
+                TcpTestHarness::is_tcp_packet(packet)
+                    .is_some_and(|tcp| tcp.control == TcpControl::Rst)
+            }),
+            "stale connection should be reset"
+        );
+        packets
+            .iter()
+            .find(|packet| {
+                TcpTestHarness::is_tcp_packet(packet)
+                    .is_some_and(|tcp| tcp.control == TcpControl::Syn)
+            })
+            .cloned()
+            .expect("new connection SYN should be retried")
+    };
+
+    let (_, _, retry_syn) = parse_tcp_packet(&retry_syn_packet);
+    let syn_ack = TcpRepr {
+        src_port: guest_port,
+        dst_port: retry_syn.src_port,
+        control: TcpControl::Syn,
+        seq_number: TcpSeqNumber(10000),
+        ack_number: Some(retry_syn.seq_number + 1),
+        window_len: 64240,
+        window_scale: Some(7),
+        max_seg_size: Some(1460),
+        sack_permitted: false,
+        sack_ranges: [None, None, None],
+        timestamp: None,
+        payload: &[],
+    };
+    let len = build_tcp_packet(
+        &mut buf,
+        guest_mac,
+        gateway_mac,
+        guest_ip,
+        syn_src_ip,
+        &syn_ack,
+    );
+    consomme
+        .access(&mut client)
+        .send(&buf[..len], &ChecksumState::NONE)
+        .unwrap();
+
+    let ft = FourTuple {
+        src: SocketAddr::V4(SocketAddrV4::new(guest_ip, guest_port)),
+        dst: SocketAddr::V4(SocketAddrV4::new(syn_src_ip, retry_syn.src_port)),
+    };
+    assert_eq!(
+        consomme
+            .tcp
+            .connections
+            .get(&ft)
+            .expect("connection should remain active")
+            .inner
+            .state,
+        TcpState::Established
+    );
+}
+
 /// Test that when a loopback connection is forwarded to the guest, the source
 /// IP is rewritten from loopback to a virtual address within the subnet (not
 /// the raw 127.0.0.1), ensuring the guest routes its reply through the virtual


### PR DESCRIPTION
This change solves an issue where we incorrectly drop a connection if we receive a SYN packet that matches a stale tuple. 

Sample repro: 

```
The guest packets are normal TCP reactions during a rapid loopback connection reuse:

15:47:53.516214  recv SYN
127.0.0.1:12974 -> 127.0.0.1:5000

Dockerd sends this SYN to open a new HTTP connection to the local registry for the blob-upload  PATCH .

15:47:53.516216  xmit ACK
15:47:53.516326  recv RST

 net_consomme  still associates the tuple with an older connection and replies with an ACK rather than a SYN-ACK. Because that ACK does not acknowledge the new SYN correctly, the guest TCP stack rejects it with RST.

15:47:53.526396  recv SYN

The guest retransmits the unanswered SYN. DeviceHost then establishes the host-side connection and accepts it through the registry port forward:

15:47:53.526662  connection established
15:47:53.526781  TCP connection established
FourTuple { src: 169.254.73.250:5000,
            dst: 169.254.73.254:12974 }

Consomme sends a new SYN toward the guest registry. The guest responds with an ACK-only packet because that reverse tuple still matches stale guest TCP state, rather than starting a new passive-open handshake with SYN-ACK:

15:47:53.526831  recv tcp packet, control=None
15:47:53.526835  invalid packet waiting for syn, drop connection

Consomme is in  SynSent  and treats the ACK-only response as fatal. It closes the accepted socket, causing:

15:47:53.527042  socket write error, os error 10053
15:47:53.527270  Patch "http://127.0.0.1:5000/v2/...": EOF
15:47:53.528002  WslcPushSessionImage returned 0x80004005

Thus, the guest behavior follows TCP rules; the bug is that consomme drops the new forwarded socket instead of resetting the stale tuple and retrying its SYN.

```