### PR TITLE
openvmm: allow selecting the virtio-vsock bus

### DIFF
--- a/Guide/src/reference/openvmm/management/cli.md
+++ b/Guide/src/reference/openvmm/management/cli.md
@@ -161,6 +161,9 @@ as well as the generated CLI help (via `cargo run -- --help`).
   Defaults to `auto`.
 * `--virtio-vsock-path <PATH>`: Add a virtio-vsock device using OpenVMM's
   hybrid Unix-socket relay.
+* `--virtio-vsock-bus <mmio|pci>`: Select the bus for a virtio-vsock device
+  created by `--virtio-vsock-path` or `--virtio-vsock-vhost-cid`. When omitted,
+  OpenVMM selects the bus automatically.
 * `--virtio-vsock-vhost-cid <CID>`: Add a virtio-vsock device backed by the
   Linux kernel's `vhost_vsock` implementation. This makes the guest reachable
   from host applications through `AF_VSOCK` at `CID`, which must be between 3

--- a/openvmm/openvmm_entry/src/cli_args.rs
+++ b/openvmm/openvmm_entry/src/cli_args.rs
@@ -761,6 +761,10 @@ options:
     #[clap(long, value_name = "PORT", requires("virtio_console"))]
     pub virtio_console_pcie_port: Option<String>,
 
+    /// select the bus for virtio vsock devices (pci | mmio)
+    #[clap(long, value_name = "BUS", value_parser = parse_virtio_vsock_bus)]
+    pub virtio_vsock_bus: Option<VirtioBusCli>,
+
     /// add a virtio vsock device with the given Unix socket base path
     #[clap(long, value_name = "PATH")]
     pub virtio_vsock_path: Option<String>,
@@ -1455,6 +1459,13 @@ pub enum VirtioBusCli {
     Mmio,
     Pci,
     Vpci,
+}
+
+fn parse_virtio_vsock_bus(value: &str) -> Result<VirtioBusCli, String> {
+    match VirtioBusCli::from_str(value, true) {
+        Ok(bus @ (VirtioBusCli::Mmio | VirtioBusCli::Pci)) => Ok(bus),
+        _ => Err("expected mmio or pci".to_string()),
+    }
 }
 
 #[cfg(target_os = "linux")]
@@ -5039,6 +5050,18 @@ mod tests {
             ])
             .is_err()
         );
+    }
+
+    #[test]
+    fn test_virtio_vsock_bus_cli() {
+        let opt = Options::try_parse_from(["openvmm", "--virtio-vsock-bus", "mmio"]).unwrap();
+        assert!(matches!(opt.virtio_vsock_bus, Some(VirtioBusCli::Mmio)));
+
+        let opt = Options::try_parse_from(["openvmm", "--virtio-vsock-bus", "pci"]).unwrap();
+        assert!(matches!(opt.virtio_vsock_bus, Some(VirtioBusCli::Pci)));
+
+        assert!(Options::try_parse_from(["openvmm", "--virtio-vsock-bus", "auto"]).is_err());
+        assert!(Options::try_parse_from(["openvmm", "--virtio-vsock-bus", "vpci"]).is_err());
     }
 
     #[test]

--- a/openvmm/openvmm_entry/src/lib.rs
+++ b/openvmm/openvmm_entry/src/lib.rs
@@ -1851,10 +1851,12 @@ async fn vm_config_from_command_line(
         }
     }
 
+    let virtio_vsock_bus = opt.virtio_vsock_bus.unwrap_or(VirtioBusCli::Auto);
+
     if let Some(vsock_path) = &opt.virtio_vsock_path {
         let listener = vsock_listener(Some(vsock_path))?.unwrap();
         add_virtio_device(
-            VirtioBusCli::Auto,
+            virtio_vsock_bus,
             virtio_resources::vsock::VirtioVsockHandle {
                 // The guest CID does not matter since the UDS relay does not use it. It just needs
                 // to be some non-reserved value for the guest to use.
@@ -1875,7 +1877,7 @@ async fn vm_config_from_command_line(
             .context("failed to open /dev/vhost-vsock")?
             .into();
         add_virtio_device(
-            VirtioBusCli::Auto,
+            virtio_vsock_bus,
             virtio_resources::vsock::VirtioVsockVhostHandle { vhost, guest_cid }.into_resource(),
         );
     }


### PR DESCRIPTION
## Summary
While testing with SNP, I realized we had no way of setting the bus. Fix that.

- add `--virtio-vsock-bus mmio|pci` for selecting the virtio-vsock transport
- apply the selection to both Unix-relay and Linux vhost-vsock devices while preserving automatic selection when omitted
- document the new option in the OpenVMM CLI Guide