### PR TITLE
openvmm: support systems with more than 64 cores per socket (#4148)

### DIFF
--- a/vmm_core/virt/src/x86/topology.rs
+++ b/vmm_core/virt/src/x86/topology.rs
@@ -4,6 +4,7 @@
 //! Provides processor topology related cpuid leaves.
 
 use crate::CpuidLeaf;
+use std::cmp::min;
 use thiserror::Error;
 use vm_topology::processor::ProcessorTopology;
 use x86defs::cpuid::CacheParametersEax;
@@ -106,11 +107,20 @@ fn cache_parameters_cpuid(
             break;
         }
         let mut eax = CacheParametersEax::new();
+        // Only 6 bits are available in the cache parameters CPUID leaf (04H)
+        // so use a saturated value here as the maximum to avoid a panic later.
+        const MAX_CORES_PER_SOCKET_MINUS_ONE: u32 = 0b111111;
         if topology.smt_enabled() {
-            eax.set_cores_per_socket_minus_one((topology.reserved_vps_per_socket() / 2) - 1);
+            eax.set_cores_per_socket_minus_one(min(
+                MAX_CORES_PER_SOCKET_MINUS_ONE,
+                topology.reserved_vps_per_socket() / 2 - 1,
+            ));
             eax.set_threads_sharing_cache_minus_one(1);
         } else {
-            eax.set_cores_per_socket_minus_one(topology.reserved_vps_per_socket() - 1);
+            eax.set_cores_per_socket_minus_one(min(
+                MAX_CORES_PER_SOCKET_MINUS_ONE,
+                topology.reserved_vps_per_socket() - 1,
+            ));
             eax.set_threads_sharing_cache_minus_one(0);
         }
 


### PR DESCRIPTION
Clean cherry pick of PR #4148

On the new GNR test machines, openvmm panics while launching a VM due to the machine having 96 cores for socket. This overflows the 6 bits (64 core) maximum that can be represented in the cache parameters CPUID leaf (04H). The Intel SDM says a saturated value should be reported here in that case.
