### PR TITLE
netvsp: Split out RNDIS message size errors to identify individual causes.

### DIFF
--- a/vm/devices/net/netvsp/src/lib.rs
+++ b/vm/devices/net/netvsp/src/lib.rs
@@ -2032,6 +2032,18 @@ impl Nic {
 }
 
 #[derive(Debug, Error)]
+enum MessageComponentError {
+    #[error("header")]
+    Header,
+    #[error("per-packet information")]
+    PerPacketInfo,
+    #[error("message body")]
+    Data,
+    #[error("control message")]
+    Control,
+}
+
+#[derive(Debug, Error)]
 enum WorkerError {
     #[error("packet error")]
     Packet(#[source] PacketError),
@@ -2044,7 +2056,10 @@ enum WorkerError {
     #[error("memory access error")]
     Access(#[from] AccessError),
     #[error("rndis message too small")]
-    RndisMessageTooSmall,
+    RndisMessageTooSmall(#[from] MessageComponentError),
+    // See https://lkml.org/lkml/2025/5/12/1565 for more information.
+    #[error("rndis headers missing or split across a page")]
+    RndisBadHeaders,
     #[error("unsupported rndis behavior")]
     UnsupportedRndisBehavior,
     #[error("vmbus queue error")]
@@ -2494,7 +2509,7 @@ impl<T: RingMem> NetChannel<T> {
         // process the queue as suballocations become available.
         const CONTROL_MESSAGE_MAX_QUEUED_BYTES: usize = 100 * 1024;
         if reader.len() == 0 {
-            return Err(WorkerError::RndisMessageTooSmall);
+            return Err(WorkerError::RndisMessageTooSmall(MessageComponentError::Control));
         }
         // Do not let the queue get too large--the guest should not be
         // sending very many control messages at a time.
@@ -2534,7 +2549,7 @@ impl<T: RingMem> NetChannel<T> {
         loop {
             let next_message_offset = message_len
                 .checked_sub(size_of::<rndisprot::MessageHeader>())
-                .ok_or(WorkerError::RndisMessageTooSmall)?;
+                .ok_or(MessageComponentError::Header)?;
 
             self.handle_rndis_packet_message(
                 id,
@@ -2573,7 +2588,7 @@ impl<T: RingMem> NetChannel<T> {
             .into_inner()
             .paged_ranges()
             .next()
-            .ok_or(WorkerError::RndisMessageTooSmall)?;
+            .ok_or(WorkerError::RndisBadHeaders)?;
         let mut data = reader.into_inner();
         let request: rndisprot::Packet = headers.reader(mem).read_plain()?;
         if request.num_oob_data_elements != 0
@@ -2588,7 +2603,7 @@ impl<T: RingMem> NetChannel<T> {
             || (data.len() - request.data_offset as usize) < request.data_length as usize
             || request.data_length == 0
         {
-            return Err(WorkerError::RndisMessageTooSmall);
+            return Err(WorkerError::RndisMessageTooSmall(MessageComponentError::Data));
         }
 
         data.skip(request.data_offset as usize);
@@ -2606,18 +2621,18 @@ impl<T: RingMem> NetChannel<T> {
                     request.per_packet_info_offset as usize,
                     request.per_packet_info_length as usize,
                 )
-                .ok_or(WorkerError::RndisMessageTooSmall)?;
+                .ok_or(MessageComponentError::PerPacketInfo)?;
             while !ppi.is_empty() {
                 let h: rndisprot::PerPacketInfo = ppi.reader(mem).read_plain()?;
                 if h.size == 0 {
-                    return Err(WorkerError::RndisMessageTooSmall);
+                    return Err(WorkerError::RndisMessageTooSmall(MessageComponentError::PerPacketInfo));
                 }
                 let (this, rest) = ppi
                     .try_split(h.size as usize)
-                    .ok_or(WorkerError::RndisMessageTooSmall)?;
+                    .ok_or(MessageComponentError::PerPacketInfo)?;
                 let (_, d) = this
                     .try_split(h.per_packet_information_offset as usize)
-                    .ok_or(WorkerError::RndisMessageTooSmall)?;
+                    .ok_or(MessageComponentError::PerPacketInfo)?;
                 match h.typ {
                     rndisprot::PPI_TCP_IP_CHECKSUM => {
                         let n: rndisprot::TxTcpIpChecksumInfo = d.reader(mem).read_plain()?;
@@ -3102,7 +3117,7 @@ impl<T: RingMem> NetChannel<T> {
                         size_of::<rndisprot::MessageHeader>()
                             + size_of::<rndisprot::QueryComplete>(),
                     )
-                    .ok_or(WorkerError::RndisMessageTooSmall)?;
+                    .ok_or(MessageComponentError::Header)?;
                 let (status, tx) = match self.adapter.handle_oid_query(
                     buffers,
                     primary,

--- a/vm/devices/net/netvsp/src/lib.rs
+++ b/vm/devices/net/netvsp/src/lib.rs
@@ -2055,8 +2055,8 @@ enum WorkerError {
     NonRndisPacketAfterPacket(u32),
     #[error("memory access error")]
     Access(#[from] AccessError),
-    #[error("rndis message too small")]
-    RndisMessageTooSmall(#[from] MessageComponentError),
+    #[error("rndis message too small: {0}")]
+    RndisMessageTooSmall(#[source] MessageComponentError),
     // See https://lkml.org/lkml/2025/5/12/1565 for more information.
     #[error("rndis headers missing or split across a page")]
     RndisBadHeaders,
@@ -2509,7 +2509,9 @@ impl<T: RingMem> NetChannel<T> {
         // process the queue as suballocations become available.
         const CONTROL_MESSAGE_MAX_QUEUED_BYTES: usize = 100 * 1024;
         if reader.len() == 0 {
-            return Err(WorkerError::RndisMessageTooSmall(MessageComponentError::Control));
+            return Err(WorkerError::RndisMessageTooSmall(
+                MessageComponentError::Control,
+            ));
         }
         // Do not let the queue get too large--the guest should not be
         // sending very many control messages at a time.
@@ -2549,7 +2551,9 @@ impl<T: RingMem> NetChannel<T> {
         loop {
             let next_message_offset = message_len
                 .checked_sub(size_of::<rndisprot::MessageHeader>())
-                .ok_or(MessageComponentError::Header)?;
+                .ok_or(WorkerError::RndisMessageTooSmall(
+                    MessageComponentError::Header,
+                ))?;
 
             self.handle_rndis_packet_message(
                 id,
@@ -2603,7 +2607,9 @@ impl<T: RingMem> NetChannel<T> {
             || (data.len() - request.data_offset as usize) < request.data_length as usize
             || request.data_length == 0
         {
-            return Err(WorkerError::RndisMessageTooSmall(MessageComponentError::Data));
+            return Err(WorkerError::RndisMessageTooSmall(
+                MessageComponentError::Data,
+            ));
         }
 
         data.skip(request.data_offset as usize);
@@ -2621,18 +2627,26 @@ impl<T: RingMem> NetChannel<T> {
                     request.per_packet_info_offset as usize,
                     request.per_packet_info_length as usize,
                 )
-                .ok_or(MessageComponentError::PerPacketInfo)?;
+                .ok_or(WorkerError::RndisMessageTooSmall(
+                    MessageComponentError::PerPacketInfo,
+                ))?;
             while !ppi.is_empty() {
                 let h: rndisprot::PerPacketInfo = ppi.reader(mem).read_plain()?;
                 if h.size == 0 {
-                    return Err(WorkerError::RndisMessageTooSmall(MessageComponentError::PerPacketInfo));
+                    return Err(WorkerError::RndisMessageTooSmall(
+                        MessageComponentError::PerPacketInfo,
+                    ));
                 }
-                let (this, rest) = ppi
-                    .try_split(h.size as usize)
-                    .ok_or(MessageComponentError::PerPacketInfo)?;
+                let (this, rest) =
+                    ppi.try_split(h.size as usize)
+                        .ok_or(WorkerError::RndisMessageTooSmall(
+                            MessageComponentError::PerPacketInfo,
+                        ))?;
                 let (_, d) = this
                     .try_split(h.per_packet_information_offset as usize)
-                    .ok_or(MessageComponentError::PerPacketInfo)?;
+                    .ok_or(WorkerError::RndisMessageTooSmall(
+                        MessageComponentError::PerPacketInfo,
+                    ))?;
                 match h.typ {
                     rndisprot::PPI_TCP_IP_CHECKSUM => {
                         let n: rndisprot::TxTcpIpChecksumInfo = d.reader(mem).read_plain()?;
@@ -3117,7 +3131,9 @@ impl<T: RingMem> NetChannel<T> {
                         size_of::<rndisprot::MessageHeader>()
                             + size_of::<rndisprot::QueryComplete>(),
                     )
-                    .ok_or(MessageComponentError::Header)?;
+                    .ok_or(WorkerError::RndisMessageTooSmall(
+                        MessageComponentError::Header,
+                    ))?;
                 let (status, tx) = match self.adapter.handle_oid_query(
                     buffers,
                     primary,


### PR DESCRIPTION
This is currently the top-hitting error in logs for netvsp, but it combines [known Linux kernel issues](https://lkml.org/lkml/2025/5/12/1565) with actual malformed RNDIS messages, either missing data, missing PPI, or other format issues. The traces we have don't allow us to identify these different failure modes, so this conflates a known defect in guest kernels with potential actual errors.

The changes in this PR split that single error into a set of more targeted buckets for better reporting.