### PR TITLE
Add reusable GitHub release plumbing

### DIFF
--- a/flowey/flowey_cli/src/pipeline_resolver/github_yaml/github_yaml_defs.rs
+++ b/flowey/flowey_cli/src/pipeline_resolver/github_yaml/github_yaml_defs.rs
@@ -131,6 +131,7 @@ pub enum PermissionValue {
 #[serde(rename_all = "kebab-case")]
 pub enum Permissions {
     Actions,
+    ArtifactMetadata,
     Attestations,
     Checks,
     Contents,

--- a/flowey/flowey_cli/src/pipeline_resolver/github_yaml/mod.rs
+++ b/flowey/flowey_cli/src/pipeline_resolver/github_yaml/mod.rs
@@ -576,6 +576,7 @@ EOF
 
         let perm_kind_to_yaml = |permission: &GhPermission| match permission {
             GhPermission::Actions => github_yaml_defs::Permissions::Actions,
+            GhPermission::ArtifactMetadata => github_yaml_defs::Permissions::ArtifactMetadata,
             GhPermission::Attestations => github_yaml_defs::Permissions::Attestations,
             GhPermission::Checks => github_yaml_defs::Permissions::Checks,
             GhPermission::Contents => github_yaml_defs::Permissions::Contents,

--- a/flowey/flowey_core/src/node.rs
+++ b/flowey/flowey_core/src/node.rs
@@ -2234,6 +2234,7 @@ pub mod steps {
         #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
         pub enum GhPermission {
             Actions,
+            ArtifactMetadata,
             Attestations,
             Checks,
             Contents,

--- a/flowey/flowey_lib_common/src/attest_build_provenance.rs
+++ b/flowey/flowey_lib_common/src/attest_build_provenance.rs
@@ -35,6 +35,7 @@ impl SimpleFlowNode for Node {
                 .requires_permission(GhPermission::Contents, GhPermissionValue::Read)
                 .requires_permission(GhPermission::IdToken, GhPermissionValue::Write)
                 .requires_permission(GhPermission::Attestations, GhPermissionValue::Write)
+                .requires_permission(GhPermission::ArtifactMetadata, GhPermissionValue::Write)
                 .finish(ctx)
         } else {
             ctx.emit_rust_step("(stub) attest release artifacts", |ctx| {

--- a/flowey/flowey_lib_common/src/attest_build_provenance.rs
+++ b/flowey/flowey_lib_common/src/attest_build_provenance.rs
@@ -1,0 +1,52 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Generate GitHub build provenance attestations for a set of files.
+
+use flowey::node::prelude::*;
+
+flowey_request! {
+    pub struct Request {
+        pub files: ReadVar<Vec<(PathBuf, Option<String>)>>,
+        pub done: WriteVar<SideEffect>,
+    }
+}
+
+new_simple_flow_node!(struct Node);
+
+impl SimpleFlowNode for Node {
+    type Request = Request;
+
+    fn imports(_ctx: &mut ImportCtx<'_>) {}
+
+    fn process_request(request: Self::Request, ctx: &mut NodeCtx<'_>) -> anyhow::Result<()> {
+        let Request { files, done } = request;
+        let subject_paths = files.map(ctx, |files| {
+            files
+                .into_iter()
+                .map(|(path, _)| path.to_string_lossy().into_owned())
+                .collect::<Vec<_>>()
+                .join("\n")
+        });
+
+        let attested = if matches!(ctx.backend(), FlowBackend::Github) {
+            ctx.emit_gh_step("Attest release artifacts", "actions/attest@v4")
+                .with("subject-path", subject_paths)
+                .requires_permission(GhPermission::Contents, GhPermissionValue::Read)
+                .requires_permission(GhPermission::IdToken, GhPermissionValue::Write)
+                .requires_permission(GhPermission::Attestations, GhPermissionValue::Write)
+                .finish(ctx)
+        } else {
+            ctx.emit_rust_step("(stub) attest release artifacts", |ctx| {
+                subject_paths.claim(ctx);
+                |_rt| {
+                    log::warn!("not running in GitHub Actions, so no attestation was generated");
+                    Ok(())
+                }
+            })
+        };
+
+        ctx.emit_side_effect_step([attested], [done]);
+        Ok(())
+    }
+}

--- a/flowey/flowey_lib_common/src/lib.rs
+++ b/flowey/flowey_lib_common/src/lib.rs
@@ -14,6 +14,7 @@ pub mod ado_task_azure_key_vault;
 pub mod ado_task_npm_authenticate;
 pub mod ado_task_nuget_authenticate;
 pub mod ado_task_publish_test_results;
+pub mod attest_build_provenance;
 pub mod cache;
 pub mod cfg_cargo_common_flags;
 pub mod cfg_persistent_dir_cargo_install;

--- a/flowey/flowey_lib_common/src/publish_gh_release.rs
+++ b/flowey/flowey_lib_common/src/publish_gh_release.rs
@@ -10,6 +10,30 @@ flowey_request! {
 }
 
 #[derive(Serialize, Deserialize)]
+pub enum GhReleaseNotes {
+    /// Create the release noninteractively with an empty body.
+    Empty,
+    Generated,
+    Text(String),
+}
+
+/// What to do when a release already exists for the tag being published.
+#[derive(Serialize, Deserialize)]
+pub enum OnExistingRelease {
+    /// Leave it alone and report success.
+    ///
+    /// Suits a release whose tag comes from a version in the tree, where
+    /// rerunning on an unchanged version is routine and means nothing is
+    /// wrong.
+    Skip,
+    /// Fail.
+    ///
+    /// Assets are never replaced automatically, because the existing release
+    /// may already have been reviewed or published.
+    Fail,
+}
+
+#[derive(Serialize, Deserialize)]
 pub struct GhReleaseParams<C = VarNotClaimed> {
     /// First component of a github repo path
     ///
@@ -27,8 +51,14 @@ pub struct GhReleaseParams<C = VarNotClaimed> {
     pub title: ReadVar<String, C>,
     /// Files to upload.
     pub files: ReadVar<Vec<(PathBuf, Option<String>)>, C>,
+    /// Release notes to attach to the release.
+    pub notes: GhReleaseNotes,
     /// Whether the release should be created as a draft
     pub draft: bool,
+    /// What to do when a release already exists for this tag.
+    pub on_existing: OnExistingRelease,
+    /// Side effects that must complete before the release is published.
+    pub prerequisites: Vec<ReadVar<SideEffect, C>>,
 
     pub done: WriteVar<SideEffect, C>,
 }
@@ -42,7 +72,10 @@ impl GhReleaseParams {
             tag,
             title,
             files,
+            notes,
             draft,
+            on_existing,
+            prerequisites,
             done,
         } = self;
 
@@ -53,7 +86,10 @@ impl GhReleaseParams {
             tag: tag.claim(ctx),
             title: title.claim(ctx),
             files: files.claim(ctx),
+            notes,
             draft,
+            on_existing,
+            prerequisites: prerequisites.claim(ctx),
             done: done.claim(ctx),
         }
     }
@@ -94,30 +130,72 @@ impl FlowNode for Node {
                         tag,
                         title,
                         files,
+                        notes,
                         draft,
+                        on_existing,
+                        prerequisites,
                         done: _,
                     } = req;
+
+                    for prerequisite in prerequisites {
+                        rt.read(prerequisite);
+                    }
 
                     let repo = format!("{repo_owner}/{repo_name}");
                     let target = rt.read(target);
                     let tag = rt.read(tag);
 
-                    // check if the release already exists
+                    // Check if the release already exists.
                     //
                     // xshell doesn't give us the exit code, so we have to
                     // use the raw process API instead.
-                    let mut command = std::process::Command::new(&gh_cli);
-                    command
-                        .arg("release").arg("view").arg(&tag).arg("--repo").arg(&repo);
-                    let mut child = command.spawn().context(
-                       "failed to spawn gh cli"
-                    )?;
-                    let status = child.wait()?;
+                    //
+                    // Capture the output rather than letting it inherit. On the
+                    // ordinary path there is no release yet, so `gh` writes
+                    // "release not found", which is a confusing thing to find in
+                    // the log of a run that went on to publish successfully. It
+                    // is still logged when the command fails for some other
+                    // reason -- an auth failure or a 5xx also exit non-zero, and
+                    // are indistinguishable from "not found" without it.
+                    let output = std::process::Command::new(&gh_cli)
+                        .arg("release")
+                        .arg("view")
+                        .arg(&tag)
+                        .arg("--repo")
+                        .arg(&repo)
+                        .output()
+                        .context("failed to spawn gh cli")?;
 
-                    // success means the release already exists, so skip publishing this release
-                    if status.success() {
-                        log::info!("GitHub release with tag {tag} already exists in repo {repo}. Skipping...");
-                        continue;
+                    // Success means the release already exists.
+                    if output.status.success() {
+                        match on_existing {
+                            OnExistingRelease::Skip => {
+                                log::info!("GitHub release with tag {tag} already exists in repo {repo}. Skipping...");
+                                continue;
+                            }
+                            OnExistingRelease::Fail => {
+                                anyhow::bail!(
+                                    "a GitHub release already exists for tag {tag} in repo \
+                                     {repo}. Its assets are not replaced automatically, since \
+                                     the existing release may already have been reviewed or \
+                                     published. Delete it and rerun if it should be regenerated."
+                                );
+                            }
+                        }
+                    } else {
+                        let stderr = String::from_utf8_lossy(&output.stderr);
+                        if !stderr.contains("release not found") {
+                            anyhow::bail!(
+                                "failed to query GitHub release {tag} in {repo}: {}",
+                                stderr.trim()
+                            );
+                        }
+                        log::debug!(
+                            "assuming no release exists for tag {tag} in repo {repo}; \
+                             `gh release view` exited {} with: {}",
+                            output.status,
+                            stderr.trim(),
+                        );
                     };
 
                     let title = rt.read(title);
@@ -132,9 +210,15 @@ impl FlowNode for Node {
                             }
                         })
                         .collect::<Vec<_>>();
+                    let notes = match notes {
+                        GhReleaseNotes::Empty => {
+                            vec!["--notes".to_owned(), String::new()]
+                        }
+                        GhReleaseNotes::Generated => vec!["--generate-notes".to_owned()],
+                        GhReleaseNotes::Text(notes) => vec!["--notes".to_owned(), notes],
+                    };
                     let draft = draft.then_some("--draft");
-
-                    flowey::shell_cmd!(rt, "{gh_cli} release create --repo {repo} --target {target} {tag} --title {title} --notes TODO {draft...} {files...}").run()?;
+                    flowey::shell_cmd!(rt, "{gh_cli} release create {tag} {files...} --repo {repo} --target {target} --title {title} {notes...} {draft...}").run()?;
                 }
 
                 Ok(())

--- a/flowey/flowey_lib_common/src/publish_gh_release.rs
+++ b/flowey/flowey_lib_common/src/publish_gh_release.rs
@@ -147,9 +147,6 @@ impl FlowNode for Node {
 
                     // Check if the release already exists.
                     //
-                    // xshell doesn't give us the exit code, so we have to
-                    // use the raw process API instead.
-                    //
                     // Capture the output rather than letting it inherit. On the
                     // ordinary path there is no release yet, so `gh` writes
                     // "release not found", which is a confusing thing to find in
@@ -157,14 +154,11 @@ impl FlowNode for Node {
                     // is still logged when the command fails for some other
                     // reason -- an auth failure or a 5xx also exit non-zero, and
                     // are indistinguishable from "not found" without it.
-                    let output = std::process::Command::new(&gh_cli)
-                        .arg("release")
-                        .arg("view")
-                        .arg(&tag)
-                        .arg("--repo")
-                        .arg(&repo)
+                    let output =
+                        flowey::shell_cmd!(rt, "{gh_cli} release view {tag} --repo {repo}")
+                        .ignore_status()
                         .output()
-                        .context("failed to spawn gh cli")?;
+                        .context("failed to run gh cli")?;
 
                     // Success means the release already exists.
                     if output.status.success() {

--- a/flowey/flowey_lib_hvlite/src/_jobs/publish_vmgstool_gh_release.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/publish_vmgstool_gh_release.rs
@@ -94,7 +94,13 @@ impl SimpleFlowNode for Node {
                 tag,
                 title,
                 files,
+                notes: flowey_lib_common::publish_gh_release::GhReleaseNotes::Text("TODO".into()),
                 draft: true,
+                // This job runs on every push to main, but the tag only
+                // changes when the version in the tree does, so an existing
+                // release is the normal steady state rather than a problem.
+                on_existing: flowey_lib_common::publish_gh_release::OnExistingRelease::Skip,
+                prerequisites: Vec::new(),
                 done,
             },
         ));


### PR DESCRIPTION
Adds the reusable release-publication primitives needed by the standalone OpenVMM source release described in #4150.

- makes release notes and existing-release handling explicit
- allows callers to require validation/attestation side effects before publication
- distinguishes a missing release from `gh` authentication or server failures
- adds a reusable `actions/attest@v4` Flowey node
- preserves the existing VmgsTool draft, `TODO` notes, and skip-existing behavior

This is independent of the build identity work in #4162 and does not yet add the OpenVMM publication workflow.