### PR TITLE
openhcl_attestation: signal IGVM Agent to fetch CoRIM endorsement (TDX)

### DIFF
--- a/openhcl/openhcl_attestation_protocol/src/igvm_attest/get.rs
+++ b/openhcl/openhcl_attestation_protocol/src/igvm_attest/get.rs
@@ -177,6 +177,8 @@ impl IgvmAttestRequestHeader {
 ///     AES-256 KEK that performs AES Key Wrap on the released key. The default
 ///     is the same CKM_RSA_AES_KEY_WRAP scheme with the inner RSA-OAEP using
 ///     SHA-1 (MGF1-SHA-1).
+/// 4 - corim_endorsement: Request that the IGVM Agent fetch the CoRIM launch
+///     endorsement for the guest and include it in the attestation flow.
 #[bitfield(u32)]
 #[derive(IntoBytes, FromBytes, Immutable, KnownLayout)]
 pub struct IgvmCapabilityBitMap {
@@ -184,7 +186,8 @@ pub struct IgvmCapabilityBitMap {
     pub retry: bool,
     pub skip_hw_unsealing: bool,
     pub use_rsa_aes_key_wrap_384: bool,
-    #[bits(28)]
+    pub corim_endorsement: bool,
+    #[bits(27)]
     _reserved: u32,
 }
 
@@ -247,13 +250,16 @@ impl IgvmAttestRequestDataExt {
 ///     (RSA_AES_KEY_WRAP_384) and AKV used it to wrap the key in the payload.
 ///     If this bit is clear, AKV wrapped the key with the default
 ///     CKM_RSA_AES_KEY_WRAP scheme (inner RSA-OAEP using SHA-1).
+/// 3 - IGVM_SIGNAL_CORIM_ENDORSEMENT_REQUESTED_BIT: Set by the IGVM Agent to
+///     indicate that the agent requested the CoRIM endorsement.
 #[bitfield(u32)]
 #[derive(IntoBytes, Immutable, KnownLayout, FromBytes)]
 pub struct IgvmSignal {
     pub retry: bool,
     pub skip_hw_unsealing: bool,
     pub rsa_aes_key_wrap_384_used: bool,
-    #[bits(29)]
+    pub corim_endorsement_requested: bool,
+    #[bits(28)]
     _reserved: u32,
 }
 

--- a/openhcl/underhill_attestation/src/igvm_attest/key_release.rs
+++ b/openhcl/underhill_attestation/src/igvm_attest/key_release.rs
@@ -14,6 +14,11 @@ use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub(crate) enum KeyReleaseError {
+    #[error("the response data size {response_size} is smaller than its header size {header_size}")]
+    ResponseSizeTooSmall {
+        response_size: usize,
+        header_size: usize,
+    },
     #[error("the response payload size is too small to parse")]
     PayloadSizeTooSmall,
     #[error("failed to parse AKV JWT (API version > 7.2)")]
@@ -72,10 +77,18 @@ pub fn parse_response(
                     })
                 })?
                 .0; // TODO: zerocopy: err (https://github.com/microsoft/openvmm/issues/759)
-            full_header
-                .error_info
-                .igvm_signal
-                .rsa_aes_key_wrap_384_used()
+            let igvm_signal = full_header.error_info.igvm_signal;
+            let rsa_aes_key_wrap_384_used = igvm_signal.rsa_aes_key_wrap_384_used();
+
+            // Record the IGVM Agent response signals that indicate whether the IGVM Agent
+            // requested the corresponding actions.
+            tracing::info!(
+                corim_endorsement_requested = igvm_signal.corim_endorsement_requested(),
+                rsa_aes_key_wrap_384_used,
+                "IGVM Agent attestation response signals"
+            );
+
+            rsa_aes_key_wrap_384_used
         }
         _ => false,
     };
@@ -86,6 +99,12 @@ pub fn parse_response(
         IgvmAttestResponseVersion::VERSION_2 => size_of::<IgvmAttestKeyReleaseResponseHeader>(),
         invalid_version => return Err(KeyReleaseError::InvalidResponseVersion(invalid_version.0)),
     };
+    if (header.data_size as usize) < header_size {
+        return Err(KeyReleaseError::ResponseSizeTooSmall {
+            response_size: header.data_size as usize,
+            header_size,
+        });
+    }
     let payload = &response[header_size..header.data_size as usize];
     let wrapped_key_size = rsa_modulus_size + rsa_modulus_size + AES_IC_SIZE;
     let wrapped_key_base64_url_size = wrapped_key_size / 3 * 4;

--- a/openhcl/underhill_attestation/src/igvm_attest/mod.rs
+++ b/openhcl/underhill_attestation/src/igvm_attest/mod.rs
@@ -319,7 +319,10 @@ fn create_request(
             .with_error_code(true)
             .with_retry(true)
             .with_skip_hw_unsealing(true)
-            .with_use_rsa_aes_key_wrap_384(true);
+            .with_use_rsa_aes_key_wrap_384(true)
+            // Signal the IGVM Agent to fetch the CoRIM launch endorsement.
+            // TDX only for now.
+            .with_corim_endorsement(matches!(report_type, &ReportType::Tdx));
         let ext = IgvmAttestRequestDataExt::new(capability_bitmap);
         buffer.extend_from_slice(ext.as_bytes());
     }
@@ -470,6 +473,9 @@ mod tests {
         assert!(ext.capability_bitmap.error_code());
         assert!(ext.capability_bitmap.retry());
         assert!(ext.capability_bitmap.skip_hw_unsealing());
+        // CoRIM endorsement is requested for TDX only; an SNP request must not
+        // set the bit.
+        assert!(!ext.capability_bitmap.corim_endorsement());
 
         assert_eq!(
             buffer.len(),
@@ -479,6 +485,33 @@ mod tests {
             &buffer[header_size + expected_extension_size..],
             runtime_claims.as_slice()
         );
+    }
+
+    #[test]
+    fn test_create_request_version2_tdx_requests_corim() {
+        use openhcl_attestation_protocol::igvm_attest::get::IgvmAttestRequestBase;
+        use openhcl_attestation_protocol::igvm_attest::get::IgvmAttestRequestDataExt;
+        use openhcl_attestation_protocol::igvm_attest::get::IgvmAttestRequestVersion;
+
+        let runtime_claims = vec![4u8, 5, 6, 7];
+        let attestation_report =
+            vec![0u8; openhcl_attestation_protocol::igvm_attest::get::TDX_VM_REPORT_SIZE];
+
+        let buffer = create_request(
+            IgvmAttestRequestVersion::VERSION_2,
+            IgvmAttestRequestType::KEY_RELEASE_REQUEST,
+            &runtime_claims,
+            &attestation_report,
+            &ReportType::Tdx,
+            IgvmAttestHashType::SHA_256,
+        )
+        .expect("request generation");
+
+        let header_size = size_of::<IgvmAttestRequestBase>();
+        let (ext, _) = IgvmAttestRequestDataExt::read_from_prefix(&buffer[header_size..])
+            .expect("parse IgvmAttestRequestDataExt");
+        // TDX requests must signal the IGVM Agent to fetch the CoRIM endorsement.
+        assert!(ext.capability_bitmap.corim_endorsement());
     }
 
     #[test]


### PR DESCRIPTION
Clean cherry pick of #4159.

Send one-way signal to IGVMAgent for fetching CoRIM endorsement (TDX only).