### PR TITLE
serial: Fix reset when disconnected

### DIFF
--- a/vm/devices/serial/serial_16550/src/lib.rs
+++ b/vm/devices/serial/serial_16550/src/lib.rs
@@ -203,7 +203,7 @@ impl Serial16550 {
             register_width,
             register_shift: register_width.trailing_zeros() as u8,
             wait_for_rts,
-            state: State::new(),
+            state: State::new(io.is_connected()),
             interrupt,
             io,
             rx_waker: None,
@@ -216,9 +216,6 @@ impl Serial16550 {
             }),
             stats: Default::default(),
         };
-        if this.io.is_connected() {
-            this.state.connect();
-        }
         this.sync();
         Ok(this)
     }
@@ -513,8 +510,7 @@ impl ChangeDeviceState for Serial16550 {
     async fn stop(&mut self) {}
 
     async fn reset(&mut self) {
-        self.state = State::new();
-        self.state.connect();
+        self.state = State::new(self.io.is_connected());
         self.sync();
     }
 }
@@ -544,8 +540,8 @@ impl PollDevice for Serial16550 {
 }
 
 impl State {
-    fn new() -> Self {
-        Self {
+    fn new(is_connected: bool) -> Self {
+        let mut this = Self {
             ier: InterruptEnableRegister::new(),
             lcr: LineControlRegister::new(),
             mcr: ModemControlRegister::new(),
@@ -558,7 +554,11 @@ impl State {
             tx_buffer: VecDeque::new(),
             rx_buffer: VecDeque::new(),
             fcr: FifoControlRegister::new(),
+        };
+        if is_connected {
+            this.connect();
         }
+        this
     }
 
     /// Updates MSR when the modem connects.
@@ -857,7 +857,7 @@ impl State {
             rx_overrun,
             tx_buffer,
             rx_buffer,
-        } = Self::new();
+        } = Self::new(false);
 
         // Reset this state.
         self.ier = ier;
@@ -1346,6 +1346,28 @@ mod tests {
                 "reads must never be deferred without debugger mode"
             );
         }
+    }
+
+    /// Resetting the device must leave the modem lines matching the backend, so
+    /// a port with no backend attached does not come back reporting carrier.
+    #[async_test]
+    async fn reset_does_not_connect_disconnected_backend() {
+        let mut serial = Serial16550::new(
+            "com1".to_string(),
+            MmioOrIoPort::IoPort(0x3f8),
+            1,
+            LineInterrupt::detached(),
+            Box::new(serial_core::disconnected::Disconnected),
+            false,
+            None,
+        )
+        .unwrap();
+
+        serial.reset().await;
+
+        // MSR: no carrier detect, and no delta bits to raise a modem-status
+        // interrupt with.
+        assert_eq!(read_reg(&mut serial, Register::MSR), 0);
     }
 
     #[async_test]

--- a/vm/devices/serial/serial_pl011/src/lib.rs
+++ b/vm/devices/serial/serial_pl011/src/lib.rs
@@ -190,7 +190,7 @@ impl SerialPl011 {
             debug_name,
             mmio_region: ("registers", base..=base + (REGISTERS_SIZE - 1)),
             wait_for_rts: false,
-            state: State::new(),
+            state: State::new(io.is_connected()),
             interrupt,
             io,
             rx_waker: None,
@@ -203,9 +203,6 @@ impl SerialPl011 {
             }),
             stats: Default::default(),
         };
-        if this.io.is_connected() {
-            this.state.connect();
-        }
         this.sync();
         Ok(this)
     }
@@ -553,8 +550,7 @@ impl ChangeDeviceState for SerialPl011 {
     async fn stop(&mut self) {}
 
     async fn reset(&mut self) {
-        self.state = State::new();
-        self.state.connect();
+        self.state = State::new(self.io.is_connected());
         self.sync();
     }
 }
@@ -580,7 +576,7 @@ impl PollDevice for SerialPl011 {
 }
 
 impl State {
-    fn new() -> Self {
+    fn new(is_connected: bool) -> Self {
         // The initial state for this UART does not completely match the PL011
         // specification. This is because Linux loads its SBSA-compatible UART
         // driver instead of its PL011 driver, and the SBSA-compatible driver
@@ -604,7 +600,7 @@ impl State {
 
         let lcr = LineControlRegister::new().with_enable_fifos(true);
 
-        Self {
+        let mut this = Self {
             tx_buffer: VecDeque::new(),
             rx_buffer: VecDeque::new(),
             rx_overrun: false,
@@ -622,7 +618,11 @@ impl State {
             dmacr: DmaControlRegister::new(),
             new_ibrd: 0,
             new_fbrd: FractionalBaudRateRegister::new(),
+        };
+        if is_connected {
+            this.connect();
         }
+        this
     }
 
     /// Updates CR when the modem connects.
@@ -1687,6 +1687,32 @@ mod tests {
             Poll::Ready(())
         })
         .await
+    }
+
+    /// Resetting the device must leave the modem lines matching the backend, so
+    /// a port with no backend attached does not come back reporting carrier.
+    #[async_test]
+    async fn reset_does_not_connect_disconnected_backend() {
+        let mut serial = SerialPl011::new(
+            "com1".to_string(),
+            PL011_SERIAL0_BASE,
+            LineInterrupt::detached(),
+            Box::new(serial_core::disconnected::Disconnected),
+            None,
+        )
+        .unwrap();
+
+        serial.reset().await;
+
+        let fr = spec::FlagRegister::from(read(&mut serial, Register::UARTFR));
+        assert!(!fr.cts() && !fr.dsr() && !fr.dcd(), "no carrier");
+
+        // And no modem-status change bits to raise an interrupt with.
+        let ris = InterruptRegister::from(read(&mut serial, Register::UARTRIS));
+        assert!(
+            !ris.cts() && !ris.dsr() && !ris.dcd(),
+            "no modem status change"
+        );
     }
 
     #[async_test]


### PR DESCRIPTION
Refactors how serial device state is initialized and reset to ensure that the device's modem connection state actually matches the backend connection status after a reset. This prevents devices from incorrectly reporting a carrier when no backend is attached. Also add new tests to verify this behavior.