### PR TITLE
ci: fixed the auto-comment link to logviewer when a run fails

### DIFF
--- a/.github/workflows/upload-petri-results.yml
+++ b/.github/workflows/upload-petri-results.yml
@@ -137,9 +137,7 @@ jobs:
           gh pr comment \
             -R "$repo" \
             "$SOURCE_PR" \
-            -F - <<EOF
-          [$FAIL_COUNT Petri tests failed ($FAIL_UNSTABLE_COUNT unstable)](https://openvmm.dev/test-results/#/runs/${run_id}_${run_attempt})
-          EOF
+            -b "[$FAIL_COUNT Petri tests failed ($FAIL_UNSTABLE_COUNT unstable)](https://openvmm.dev/test-results/#/runs/${run_id}_${run_attempt})"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           repo: ${{ github.event.workflow_run.repository.full_name }}

--- a/.github/workflows/upload-petri-results.yml
+++ b/.github/workflows/upload-petri-results.yml
@@ -138,9 +138,10 @@ jobs:
             -R "$repo" \
             "$SOURCE_PR" \
             -F - <<EOF
-          [$FAIL_COUNT Petri tests failed ($FAIL_UNSTABLE_COUNT unstable)](https://openvmm.dev/test-results/#/runs/$run_id)
+          [$FAIL_COUNT Petri tests failed ($FAIL_UNSTABLE_COUNT unstable)](https://openvmm.dev/test-results/#/runs/${run_id}_${run_attempt})
           EOF
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           repo: ${{ github.event.workflow_run.repository.full_name }}
           run_id: ${{ github.event.workflow_run.id }}
+          run_attempt: ${{ github.event.workflow_run.run_attempt }}


### PR DESCRIPTION
No longer a broken link to the logviewer when a run fails