### PR TITLE
hv1_emulator: Fix stale overlay information on reset

### DIFF
--- a/vm/hv1/hv1_emulator/src/hv.rs
+++ b/vm/hv1/hv1_emulator/src/hv.rs
@@ -177,7 +177,7 @@ impl ProcessorVtlHv {
     }
 
     /// Resets the processor's state.
-    pub fn reset(&mut self) {
+    pub fn reset(&mut self, prot_access: &mut dyn VtlProtectAccess) {
         let Self {
             vp_index: _,
             partition_state: _,
@@ -187,9 +187,9 @@ impl ProcessorVtlHv {
             vp_assist_page,
         } = self;
 
-        synic.reset();
+        synic.reset(prot_access);
         *vp_assist_page_reg = Default::default();
-        *vp_assist_page = OverlayPage::default();
+        vp_assist_page.reset(prot_access);
     }
 
     /// Emulates an MSR write for the guest OS ID MSR.

--- a/vm/hv1/hv1_emulator/src/pages.rs
+++ b/vm/hv1/hv1_emulator/src/pages.rs
@@ -113,6 +113,16 @@ impl OverlayPage {
         *self = OverlayPage::Local(new_page);
     }
 
+    /// Releases any mapped guest page and returns the overlay to its initial
+    /// unmapped, zeroed state.
+    ///
+    /// Unlike [`unmap`](Self::unmap), the contents are discarded rather than
+    /// carried into the VMM-owned buffer, since a reset clears them anyway.
+    pub fn reset(&mut self, prot_access: &mut dyn VtlProtectAccess) {
+        self.unlock_prev_gpn(prot_access);
+        *self = Self::default();
+    }
+
     fn unlock_prev_gpn(&mut self, prot_access: &mut dyn VtlProtectAccess) {
         if let Self::Mapped(page) = self {
             prot_access.unlock_overlay_page(page.gpn).unwrap();

--- a/vm/hv1/hv1_emulator/src/synic.rs
+++ b/vm/hv1/hv1_emulator/src/synic.rs
@@ -115,6 +115,11 @@ impl SharedProcessorState {
             sint: [hvdef::HvSynicSint::new().with_masked(true); NUM_SINTS],
         }
     }
+
+    fn reset(&mut self, prot_access: &mut dyn VtlProtectAccess) {
+        self.siefp_page.reset(prot_access);
+        *self = Self::at_reset();
+    }
 }
 
 /// A partition-wide synthetic interrupt controller.
@@ -278,16 +283,17 @@ impl GlobalSynic {
 
 impl ProcessorSynic {
     /// Resets the synic state back to its initial state.
-    pub fn reset(&mut self) {
+    pub fn reset(&mut self, prot_access: &mut dyn VtlProtectAccess) {
         let Self {
             sints,
             timers,
             shared,
             vina,
         } = self;
-        *sints = SintState::default();
+
+        sints.reset(prot_access);
         *timers = array::from_fn(|_| Timer::default());
-        *shared.write() = SharedProcessorState::at_reset();
+        shared.write().reset(prot_access);
         *vina = HvRegisterVsmVina::new();
     }
 
@@ -717,5 +723,10 @@ impl SintState {
         }
         self.ready_sints |= 1 << sint;
         true
+    }
+
+    fn reset(&mut self, prot_access: &mut dyn VtlProtectAccess) {
+        self.simp_page.reset(prot_access);
+        *self = Self::default();
     }
 }

--- a/vmm_core/virt_whp/src/lib.rs
+++ b/vmm_core/virt_whp/src/lib.rs
@@ -315,7 +315,12 @@ impl IndexMut<Vtl> for RunStateVtls {
 }
 
 impl RunState {
-    fn reset(&mut self, vtl2_scrub: bool, is_bsp: bool) {
+    fn reset(
+        &mut self,
+        vtl2_scrub: bool,
+        is_bsp: bool,
+        prot_access: &mut dyn hv1_emulator::VtlProtectAccess,
+    ) {
         let &mut Self {
             ref mut active_vtl,
             ref mut runnable_vtls,
@@ -336,17 +341,17 @@ impl RunState {
         *crash_msg_address = None;
         *crash_msg_len = None;
         if !vtl2_scrub {
-            vtls.vtl0.reset(is_bsp);
+            vtls.vtl0.reset(is_bsp, prot_access);
         }
         if let Some(vtl) = &mut vtls.vtl2 {
-            vtl.reset(is_bsp);
+            vtl.reset(is_bsp, prot_access);
         }
         *halted = false;
     }
 }
 
 impl PerVtlRunState {
-    fn reset(&mut self, is_bsp: bool) {
+    fn reset(&mut self, is_bsp: bool, prot_access: &mut dyn hv1_emulator::VtlProtectAccess) {
         let Self {
             #[cfg(guest_arch = "x86_64")]
             lapic,
@@ -361,7 +366,7 @@ impl PerVtlRunState {
         }
 
         if let Some(hv) = hv {
-            hv.reset();
+            hv.reset(prot_access);
         }
 
         #[cfg(guest_arch = "aarch64")]
@@ -1836,7 +1841,9 @@ impl<'p> virt::Processor for WhpProcessor<'p> {
 
     fn reset(&mut self) -> Result<(), impl std::error::Error + Send + Sync + 'static> {
         let is_bsp = self.inner.vp_info.base.is_bsp();
-        self.state.reset(false, is_bsp);
+        let partition = self.vp.partition;
+        self.state
+            .reset(false, is_bsp, &mut WhpNoVtlProtections(&partition.gm));
 
         // For each enabled VTL: apply arch fixups that WHP doesn't handle (via
         // `finish_reset`), then clear stale pending per-VTL VP signal flags,
@@ -1867,7 +1874,9 @@ impl<'p> virt::Processor for WhpProcessor<'p> {
         // VTL2 stays enabled across a scrub. `enabled_vtls` and `vtl2_enable`
         // are both left set, so `state.reset` keeps `active_vtl` at VTL2 and
         // each AP idles in VTL2 (in startup suspend) during the servicing window.
-        self.state.reset(true, is_bsp);
+        let partition = self.vp.partition;
+        self.state
+            .reset(true, is_bsp, &mut WhpNoVtlProtections(&partition.gm));
 
         // Re-apply arch register fixups that WHP doesn't handle (`finish_reset`
         // must run after the partition-level WHP reset), then clear stale


### PR DESCRIPTION
The previous implicit drop behavior of OverlayPage would leave stale locked page information behind during a virt backing's reset. Fix this by adding a proper reset method that unlocks the pages. This is a no-op today, because the relevent virt backings don't do any permissions tracking, but they could in the future.