### PR TITLE
nvme: reset shadow doorbell state (#4011)

### DIFF
--- a/vm/devices/storage/nvme/src/queue.rs
+++ b/vm/devices/storage/nvme/src/queue.rs
@@ -20,6 +20,7 @@ use vmcore::interrupt::Interrupt;
 
 pub struct DoorbellMemory {
     mem: GuestMemory,
+    private_mem: GuestMemory,
     offset: u64,
     event_idx_offset: Option<u64>,
     wakers: Vec<Option<Waker>>,
@@ -29,12 +30,31 @@ pub struct InvalidDoorbell;
 
 impl DoorbellMemory {
     pub fn new(num_qids: u16) -> Self {
+        let private_mem = GuestMemory::allocate((num_qids as usize) << DOORBELL_STRIDE_BITS);
         Self {
-            mem: GuestMemory::allocate((num_qids as usize) << DOORBELL_STRIDE_BITS),
+            mem: private_mem.clone(),
+            private_mem,
             offset: 0,
             event_idx_offset: None,
             wakers: (0..num_qids).map(|_| None).collect(),
         }
+    }
+
+    pub fn reset(&mut self) {
+        let Self {
+            mem,
+            private_mem,
+            offset,
+            event_idx_offset,
+            wakers,
+        } = self;
+        private_mem
+            .fill_at(0, 0, wakers.len() << DOORBELL_STRIDE_BITS)
+            .expect("private doorbell memory must be writable");
+        *mem = private_mem.clone();
+        *offset = 0;
+        *event_idx_offset = None;
+        wakers.fill(None);
     }
 
     /// Update the memory used to store the doorbell values. This is used to

--- a/vm/devices/storage/nvme/src/tests/shadow_doorbell_tests.rs
+++ b/vm/devices/storage/nvme/src/tests/shadow_doorbell_tests.rs
@@ -14,6 +14,7 @@ use pal_async::DefaultDriver;
 use pal_async::async_test;
 use pci_core::test_helpers::TestPciInterruptController;
 use user_driver::backoff::Backoff;
+use vmcore::device_state::ChangeDeviceState;
 use zerocopy::FromZeros;
 use zerocopy::IntoBytes;
 
@@ -155,6 +156,86 @@ async fn test_setup_shadow_doorbells(driver: DefaultDriver) {
     let int_controller = TestPciInterruptController::new();
 
     setup_shadow_doorbells(driver.clone(), &cq_buf, &sq_buf, &gm, &int_controller, None).await;
+}
+
+#[async_test]
+async fn test_reset_shadow_doorbells(driver: DefaultDriver) {
+    let cq_buf = PrpRange::new(vec![CQ_BASE], 0, PAGE_SIZE64).unwrap();
+    let sq_buf = PrpRange::new(vec![SQ_BASE], 0, PAGE_SIZE64).unwrap();
+    let gm = test_memory();
+    let int_controller = TestPciInterruptController::new();
+
+    let mut nvmec =
+        setup_shadow_doorbells(driver, &cq_buf, &sq_buf, &gm, &int_controller, None).await;
+
+    ChangeDeviceState::reset(&mut nvmec).await;
+
+    let shadow_value = 0x1234;
+    gm.write_plain::<u32>(DOORBELL_BUFFER_BASE, &shadow_value)
+        .unwrap();
+    nvmec.write_bar0(0x1000, 0x5678_u32.as_bytes()).unwrap();
+
+    assert_eq!(
+        gm.read_plain::<u32>(DOORBELL_BUFFER_BASE).unwrap(),
+        shadow_value
+    );
+}
+
+#[async_test]
+async fn test_controller_reset_shadow_doorbells(driver: DefaultDriver) {
+    let cq_buf = PrpRange::new(vec![CQ_BASE], 0, PAGE_SIZE64).unwrap();
+    let sq_buf = PrpRange::new(vec![SQ_BASE], 0, PAGE_SIZE64).unwrap();
+    let gm = test_memory();
+    let int_controller = TestPciInterruptController::new();
+    let mut backoff = Backoff::new(&driver);
+
+    let mut nvmec =
+        setup_shadow_doorbells(driver.clone(), &cq_buf, &sq_buf, &gm, &int_controller, None).await;
+
+    let mut cc = 0;
+    nvmec.read_bar0(0x14, cc.as_mut_bytes()).unwrap();
+    cc &= !1;
+    nvmec.write_bar0(0x14, cc.as_bytes()).unwrap();
+    let mut reset = false;
+    for _ in 0..5 {
+        let mut csts = 0;
+        nvmec.read_bar0(0x1c, csts.as_mut_bytes()).unwrap();
+        if !spec::Csts::from(csts).rdy() {
+            reset = true;
+            break;
+        }
+        backoff.back_off().await;
+    }
+    assert!(reset);
+
+    const SENTINEL: u64 = 0x0123_4567_89ab_cdef;
+    gm.write_plain::<u64>(DOORBELL_BUFFER_BASE, &SENTINEL)
+        .unwrap();
+    gm.write_plain::<u64>(EVT_IDX_BUFFER_BASE, &SENTINEL)
+        .unwrap();
+
+    cc |= 1;
+    nvmec.write_bar0(0x14, cc.as_bytes()).unwrap();
+    let mut ready = false;
+    for _ in 0..5 {
+        let mut csts = 0;
+        nvmec.read_bar0(0x1c, csts.as_mut_bytes()).unwrap();
+        if spec::Csts::from(csts).rdy() {
+            ready = true;
+            break;
+        }
+        backoff.back_off().await;
+    }
+    assert!(ready);
+
+    nvmec.write_bar0(0x1000, 0_u32.as_bytes()).unwrap();
+    backoff.back_off().await;
+
+    assert_eq!(
+        gm.read_plain::<u64>(DOORBELL_BUFFER_BASE).unwrap(),
+        SENTINEL
+    );
+    assert_eq!(gm.read_plain::<u64>(EVT_IDX_BUFFER_BASE).unwrap(), SENTINEL);
 }
 
 #[async_test]

--- a/vm/devices/storage/nvme/src/workers/coordinator.rs
+++ b/vm/devices/storage/nvme/src/workers/coordinator.rs
@@ -144,15 +144,22 @@ impl NvmeWorkers {
     }
 
     pub fn poll_controller_reset(&mut self) -> bool {
-        if let EnableState::Resetting(recv) = &mut self.state {
+        let Self {
+            _task: _,
+            send: _,
+            doorbells,
+            state,
+        } = self;
+        if let EnableState::Resetting(recv) = state {
             if recv.now_or_never().is_some() {
-                self.state = EnableState::Disabled;
+                *state = EnableState::Disabled;
+                doorbells.write().reset();
                 true
             } else {
                 false
             }
         } else {
-            panic!("not resetting: {:?}", self.state)
+            panic!("not resetting: {:?}", state)
         }
     }
 
@@ -174,6 +181,7 @@ impl NvmeWorkers {
                 }
             }
         }
+        self.doorbells.write().reset();
     }
 }
 

--- a/vm/devices/storage/nvme_test/src/queue.rs
+++ b/vm/devices/storage/nvme_test/src/queue.rs
@@ -20,6 +20,7 @@ use vmcore::interrupt::Interrupt;
 
 pub struct DoorbellMemory {
     mem: GuestMemory,
+    private_mem: GuestMemory,
     offset: u64,
     event_idx_offset: Option<u64>,
     wakers: Vec<Option<Waker>>,
@@ -29,12 +30,31 @@ pub struct InvalidDoorbell;
 
 impl DoorbellMemory {
     pub fn new(num_qids: u16) -> Self {
+        let private_mem = GuestMemory::allocate((num_qids as usize) << DOORBELL_STRIDE_BITS);
         Self {
-            mem: GuestMemory::allocate((num_qids as usize) << DOORBELL_STRIDE_BITS),
+            mem: private_mem.clone(),
+            private_mem,
             offset: 0,
             event_idx_offset: None,
             wakers: (0..num_qids).map(|_| None).collect(),
         }
+    }
+
+    pub fn reset(&mut self) {
+        let Self {
+            mem,
+            private_mem,
+            offset,
+            event_idx_offset,
+            wakers,
+        } = self;
+        private_mem
+            .fill_at(0, 0, wakers.len() << DOORBELL_STRIDE_BITS)
+            .expect("private doorbell memory must be writable");
+        *mem = private_mem.clone();
+        *offset = 0;
+        *event_idx_offset = None;
+        wakers.fill(None);
     }
 
     /// Update the memory used to store the doorbell values. This is used to

--- a/vm/devices/storage/nvme_test/src/tests/shadow_doorbell_tests.rs
+++ b/vm/devices/storage/nvme_test/src/tests/shadow_doorbell_tests.rs
@@ -16,6 +16,7 @@ use pal_async::DefaultDriver;
 use pal_async::async_test;
 use pci_core::test_helpers::TestPciInterruptController;
 use user_driver::backoff::Backoff;
+use vmcore::device_state::ChangeDeviceState;
 use zerocopy::FromZeros;
 use zerocopy::IntoBytes;
 
@@ -160,6 +161,29 @@ async fn test_setup_shadow_doorbells(driver: DefaultDriver) {
     let int_controller = TestPciInterruptController::new();
 
     setup_shadow_doorbells(driver.clone(), &cq_buf, &sq_buf, &gm, &int_controller, None).await;
+}
+
+#[async_test]
+async fn test_reset_shadow_doorbells(driver: DefaultDriver) {
+    let cq_buf = PrpRange::new(vec![CQ_BASE], 0, PAGE_SIZE64).unwrap();
+    let sq_buf = PrpRange::new(vec![SQ_BASE], 0, PAGE_SIZE64).unwrap();
+    let gm = test_memory();
+    let int_controller = TestPciInterruptController::new();
+
+    let mut nvmec =
+        setup_shadow_doorbells(driver, &cq_buf, &sq_buf, &gm, &int_controller, None).await;
+
+    ChangeDeviceState::reset(&mut nvmec).await;
+
+    let shadow_value = 0x1234;
+    gm.write_plain::<u32>(DOORBELL_BUFFER_BASE, &shadow_value)
+        .unwrap();
+    nvmec.write_bar0(0x1000, 0x5678_u32.as_bytes()).unwrap();
+
+    assert_eq!(
+        gm.read_plain::<u32>(DOORBELL_BUFFER_BASE).unwrap(),
+        shadow_value
+    );
 }
 
 #[async_test]

--- a/vm/devices/storage/nvme_test/src/workers/coordinator.rs
+++ b/vm/devices/storage/nvme_test/src/workers/coordinator.rs
@@ -147,15 +147,22 @@ impl NvmeWorkers {
     }
 
     pub fn poll_controller_reset(&mut self) -> bool {
-        if let EnableState::Resetting(recv) = &mut self.state {
+        let Self {
+            _task: _,
+            send: _,
+            doorbells,
+            state,
+        } = self;
+        if let EnableState::Resetting(recv) = state {
             if recv.now_or_never().is_some() {
-                self.state = EnableState::Disabled;
+                *state = EnableState::Disabled;
+                doorbells.write().reset();
                 true
             } else {
                 false
             }
         } else {
-            panic!("not resetting: {:?}", self.state)
+            panic!("not resetting: {:?}", state)
         }
     }
 
@@ -177,6 +184,7 @@ impl NvmeWorkers {
                 }
             }
         }
+        self.doorbells.write().reset();
     }
 }
 


### PR DESCRIPTION
Clean cherry pick of PR #4011

Restore and clear the controller-owned doorbell backing after queue workers drain so stale shadow doorbell and event-index mappings do not survive controller reset. Retain the original backing allocation for reuse and cover both the normal and fault-injection emulators.

Thanks to @bitranox for identifying the stale mapping and suggesting the reset approach in #3915.
