### PR TITLE
guide: mark release 1.8.2607 as ask mode

### DIFF
--- a/Guide/src/dev_guide/contrib/release.md
+++ b/Guide/src/dev_guide/contrib/release.md
@@ -79,7 +79,7 @@ When creating a backport PR to a release branch:
 | release/2411     | Out of service     |                                                                                      |
 | release/2505     | Out of service     | Supports runtime servicing from release/2411.                                        |
 | release/1.7.2511 | Servicing          | Supports runtime servicing from release/2411 and release/2505.                       |
-| release/1.8.2607 | Stabilization      | Supports runtime servicing from release/2411, release/2505, and release/1.7.2511.    |
+| release/1.8.2607 | Ask Mode           | Supports runtime servicing from release/2411, release/2505, and release/1.7.2511.    |
 | _tbd, in main_   | Active Development | Supports runtime servicing from release/2411, release/2505, and release/1.7.2511.    |
 
 ## Taking a Dependency on a Release

--- a/Guide/src/dev_guide/contrib/release.md
+++ b/Guide/src/dev_guide/contrib/release.md
@@ -74,7 +74,7 @@ When creating a backport PR to a release branch:
 | release/2411     | Out of service     |                                                                                      |
 | release/2505     | Out of service     | Supports runtime servicing from release/2411.                                        |
 | release/1.7.2511 | Servicing          | Supports runtime servicing from release/2411 and release/2505.                       |
-| release/1.8.2607 | Stabilization      | Supports runtime servicing from release/2411, release/2505, and release/1.7.2511.    |
+| release/1.8.2607 | Ask Mode           | Supports runtime servicing from release/2411, release/2505, and release/1.7.2511.    |
 | _tbd, in main_   | Active Development | Supports runtime servicing from release/2411, release/2505, and release/1.7.2511.    |
 
 ## Taking a Dependency on a Release


### PR DESCRIPTION
The release/1.8.2607 branch has entered ask mode. Update the release management guide so contributors can see the current phase and its stricter acceptance criteria.