### PR TITLE
vmm_tests: Fix serial interrupt test race (#4186)

### DIFF
--- a/vmm_tests/vmm_tests/tests/tests/multiarch/pcie.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch/pcie.rs
@@ -853,13 +853,22 @@ async fn verify_ioapic_interrupt_remapping(
     // (kernel console, getty) owns the tty while the test drives it. The 8250
     // driver only requests the port's IRQ while the port is open, so `ttyS1`
     // has no `/proc/interrupts` line until then — both snapshots have to be
-    // taken from a shell that is holding the port open. `set -e` matters
-    // because a `for` loop's status is just its last iteration's, so without it
-    // a failed write anywhere but the final one is silently ignored.
+    // taken from a shell that is holding the port open. `set -e` matters so any
+    // failure in the snapshot or write sequence causes the script to fail (and the
+    // test to surface the error) instead of silently continuing.
+    //
+    // The traffic has to be larger than the tty's transmit buffer (one page).
+    // A smaller write only lands in that buffer and returns immediately,
+    // leaving the transmission — and therefore every interrupt it raises —
+    // racing the second snapshot below. Overflowing the buffer makes `write()`
+    // block until the driver has drained it, and the driver only drains from
+    // its THR-empty interrupt handler, so a completed write proves interrupts
+    // were delivered.
     const SNAPSHOT_SEPARATOR: &str = "===petri-after===";
+    const TX_PAGES: usize = 4;
     let script = format!(
         "set -e; exec 3>/dev/ttyS1; cat /proc/interrupts; echo {SNAPSHOT_SEPARATOR}; \
-         for i in $(seq 1 100); do echo ir-remap-test >&3; done; cat /proc/interrupts"
+         dd if=/dev/zero bs=4096 count={TX_PAGES} 2>/dev/null >&3; cat /proc/interrupts"
     );
     let snapshots = cmd!(sh, "sh -c {script}").read().await?;
     let (interrupts, interrupts_after) = snapshots


### PR DESCRIPTION
Clean cherry pick of PR #4186

Write a larger amount of data to the serial device to ensure that it triggers interrupts as needed.
