### PR TITLE
openvmm: support aarch64 UEFI without Hyper-V hypervisor enlightenments

### DIFF
--- a/Guide/src/reference/openvmm/management/cli.md
+++ b/Guide/src/reference/openvmm/management/cli.md
@@ -51,6 +51,10 @@ as well as the generated CLI help (via `cargo run -- --help`).
 * `--hv`: Exposes Hyper-V enlightenments. VMBus is enabled by default
   when `--hv` is active; pass `--no-vmbus` to suppress VMBus while keeping
   enlightenments.
+* `--no-hv`: Boots AArch64 UEFI without exposing Hyper-V enlightenments.
+  By default, UEFI exposes the enlightenments. This option requires
+  `--no-vmbus`, is not supported for x86_64 UEFI, and conflicts with `--hv`,
+  `--vtl2`, `--get`, and `--pcat`.
 * `--no-vmbus`: Disables the VMBus server and all VMBus devices, even when
   `--hv` or `--uefi` is active. The guest boots using only standard PCIe
   devices and virtio transports. Incompatible with `--disk`, `--pcat`,

--- a/openvmm/openvmm_core/src/worker/dispatch.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch.rs
@@ -3212,6 +3212,7 @@ impl LoadedVmInner {
                 bios_guid,
                 enable_vmbus,
                 force_dma_bounce,
+                enable_hv,
             } => {
                 let acpi_tables = [
                     // MADT
@@ -3248,6 +3249,7 @@ impl LoadedVmInner {
                     bios_guid,
                     vmbus: enable_vmbus,
                     force_dma_bounce,
+                    hv: enable_hv,
                 };
                 let regs =
                     super::vm_loaders::uefi::load_uefi(&super::vm_loaders::uefi::LoadUefiParams {

--- a/openvmm/openvmm_core/src/worker/dispatch.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch.rs
@@ -2136,9 +2136,13 @@ impl InitializedVm {
                     cxl,
                     vnode: rc.vnode,
                     preserve_bars: rc.preserve_bars,
-                    // A request to pin BARs (GPA = HPA) also requires the guest
-                    // to leave the firmware's boot configuration alone.
-                    preserve_boot_config: rc.preserve_bars,
+                    // OpenVMM assigns PCI resources before loading UEFI and
+                    // tells the firmware to use that configuration. Tell the
+                    // guest OS to preserve it as well; otherwise Linux may
+                    // transiently program overlapping BARs while reallocating
+                    // resources, which the device model cannot map.
+                    preserve_boot_config: rc.preserve_bars
+                        || matches!(&cfg.load_mode, LoadMode::Uefi { .. }),
                 });
 
                 pcie_root_complexes.push(root_complex.clone());

--- a/openvmm/openvmm_core/src/worker/dispatch.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch.rs
@@ -2136,11 +2136,10 @@ impl InitializedVm {
                     cxl,
                     vnode: rc.vnode,
                     preserve_bars: rc.preserve_bars,
-                    // OpenVMM assigns PCI resources before loading UEFI and
-                    // tells the firmware to use that configuration. Tell the
-                    // guest OS to preserve it as well; otherwise Linux may
-                    // transiently program overlapping BARs while reallocating
-                    // resources, which the device model cannot map.
+                    // Pinned BARs require the guest to preserve their assigned
+                    // addresses. UEFI also consumes OpenVMM's preassigned PCI
+                    // configuration, so tell the guest OS not to reallocate it
+                    // and transiently overlap BAR mappings.
                     preserve_boot_config: rc.preserve_bars
                         || matches!(&cfg.load_mode, LoadMode::Uefi { .. }),
                 });

--- a/openvmm/openvmm_core/src/worker/vm_loaders/uefi.rs
+++ b/openvmm/openvmm_core/src/worker/vm_loaders/uefi.rs
@@ -50,6 +50,8 @@ pub struct UefiLoadSettings {
     pub vmbus: bool,
     /// Force UEFI to bounce-buffer all DMA traffic.
     pub force_dma_bounce: bool,
+    /// Whether the hypervisor (HV#1) enlightenments are exposed to the guest.
+    pub hv: bool,
 }
 
 /// All inputs needed by [`load_uefi`].
@@ -222,6 +224,7 @@ pub fn load_uefi(params: &LoadUefiParams<'_>) -> Result<Vec<Register>, Error> {
         &mut loader,
         image,
         loader::uefi::ConfigType::ConfigBlob(cfg),
+        settings.hv,
     )
     .map_err(Error::Loader)?;
 

--- a/openvmm/openvmm_defs/src/config.rs
+++ b/openvmm/openvmm_defs/src/config.rs
@@ -141,6 +141,7 @@ pub enum LoadMode {
         bios_guid: Guid,
         enable_vmbus: bool,
         force_dma_bounce: bool,
+        enable_hv: bool,
     },
     Pcat {
         firmware: RomFileLocation,

--- a/openvmm/openvmm_entry/src/cli_args.rs
+++ b/openvmm/openvmm_entry/src/cli_args.rs
@@ -279,6 +279,11 @@ Examples:
     #[clap(long)]
     pub hv: bool,
 
+    /// Boot UEFI without exposing hypervisor (HV#1) enlightenments. Requires
+    /// `--no-vmbus` since VMBus depends on the hypervisor.
+    #[clap(long, requires("no_vmbus"), conflicts_with_all = ["hv", "vtl2", "get", "pcat"])]
+    pub no_hv: bool,
+
     /// Use a full device tree instead of ACPI tables for ARM64 Linux direct
     /// boot. By default, ARM64 uses ACPI mode (stub DT + EFI + ACPI tables).
     /// This flag selects the legacy DT-only path. Rejected on x86.
@@ -4827,6 +4832,17 @@ mod tests {
             com1.backend,
             SerialConfigCli::Tcp("127.0.0.1:5555".parse().unwrap())
         );
+    }
+
+    #[test]
+    fn test_no_hv_requires_no_vmbus() {
+        assert!(Options::try_parse_from(["openvmm", "--no-hv"]).is_err());
+
+        let opt = Options::try_parse_from(["openvmm", "--no-hv", "--no-vmbus"]).unwrap();
+        assert!(opt.no_hv);
+        assert!(opt.no_vmbus);
+
+        assert!(Options::try_parse_from(["openvmm", "--no-hv", "--no-vmbus", "--hv"]).is_err());
     }
 
     #[test]

--- a/openvmm/openvmm_entry/src/cli_args.rs
+++ b/openvmm/openvmm_entry/src/cli_args.rs
@@ -281,7 +281,11 @@ Examples:
 
     /// Boot UEFI without exposing hypervisor (HV#1) enlightenments. Requires
     /// `--no-vmbus` since VMBus depends on the hypervisor.
-    #[clap(long, requires("no_vmbus"), conflicts_with_all = ["hv", "vtl2", "get", "pcat"])]
+    #[clap(
+        long,
+        requires_all = ["uefi", "no_vmbus"],
+        conflicts_with_all = ["hv", "vtl2", "get", "pcat", "igvm"]
+    )]
     pub no_hv: bool,
 
     /// Use a full device tree instead of ACPI tables for ARM64 Linux direct
@@ -4838,11 +4842,14 @@ mod tests {
     fn test_no_hv_requires_no_vmbus() {
         assert!(Options::try_parse_from(["openvmm", "--no-hv"]).is_err());
 
-        let opt = Options::try_parse_from(["openvmm", "--no-hv", "--no-vmbus"]).unwrap();
+        let opt = Options::try_parse_from(["openvmm", "--uefi", "--no-hv", "--no-vmbus"]).unwrap();
         assert!(opt.no_hv);
         assert!(opt.no_vmbus);
 
-        assert!(Options::try_parse_from(["openvmm", "--no-hv", "--no-vmbus", "--hv"]).is_err());
+        assert!(
+            Options::try_parse_from(["openvmm", "--uefi", "--no-hv", "--no-vmbus", "--hv"])
+                .is_err()
+        );
     }
 
     #[test]

--- a/openvmm/openvmm_entry/src/lib.rs
+++ b/openvmm/openvmm_entry/src/lib.rs
@@ -1279,9 +1279,7 @@ async fn vm_config_from_command_line(
         use openvmm_defs::config::UefiConsoleMode;
 
         if opt.no_hv && cfg!(guest_arch = "x86_64") {
-            anyhow::bail!(
-                "--no-hv is not supported on x86_64"
-            );
+            anyhow::bail!("--no-hv is not supported on x86_64");
         }
 
         with_hv = !opt.no_hv;

--- a/openvmm/openvmm_entry/src/lib.rs
+++ b/openvmm/openvmm_entry/src/lib.rs
@@ -1280,7 +1280,7 @@ async fn vm_config_from_command_line(
 
         if opt.no_hv && cfg!(guest_arch = "x86_64") {
             anyhow::bail!(
-                "--no-hv is not supported on x86_64; the firmware always runs under Hyper-V"
+                "--no-hv is not supported on x86_64"
             );
         }
 

--- a/openvmm/openvmm_entry/src/lib.rs
+++ b/openvmm/openvmm_entry/src/lib.rs
@@ -1278,7 +1278,13 @@ async fn vm_config_from_command_line(
     } else if opt.uefi {
         use openvmm_defs::config::UefiConsoleMode;
 
-        with_hv = true;
+        if opt.no_hv && cfg!(guest_arch = "x86_64") {
+            anyhow::bail!(
+                "--no-hv is not supported on x86_64; the firmware always runs under Hyper-V"
+            );
+        }
+
+        with_hv = !opt.no_hv;
 
         let firmware = fs_err::File::open(
             (opt.uefi_firmware.0)
@@ -1308,6 +1314,7 @@ async fn vm_config_from_command_line(
             bios_guid,
             enable_vmbus: !opt.no_vmbus,
             force_dma_bounce: opt.uefi_force_dma_bounce,
+            enable_hv: !opt.no_hv,
         };
     } else {
         // Linux Direct

--- a/openvmm/openvmm_entry/src/ttrpc/mod.rs
+++ b/openvmm/openvmm_entry/src/ttrpc/mod.rs
@@ -805,6 +805,7 @@ impl VmService {
                         enable_vpci_boot: false,
                         default_boot_always_attempt: false,
                         force_dma_bounce: false,
+                        enable_hv: true,
                     },
                     vm_manifest_builder::BaseChipsetType::HypervGen2Uefi,
                     Some((base_template_json, uefi.secure_boot_enabled)),

--- a/petri/src/vm/mod.rs
+++ b/petri/src/vm/mod.rs
@@ -406,10 +406,9 @@ pub(crate) const PETRI_NVME_BOOT_VTL0_CONTROLLER: Guid =
 pub(crate) const PETRI_NVME_BOOT_VTL2_CONTROLLER: Guid =
     guid::guid!("92bc8346-718b-449a-8751-edbf3dcd27e4");
 
-/// PCIe root port used by Petri for the agent/cidata disk when there is no
-/// existing PCIe NVMe controller (no-vmbus mode).
+/// PCIe root port used by Petri for the agent/cidata disk (no-vmbus mode)
 pub(crate) const PETRI_PCIE_NVME_AGENT_PORT: &str = "s0rc0rp1";
-/// Default NVMe namespace ID used by Petri for the agent/cidata disk.
+/// NVMe namespace ID used by Petri for the agent/cidata disk (no-vmbus mode)
 pub(crate) const PETRI_PCIE_NVME_AGENT_NSID: u32 = 1;
 
 /// A constructed Petri VM
@@ -840,27 +839,9 @@ impl<T: PetriVmmBackend> PetriVmBuilder<T> {
         // When VMBus is disabled, route the agent disk through PCIe NVMe
         // instead of VMBus SCSI.
         if self.no_vmbus {
-            let (port_name, nsid) = if let Some(controller) = self.config.pcie_nvme_drives.first() {
-                let nsid = self
-                    .config
-                    .pcie_nvme_drives
-                    .iter()
-                    .filter(|drive| drive.port_name == controller.port_name)
-                    .map(|drive| drive.nsid)
-                    .max()
-                    .unwrap()
-                    .checked_add(1)
-                    .expect("PCIe NVMe namespace ID overflow");
-                (controller.port_name.clone(), nsid)
-            } else {
-                (
-                    PETRI_PCIE_NVME_AGENT_PORT.into(),
-                    PETRI_PCIE_NVME_AGENT_NSID,
-                )
-            };
             self.config.pcie_nvme_drives.push(PcieNvmeDrive {
-                port_name,
-                nsid,
+                port_name: PETRI_PCIE_NVME_AGENT_PORT.into(),
+                nsid: PETRI_PCIE_NVME_AGENT_NSID,
                 drive: Drive::new(
                     Some(Disk::Temporary(Arc::new(agent_disk.into_temp_path()))),
                     false,

--- a/petri/src/vm/mod.rs
+++ b/petri/src/vm/mod.rs
@@ -190,6 +190,8 @@ pub struct PetriVmBuilder<T: PetriVmmBackend> {
     vhost_vsock_guest_cid: Option<u32>,
     // Disable VMBus entirely (no vmbus server, no vmbus storage controllers).
     no_vmbus: bool,
+    // Disable the hypervisor (HV#1) enlightenments. Implies `no_vmbus`.
+    no_hv: bool,
 }
 
 impl<T: PetriVmmBackend> Debug for PetriVmBuilder<T> {
@@ -213,6 +215,7 @@ impl<T: PetriVmmBackend> Debug for PetriVmBuilder<T> {
             .field("prebuilt_initrd", &self.prebuilt_initrd)
             .field("use_virtio_vsock", &self.use_virtio_vsock)
             .field("no_vmbus", &self.no_vmbus)
+            .field("no_hv", &self.no_hv)
             .finish()
     }
 }
@@ -312,6 +315,8 @@ pub struct PetriVmProperties {
     pub vhost_vsock_guest_cid: Option<u32>,
     /// VMBus is entirely disabled
     pub no_vmbus: bool,
+    /// The hypervisor (HV#1) enlightenments are entirely disabled
+    pub no_hv: bool,
 }
 
 /// VM configuration that can be changed after the VM is created
@@ -401,9 +406,10 @@ pub(crate) const PETRI_NVME_BOOT_VTL0_CONTROLLER: Guid =
 pub(crate) const PETRI_NVME_BOOT_VTL2_CONTROLLER: Guid =
     guid::guid!("92bc8346-718b-449a-8751-edbf3dcd27e4");
 
-/// PCIe root port used by Petri for the agent/cidata disk (no-vmbus mode)
+/// PCIe root port used by Petri for the agent/cidata disk when there is no
+/// existing PCIe NVMe controller (no-vmbus mode).
 pub(crate) const PETRI_PCIE_NVME_AGENT_PORT: &str = "s0rc0rp1";
-/// NVMe namespace ID used by Petri for the agent/cidata disk (no-vmbus mode)
+/// Default NVMe namespace ID used by Petri for the agent/cidata disk.
 pub(crate) const PETRI_PCIE_NVME_AGENT_NSID: u32 = 1;
 
 /// A constructed Petri VM
@@ -488,6 +494,7 @@ impl<T: PetriVmmBackend> PetriVmBuilder<T> {
             #[cfg(target_os = "linux")]
             vhost_vsock_guest_cid: None,
             no_vmbus: false,
+            no_hv: false,
         }
         .add_petri_scsi_controllers()
         .add_guest_crash_disk(params.post_test_hooks))
@@ -568,6 +575,7 @@ impl<T: PetriVmmBackend> PetriVmBuilder<T> {
             #[cfg(target_os = "linux")]
             vhost_vsock_guest_cid: None,
             no_vmbus: false,
+            no_hv: false,
         })
     }
 
@@ -715,6 +723,16 @@ impl<T: PetriVmmBackend> PetriVmBuilder<T> {
         self
     }
 
+    /// Disable the hypervisor (HV#1) enlightenments.
+    ///
+    /// This also disables VMBus, since VMBus depends on the hypervisor. On
+    /// aarch64 UEFI this causes the loader to pass the generic SEC platform
+    /// type to the firmware. This mode is not supported on x86_64 UEFI.
+    pub fn with_no_hv(mut self) -> Self {
+        self.no_hv = true;
+        self.with_no_vmbus()
+    }
+
     fn add_petri_scsi_controllers(self) -> Self {
         let builder = self.add_vmbus_storage_controller(
             &PETRI_SCSI_VTL0_CONTROLLER,
@@ -822,9 +840,27 @@ impl<T: PetriVmmBackend> PetriVmBuilder<T> {
         // When VMBus is disabled, route the agent disk through PCIe NVMe
         // instead of VMBus SCSI.
         if self.no_vmbus {
+            let (port_name, nsid) = if let Some(controller) = self.config.pcie_nvme_drives.first() {
+                let nsid = self
+                    .config
+                    .pcie_nvme_drives
+                    .iter()
+                    .filter(|drive| drive.port_name == controller.port_name)
+                    .map(|drive| drive.nsid)
+                    .max()
+                    .unwrap()
+                    .checked_add(1)
+                    .expect("PCIe NVMe namespace ID overflow");
+                (controller.port_name.clone(), nsid)
+            } else {
+                (
+                    PETRI_PCIE_NVME_AGENT_PORT.into(),
+                    PETRI_PCIE_NVME_AGENT_NSID,
+                )
+            };
             self.config.pcie_nvme_drives.push(PcieNvmeDrive {
-                port_name: PETRI_PCIE_NVME_AGENT_PORT.into(),
-                nsid: PETRI_PCIE_NVME_AGENT_NSID,
+                port_name,
+                nsid,
                 drive: Drive::new(
                     Some(Disk::Temporary(Arc::new(agent_disk.into_temp_path()))),
                     false,
@@ -1027,6 +1063,7 @@ impl<T: PetriVmmBackend> PetriVmBuilder<T> {
             #[cfg(target_os = "linux")]
             vhost_vsock_guest_cid: self.vhost_vsock_guest_cid,
             no_vmbus: self.no_vmbus,
+            no_hv: self.no_hv,
         }
     }
 

--- a/petri/src/vm/openvmm/construct.rs
+++ b/petri/src/vm/openvmm/construct.rs
@@ -76,6 +76,7 @@ use serial_16550_resources::ComPort;
 use serial_core::resources::DisconnectedSerialBackendHandle;
 use serial_socket::net::OpenSocketSerialConfig;
 use sparse_mmap::alloc_shared_memory;
+use std::collections::BTreeMap;
 use std::collections::HashMap;
 use storvsp_resources::ScsiControllerHandle;
 use storvsp_resources::ScsiDeviceAndPath;
@@ -156,6 +157,7 @@ impl PetriVmConfigOpenVmm {
             enable_serial: properties.enable_serial,
             use_virtio_vsock: properties.use_virtio_vsock,
             no_vmbus: properties.no_vmbus,
+            no_hv: properties.no_hv,
         };
 
         let mut chipset = VmManifestBuilder::new(
@@ -231,6 +233,7 @@ impl PetriVmConfigOpenVmm {
             vmbus_storage_controllers_to_openvmm(&vmbus_storage_controllers).await?;
 
         let mut pcie_devices = Vec::new();
+        let mut pcie_nvme_controllers = BTreeMap::<String, Vec<NamespaceDefinition>>::new();
         for PcieNvmeDrive {
             port_name,
             nsid,
@@ -243,17 +246,25 @@ impl PetriVmConfigOpenVmm {
                 )
             })?;
             let disk = petri_disk_to_openvmm(&disk).await?;
+            let namespaces = pcie_nvme_controllers.entry(port_name).or_default();
+            anyhow::ensure!(
+                namespaces.iter().all(|namespace| namespace.nsid != nsid),
+                "duplicate PCIe NVMe namespace ID {nsid}"
+            );
+            namespaces.push(NamespaceDefinition {
+                nsid,
+                read_only: false,
+                disk,
+            });
+        }
+        for (port_name, namespaces) in pcie_nvme_controllers {
             pcie_devices.push(PcieDeviceConfig {
                 port_name,
                 resource: NvmeControllerHandle {
                     subsystem_id: Guid::new_random(),
                     max_io_queues: 64,
                     msix_count: 64,
-                    namespaces: vec![NamespaceDefinition {
-                        nsid,
-                        read_only: false,
-                        disk,
-                    }],
+                    namespaces,
                     requests: None,
                 }
                 .into_resource(),
@@ -655,7 +666,7 @@ impl PetriVmConfigOpenVmm {
 
             // Basic virtualization device support
             hypervisor: HypervisorConfig {
-                with_hv: true,
+                with_hv: !properties.no_hv,
                 with_vtl2,
                 with_isolation: match firmware.isolation() {
                     Some(IsolationType::Vbs) => Some(openvmm_defs::config::IsolationType::Vbs),
@@ -781,6 +792,7 @@ struct PetriVmConfigSetupCore<'a> {
     enable_serial: bool,
     use_virtio_vsock: bool,
     no_vmbus: bool,
+    no_hv: bool,
 }
 
 struct SerialData {
@@ -963,6 +975,7 @@ impl PetriVmConfigSetupCore<'_> {
                     bios_guid: Guid::new_random(),
                     enable_vmbus: !self.no_vmbus,
                     force_dma_bounce: *force_dma_bounce,
+                    enable_hv: !self.no_hv,
                 }
             }
             (

--- a/petri/src/vm/openvmm/construct.rs
+++ b/petri/src/vm/openvmm/construct.rs
@@ -76,7 +76,6 @@ use serial_16550_resources::ComPort;
 use serial_core::resources::DisconnectedSerialBackendHandle;
 use serial_socket::net::OpenSocketSerialConfig;
 use sparse_mmap::alloc_shared_memory;
-use std::collections::BTreeMap;
 use std::collections::HashMap;
 use storvsp_resources::ScsiControllerHandle;
 use storvsp_resources::ScsiDeviceAndPath;
@@ -233,7 +232,6 @@ impl PetriVmConfigOpenVmm {
             vmbus_storage_controllers_to_openvmm(&vmbus_storage_controllers).await?;
 
         let mut pcie_devices = Vec::new();
-        let mut pcie_nvme_controllers = BTreeMap::<String, Vec<NamespaceDefinition>>::new();
         for PcieNvmeDrive {
             port_name,
             nsid,
@@ -246,25 +244,17 @@ impl PetriVmConfigOpenVmm {
                 )
             })?;
             let disk = petri_disk_to_openvmm(&disk).await?;
-            let namespaces = pcie_nvme_controllers.entry(port_name).or_default();
-            anyhow::ensure!(
-                namespaces.iter().all(|namespace| namespace.nsid != nsid),
-                "duplicate PCIe NVMe namespace ID {nsid}"
-            );
-            namespaces.push(NamespaceDefinition {
-                nsid,
-                read_only: false,
-                disk,
-            });
-        }
-        for (port_name, namespaces) in pcie_nvme_controllers {
             pcie_devices.push(PcieDeviceConfig {
                 port_name,
                 resource: NvmeControllerHandle {
                     subsystem_id: Guid::new_random(),
                     max_io_queues: 64,
                     msix_count: 64,
-                    namespaces,
+                    namespaces: vec![NamespaceDefinition {
+                        nsid,
+                        read_only: false,
+                        disk,
+                    }],
                     requests: None,
                 }
                 .into_resource(),

--- a/petri/src/vm/openvmm/construct.rs
+++ b/petri/src/vm/openvmm/construct.rs
@@ -948,6 +948,10 @@ impl PetriVmConfigSetupCore<'_> {
                         },
                 },
             ) => {
+                anyhow::ensure!(
+                    !(self.no_hv && self.arch == MachineArch::X86_64),
+                    "x86_64 UEFI firmware requires Hyper-V enlightenments"
+                );
                 let firmware = File::open(firmware.clone())
                     .context("Failed to open uefi firmware file")?
                     .into();

--- a/vm/loader/igvmfilegen/src/main.rs
+++ b/vm/loader/igvmfilegen/src/main.rs
@@ -1220,7 +1220,7 @@ impl IgvmfilegenRegister for X86Register {
         image: &[u8],
         config: loader::uefi::ConfigType,
     ) -> Result<loader::uefi::LoadInfo, loader::uefi::Error> {
-        loader::uefi::x86_64::load(importer, image, config)
+        loader::uefi::x86_64::load(importer, image, config, true)
     }
 
     fn load_linux_kernel_and_initrd<F>(
@@ -1277,7 +1277,7 @@ impl IgvmfilegenRegister for Aarch64Register {
         image: &[u8],
         config: loader::uefi::ConfigType,
     ) -> Result<loader::uefi::LoadInfo, loader::uefi::Error> {
-        loader::uefi::aarch64::load(importer, image, config)
+        loader::uefi::aarch64::load(importer, image, config, true)
     }
 
     fn load_linux_kernel_and_initrd<F>(

--- a/vm/loader/loader_defs/src/lib.rs
+++ b/vm/loader/loader_defs/src/lib.rs
@@ -9,3 +9,4 @@
 pub mod linux;
 pub mod paravisor;
 pub mod shim;
+pub mod uefi;

--- a/vm/loader/loader_defs/src/uefi.rs
+++ b/vm/loader/loader_defs/src/uefi.rs
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Definitions for loading the MSVM UEFI firmware.
+
+use open_enum::open_enum;
+
+open_enum! {
+    /// SEC platform type passed by the loader to the firmware in `x2` at SEC
+    /// entry on aarch64. Mirrors `MSVM_SEC_PLATFORM_TYPE` in the mu_msvm
+    /// firmware (`MsvmPkg/Include/Ppi/SecPlatformType.h`).
+    pub enum SecPlatformType: u64 {
+        /// Hyper-V with Microsoft extensions.
+        HYPERV = 0,
+        /// Generic virtualization without Microsoft hypervisor extensions.
+        GENERIC = 1,
+    }
+}

--- a/vm/loader/src/uefi/mod.rs
+++ b/vm/loader/src/uefi/mod.rs
@@ -330,6 +330,8 @@ pub enum Error {
     InvalidSharedGpaBoundary,
     #[error("Invalid config type")]
     InvalidConfigType(String),
+    #[error("x86_64 UEFI firmware requires the hypervisor to be enabled")]
+    HvRequired,
     #[error("Importer error")]
     Importer(#[source] anyhow::Error),
     #[error("PageTableBuilder: {0}")]
@@ -389,11 +391,19 @@ pub mod x86_64 {
     pub const CONFIG_BLOB_GPA_BASE: u64 = MISC_PAGES_GPA_BASE + MISC_PAGES_SIZE; // 0x709000
 
     /// Load a UEFI image with the provided config type.
+    ///
+    /// On x86_64 the firmware always runs under Hyper-V, so `hv_enabled` must
+    /// be `true`.
     pub fn load(
         importer: &mut dyn ImageLoad<X86Register>,
         image: &[u8],
         config: ConfigType,
+        hv_enabled: bool,
     ) -> Result<LoadInfo, Error> {
+        if !hv_enabled {
+            return Err(Error::HvRequired);
+        }
+
         if image.len() != IMAGE_SIZE as usize {
             return Err(Error::InvalidImageSize);
         }
@@ -873,10 +883,15 @@ pub mod aarch64 {
     pub const CONFIG_BLOB_GPA_BASE: u64 = 0x824000;
 
     /// Load a UEFI image with the provided config type.
+    ///
+    /// `hv_enabled` selects the SEC platform type passed to the firmware in
+    /// `x2`: Hyper-V when enlightenments are exposed, or generic when they are
+    /// not.
     pub fn load(
         importer: &mut dyn ImageLoad<Aarch64Register>,
         image: &[u8],
         config: ConfigType,
+        hv_enabled: bool,
     ) -> Result<LoadInfo, Error> {
         if image.len() != IMAGE_SIZE as usize {
             return Err(Error::InvalidImageSize);
@@ -957,6 +972,12 @@ pub mod aarch64 {
         import_reg(Aarch64Register::X0(0x1000))?;
         import_reg(Aarch64Register::Pc(0x1000))?;
         import_reg(Aarch64Register::X1(stack_end))?;
+        let platform_type = if hv_enabled {
+            loader_defs::uefi::SecPlatformType::HYPERV
+        } else {
+            loader_defs::uefi::SecPlatformType::GENERIC
+        };
+        import_reg(Aarch64Register::X2(platform_type.0))?;
 
         import_reg(Aarch64Register::Ttbr0El1(page_table_offset))?;
 

--- a/vmm_tests/vmm_tests/tests/tests/multiarch.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch.rs
@@ -19,6 +19,7 @@ use petri_artifacts_common::tags::MachineArch;
 use petri_artifacts_common::tags::OsFlavor;
 #[cfg(target_os = "linux")]
 use petri_artifacts_vmm_test::artifacts::OPENVMM_VHOST_NATIVE;
+use std::mem::size_of;
 use vmm_test_macros::openvmm_test;
 use vmm_test_macros::vmm_test;
 use vmm_test_macros::vmm_test_with;
@@ -170,7 +171,7 @@ async fn boot_no_vmbus(config: PetriVmBuilder<OpenVmmPetriBackend>) -> anyhow::R
 /// pipette transport because VMBus is off. Keeping separate controllers also
 /// verifies that the guest preserves OpenVMM's preassigned PCI resources.
 /// The `_aarch64_tcg` suffix opts the test into the QEMU incubator CI pass.
-/// The normal Windows AArch64 CI pass uses `all()`, so it runs there as well.
+#[cfg(target_os = "linux")]
 #[openvmm_test(uefi_aarch64(vhd(alpine_3_23_aarch64)))]
 #[openvmm_test(uefi_aarch64(vhd(ubuntu_2404_server_aarch64)))]
 async fn boot_no_hv_uefi_aarch64_tcg(
@@ -196,14 +197,15 @@ async fn boot_no_hv_uefi_aarch64_tcg(
         hyperv_detection_lines.join("\n")
     );
 
-    // ACPI FADT offset 268 is the 8-byte hypervisor vendor identity. A zero
-    // value confirms that OpenVMM did not describe Hyper-V to the guest.
-    const FADT_HYPERVISOR_VENDOR_ID_OFFSET: usize = 268;
     let facp = shell
         .read_file_raw("/sys/firmware/acpi/tables/FACP")
         .await?;
+    let vendor_id_offset = facp
+        .len()
+        .checked_sub(size_of::<u64>())
+        .context("FADT is too short to contain the hypervisor vendor identity")?;
     let vendor_id = u64::from_le_bytes(
-        facp.get(FADT_HYPERVISOR_VENDOR_ID_OFFSET..FADT_HYPERVISOR_VENDOR_ID_OFFSET + 8)
+        facp.get(vendor_id_offset..)
             .context("FADT is missing the hypervisor vendor identity")?
             .try_into()
             .context("invalid FADT hypervisor vendor identity length")?,

--- a/vmm_tests/vmm_tests/tests/tests/multiarch.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch.rs
@@ -19,6 +19,7 @@ use petri_artifacts_common::tags::MachineArch;
 use petri_artifacts_common::tags::OsFlavor;
 #[cfg(target_os = "linux")]
 use petri_artifacts_vmm_test::artifacts::OPENVMM_VHOST_NATIVE;
+#[cfg(target_os = "linux")]
 use std::mem::size_of;
 use vmm_test_macros::openvmm_test;
 use vmm_test_macros::vmm_test;

--- a/vmm_tests/vmm_tests/tests/tests/multiarch.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch.rs
@@ -166,8 +166,9 @@ async fn boot_no_vmbus(config: PetriVmBuilder<OpenVmmPetriBackend>) -> anyhow::R
 ///
 /// The loader must pass the generic SEC platform type in `x2`, allowing the
 /// firmware to avoid Hyper-V-specific facilities. PCIe NVMe provides the boot
-/// and CIDATA disks as separate namespaces, and virtio-vsock provides the
-/// pipette transport because VMBus is off.
+/// and CIDATA disks on separate controllers, and virtio-vsock provides the
+/// pipette transport because VMBus is off. Keeping separate controllers also
+/// verifies that the guest preserves OpenVMM's preassigned PCI resources.
 /// The `_aarch64_tcg` suffix opts the test into the QEMU incubator CI pass.
 /// The normal Windows AArch64 CI pass uses `all()`, so it runs there as well.
 #[openvmm_test(uefi_aarch64(vhd(alpine_3_23_aarch64)))]
@@ -179,7 +180,7 @@ async fn boot_no_hv_uefi_aarch64_tcg(
         .with_no_hv()
         .with_boot_device_type(petri::BootDeviceType::PcieNvme)
         .with_default_boot_always_attempt(true)
-        .modify_backend(|b| b.with_pcie_root_topology(1, 1, 2))
+        .modify_backend(|b| b.with_pcie_root_topology(1, 1, 3))
         .run()
         .await?;
 

--- a/vmm_tests/vmm_tests/tests/tests/multiarch.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch.rs
@@ -162,6 +162,58 @@ async fn boot_no_vmbus(config: PetriVmBuilder<OpenVmmPetriBackend>) -> anyhow::R
     Ok(())
 }
 
+/// Boot a small aarch64 Linux guest via UEFI without Hyper-V enlightenments.
+///
+/// The loader must pass the generic SEC platform type in `x2`, allowing the
+/// firmware to avoid Hyper-V-specific facilities. PCIe NVMe provides the boot
+/// and CIDATA disks as separate namespaces, and virtio-vsock provides the
+/// pipette transport because VMBus is off.
+/// The `_aarch64_tcg` suffix opts the test into the QEMU incubator CI pass.
+/// The normal Windows AArch64 CI pass uses `all()`, so it runs there as well.
+#[openvmm_test(uefi_aarch64(vhd(alpine_3_23_aarch64)))]
+#[openvmm_test(uefi_aarch64(vhd(ubuntu_2404_server_aarch64)))]
+async fn boot_no_hv_uefi_aarch64_tcg(
+    config: PetriVmBuilder<OpenVmmPetriBackend>,
+) -> anyhow::Result<()> {
+    let (vm, agent) = config
+        .with_no_hv()
+        .with_boot_device_type(petri::BootDeviceType::PcieNvme)
+        .with_default_boot_always_attempt(true)
+        .modify_backend(|b| b.with_pcie_root_topology(1, 1, 2))
+        .run()
+        .await?;
+
+    let shell = agent.unix_shell();
+    let dmesg = cmd!(shell, "dmesg").read().await?;
+    let hyperv_detection_lines: Vec<_> = dmesg
+        .lines()
+        .filter(|line| line.contains("Hyper-V:") || line.contains("Microsoft Hyper-V"))
+        .collect();
+    assert!(
+        hyperv_detection_lines.is_empty(),
+        "guest detected Hyper-V despite no-hv configuration:\n{}",
+        hyperv_detection_lines.join("\n")
+    );
+
+    // ACPI FADT offset 268 is the 8-byte hypervisor vendor identity. A zero
+    // value confirms that OpenVMM did not describe Hyper-V to the guest.
+    const FADT_HYPERVISOR_VENDOR_ID_OFFSET: usize = 268;
+    let facp = shell
+        .read_file_raw("/sys/firmware/acpi/tables/FACP")
+        .await?;
+    let vendor_id = u64::from_le_bytes(
+        facp.get(FADT_HYPERVISOR_VENDOR_ID_OFFSET..FADT_HYPERVISOR_VENDOR_ID_OFFSET + 8)
+            .context("FADT is missing the hypervisor vendor identity")?
+            .try_into()
+            .context("invalid FADT hypervisor vendor identity length")?,
+    );
+    assert_eq!(vendor_id, 0, "guest FADT advertised a hypervisor vendor");
+
+    agent.power_off().await?;
+    vm.wait_for_clean_teardown().await?;
+    Ok(())
+}
+
 /// Verify that the Linux direct loader synthesizes SMBIOS (DMI) tables so the
 /// guest can read `/sys/class/dmi/id/*`. The two architectures exercise
 /// different delivery paths for the same `_SM3_` entry point: on x86 the kernel


### PR DESCRIPTION
We added support in UEFI to not expose hv enlightenments, but did not plumb thru the value when --no-hv was specified. Pass this info to UEFI, and add new vmm_tests to test this. 