### PR TITLE
petri: Capture hyper-v analytic and operational logs too

### DIFF
--- a/petri/src/vm/hyperv/powershell.rs
+++ b/petri/src/vm/hyperv/powershell.rs
@@ -1741,28 +1741,35 @@ define_winevents!(
 /// Get Hyper-V event logs for a VM
 pub async fn hyperv_event_logs(vmid: Option<&Guid>, start_time: &Timestamp) -> Vec<WinEvent> {
     let vmid = vmid.map(|id| id.to_string());
-    let mut events = Vec::new();
-    // Query each log separately, since `Get-WinEvent` fails the whole query if
-    // any one log is unregistered or disabled on this machine. Batching them
-    // would let a missing operational channel take the admin logs down with it.
-    for log in [
-        HYPERV_WORKER_TABLE,
-        HYPERV_VMMS_TABLE,
-        HYPERV_WORKER_OPERATIONAL_TABLE,
-        HYPERV_VMMS_OPERATIONAL_TABLE,
-        HYPERV_WORKER_ANALYTIC_TABLE,
-        HYPERV_WORKER_VDEV_ANALYTIC_TABLE,
-        HYPERV_VMMS_ANALYTIC_TABLE,
-    ] {
-        match run_get_winevent(&[log], &[], Some(start_time), vmid.as_deref(), &[]).await {
-            Ok(e) => events.extend(e),
-            Err(err) => tracing::warn!(
-                log,
+    // All the logs are fetched in a single query. `Get-WinEvent` reports a log
+    // that is missing or disabled as a non-terminating error and still returns
+    // the events from the remaining logs.
+    let events = match run_get_winevent(
+        &[
+            HYPERV_WORKER_TABLE,
+            HYPERV_VMMS_TABLE,
+            HYPERV_WORKER_OPERATIONAL_TABLE,
+            HYPERV_VMMS_OPERATIONAL_TABLE,
+            HYPERV_WORKER_ANALYTIC_TABLE,
+            HYPERV_WORKER_VDEV_ANALYTIC_TABLE,
+            HYPERV_VMMS_ANALYTIC_TABLE,
+        ],
+        &[],
+        Some(start_time),
+        vmid.as_deref(),
+        &[],
+    )
+    .await
+    {
+        Ok(events) => events,
+        Err(err) => {
+            tracing::warn!(
                 error = err.as_ref() as &dyn std::error::Error,
-                "failed to read hyper-v event log"
-            ),
+                "failed to read hyper-v event logs"
+            );
+            Vec::new()
         }
-    }
+    };
     events.sort_by_key(|e| e.time_created);
     events
 }

--- a/petri/src/vm/hyperv/powershell.rs
+++ b/petri/src/vm/hyperv/powershell.rs
@@ -1744,7 +1744,7 @@ pub async fn hyperv_event_logs(vmid: Option<&Guid>, start_time: &Timestamp) -> V
     // All the logs are fetched in a single query. `Get-WinEvent` reports a log
     // that is missing or disabled as a non-terminating error and still returns
     // the events from the remaining logs.
-    let events = match run_get_winevent(
+    let mut events = match run_get_winevent(
         &[
             HYPERV_WORKER_TABLE,
             HYPERV_VMMS_TABLE,

--- a/petri/src/vm/hyperv/powershell.rs
+++ b/petri/src/vm/hyperv/powershell.rs
@@ -1633,6 +1633,9 @@ const HYPERV_WORKER_TABLE: &str = "Microsoft-Windows-Hyper-V-Worker-Admin";
 const HYPERV_VMMS_TABLE: &str = "Microsoft-Windows-Hyper-V-VMMS-Admin";
 const HYPERV_WORKER_OPERATIONAL_TABLE: &str = "Microsoft-Windows-Hyper-V-Worker-Operational";
 const HYPERV_VMMS_OPERATIONAL_TABLE: &str = "Microsoft-Windows-Hyper-V-VMMS-Operational";
+const HYPERV_WORKER_ANALYTIC_TABLE: &str = "Microsoft-Windows-Hyper-V-Worker-Analytic";
+const HYPERV_WORKER_VDEV_ANALYTIC_TABLE: &str = "Microsoft-Windows-Hyper-V-Worker-VDev-Analytic";
+const HYPERV_VMMS_ANALYTIC_TABLE: &str = "Microsoft-Windows-Hyper-V-VMMS-Analytic";
 
 /// Providers that report a process fault to Windows Error Reporting and the
 /// Azure Watson agent.
@@ -1736,24 +1739,32 @@ define_winevents!(
 );
 
 /// Get Hyper-V event logs for a VM
-pub async fn hyperv_event_logs(
-    vmid: Option<&Guid>,
-    start_time: &Timestamp,
-) -> anyhow::Result<Vec<WinEvent>> {
+pub async fn hyperv_event_logs(vmid: Option<&Guid>, start_time: &Timestamp) -> Vec<WinEvent> {
     let vmid = vmid.map(|id| id.to_string());
-    run_get_winevent(
-        &[
-            HYPERV_WORKER_TABLE,
-            HYPERV_VMMS_TABLE,
-            HYPERV_WORKER_OPERATIONAL_TABLE,
-            HYPERV_VMMS_OPERATIONAL_TABLE,
-        ],
-        &[],
-        Some(start_time),
-        vmid.as_deref(),
-        &[],
-    )
-    .await
+    let mut events = Vec::new();
+    // Query each log separately, since `Get-WinEvent` fails the whole query if
+    // any one log is unregistered or disabled on this machine. Batching them
+    // would let a missing operational channel take the admin logs down with it.
+    for log in [
+        HYPERV_WORKER_TABLE,
+        HYPERV_VMMS_TABLE,
+        HYPERV_WORKER_OPERATIONAL_TABLE,
+        HYPERV_VMMS_OPERATIONAL_TABLE,
+        HYPERV_WORKER_ANALYTIC_TABLE,
+        HYPERV_WORKER_VDEV_ANALYTIC_TABLE,
+        HYPERV_VMMS_ANALYTIC_TABLE,
+    ] {
+        match run_get_winevent(&[log], &[], Some(start_time), vmid.as_deref(), &[]).await {
+            Ok(e) => events.extend(e),
+            Err(err) => tracing::warn!(
+                log,
+                error = err.as_ref() as &dyn std::error::Error,
+                "failed to read hyper-v event log"
+            ),
+        }
+    }
+    events.sort_by_key(|e| e.time_created);
+    events
 }
 
 /// Get the Windows Error Reporting / Azure Watson events logged since

--- a/petri/src/vm/hyperv/powershell.rs
+++ b/petri/src/vm/hyperv/powershell.rs
@@ -1631,6 +1631,8 @@ pub async fn run_get_winevent(
 
 const HYPERV_WORKER_TABLE: &str = "Microsoft-Windows-Hyper-V-Worker-Admin";
 const HYPERV_VMMS_TABLE: &str = "Microsoft-Windows-Hyper-V-VMMS-Admin";
+const HYPERV_WORKER_OPERATIONAL_TABLE: &str = "Microsoft-Windows-Hyper-V-Worker-Operational";
+const HYPERV_VMMS_OPERATIONAL_TABLE: &str = "Microsoft-Windows-Hyper-V-VMMS-Operational";
 
 /// Providers that report a process fault to Windows Error Reporting and the
 /// Azure Watson agent.
@@ -1740,7 +1742,12 @@ pub async fn hyperv_event_logs(
 ) -> anyhow::Result<Vec<WinEvent>> {
     let vmid = vmid.map(|id| id.to_string());
     run_get_winevent(
-        &[HYPERV_WORKER_TABLE, HYPERV_VMMS_TABLE],
+        &[
+            HYPERV_WORKER_TABLE,
+            HYPERV_VMMS_TABLE,
+            HYPERV_WORKER_OPERATIONAL_TABLE,
+            HYPERV_VMMS_OPERATIONAL_TABLE,
+        ],
         &[],
         Some(start_time),
         vmid.as_deref(),

--- a/petri/src/vm/hyperv/vm.rs
+++ b/petri/src/vm/hyperv/vm.rs
@@ -136,7 +136,7 @@ impl HyperVVM {
     /// Get Hyper-V logs and write them to the log file
     pub async fn flush_logs(&mut self) -> anyhow::Result<()> {
         let start_time = self.last_log_flushed.as_ref().unwrap_or(&self.create_time);
-        for event in powershell::hyperv_event_logs(Some(&self.vmid), start_time).await? {
+        for event in powershell::hyperv_event_logs(Some(&self.vmid), start_time).await {
             self.log_winevent(&event);
             if self.last_log_flushed.is_none_or(|t| t < event.time_created) {
                 // add 1ms to avoid duplicate log entries


### PR DESCRIPTION
These tables may have additional useful information, and their events use the same syntax as the events we already capture, so the VM guid filter will continue to work just fine.