### PR TITLE
Temporary diagnotics for SNP: Add import regions hash and cache diagnostics on initrd CRC hash mismatch 

### DIFF
--- a/openhcl/openhcl_boot/src/arch/x86_64/memory.rs
+++ b/openhcl/openhcl_boot/src/arch/x86_64/memory.rs
@@ -15,7 +15,9 @@ use crate::hypercall::hvcall;
 use crate::memory::AllocationPolicy;
 use crate::memory::AllocationType;
 use crate::off_stack;
+use crate::single_threaded::SingleThreaded;
 use arrayvec::ArrayVec;
+use core::cell::RefCell;
 use loader_defs::shim::MemoryVtlType;
 use memory_range::MemoryRange;
 use page_table::x64::MappedRange;
@@ -29,6 +31,263 @@ use static_assertions::const_assert;
 use x86defs::X64_LARGE_PAGE_SIZE;
 use x86defs::tdx::TDX_SHARED_GPA_BOUNDARY_ADDRESS_BIT;
 use zerocopy::FromZeros;
+
+// ============================================================================
+// Diagnostic instrumentation for the "Imported regions hash mismatch" panic.
+// ============================================================================
+//
+// This is a temporary debugging aid intended for local investigation of a rare
+// mismatch seen on SNP boots. It computes SHA-384 of every 2 MB accept chunk
+// at three points to isolate which phase corruption occurs in:
+//   Phase A: bytes as read from the shared (host-visible) page, before the
+//            shared -> private transition.
+//   Phase C: bytes as read from the same GPA immediately after the transition
+//            (via the C=1 identity map), i.e. after accept + copy-back.
+//   Phase D: bytes as read from the same GPA at final verify time.
+// A running combined Phase-A hash is also accumulated to compare against
+// `imported_regions_hash()` to distinguish "host loaded bad data" from
+// "shim mangled it".
+//
+// Not intended for check-in.
+
+/// Maximum number of 2 MB chunks we track. Debug builds hash roughly
+/// kernel + initrd (~80 MB), giving ~40 chunks; leave generous headroom.
+const DIAG_MAX_CHUNKS: usize = 256;
+
+#[derive(Copy, Clone)]
+struct DiagChunkHash {
+    gpa: u64,
+    len: u32,
+    phase_a_hash: [u8; 48],
+}
+
+static DIAG_CHUNK_HASHES: SingleThreaded<RefCell<ArrayVec<DiagChunkHash, DIAG_MAX_CHUNKS>>> =
+    SingleThreaded(RefCell::new(ArrayVec::new_const()));
+
+static DIAG_RUNNING_A: SingleThreaded<RefCell<Option<Sha384>>> =
+    SingleThreaded(RefCell::new(None));
+
+/// `core::fmt::Display` adapter that prints a byte slice as lowercase hex,
+/// no separators. Convenient for hashes in log lines.
+struct HexBytes<'a>(&'a [u8]);
+impl core::fmt::Display for HexBytes<'_> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        for b in self.0 {
+            write!(f, "{:02x}", b)?;
+        }
+        Ok(())
+    }
+}
+
+/// Record the Phase-A hash of a chunk that was just copied out of a shared
+/// page into `ram_buffer`. Also feeds the bytes into a running combined
+/// Phase-A hasher so it can be compared against `imported_regions_hash()`
+/// on final mismatch.
+fn diag_record_phase_a(gpa: u64, data: &[u8]) {
+    {
+        let mut running = DIAG_RUNNING_A.0.borrow_mut();
+        if running.is_none() {
+            *running = Some(Sha384::new());
+        }
+        running.as_mut().unwrap().update(data);
+    }
+
+    let mut h = Sha384::new();
+    h.update(data);
+    let hash: [u8; 48] = h.finalize().into();
+
+    let mut chunks = DIAG_CHUNK_HASHES.0.borrow_mut();
+    if chunks
+        .try_push(DiagChunkHash {
+            gpa,
+            len: data.len() as u32,
+            phase_a_hash: hash,
+        })
+        .is_err()
+    {
+        log::error!(
+            "DIAG_CHUNK_OVERFLOW gpa={:#x} len={:#x} (increase DIAG_MAX_CHUNKS)",
+            gpa,
+            data.len(),
+        );
+    }
+}
+
+/// Immediately after the shared -> private transition and copy-back, compare
+/// the same chunk (via the identity map) against the Phase-A bytes we captured
+/// before the transition. Logs eagerly on mismatch, including hex diffs of the
+/// first few differing 64-byte cache lines, so we know acceptance corrupted
+/// this chunk right when it happened and what the corruption looks like.
+fn diag_verify_phase_c(gpa: u64, pre: &[u8], post: &[u8]) {
+    if pre.len() != post.len() {
+        log::error!(
+            "DIAG_TRANSITION_LEN_MISMATCH gpa={:#x} pre_len={:#x} post_len={:#x}",
+            gpa,
+            pre.len(),
+            post.len(),
+        );
+        return;
+    }
+    if pre == post {
+        return;
+    }
+
+    let mut ha = Sha384::new();
+    ha.update(pre);
+    let hash_a: [u8; 48] = ha.finalize().into();
+    let mut hc = Sha384::new();
+    hc.update(post);
+    let hash_c: [u8; 48] = hc.finalize().into();
+
+    log::error!(
+        "DIAG_TRANSITION_MISMATCH gpa={:#x} len={:#x} phase_a={} phase_c={}",
+        gpa,
+        pre.len(),
+        HexBytes(&hash_a),
+        HexBytes(&hash_c),
+    );
+    diag_dump_first_diffs("DIAG_TRANSITION_DIFF", gpa, pre, post);
+}
+
+/// Log the first `MAX_DIFF_LINES` 64-byte cache lines that differ between
+/// `pre` and `post`, along with byte counts. Keeps log volume bounded even
+/// when the whole chunk differs.
+fn diag_dump_first_diffs(tag: &str, gpa: u64, pre: &[u8], post: &[u8]) {
+    const CACHE_LINE: usize = 64;
+    const MAX_DIFF_LINES: usize = 8;
+
+    debug_assert_eq!(pre.len(), post.len());
+
+    let mut total_diff_bytes: usize = 0;
+    let mut diff_lines: usize = 0;
+    let mut reported: usize = 0;
+
+    for (idx, (a, b)) in pre.chunks(CACHE_LINE).zip(post.chunks(CACHE_LINE)).enumerate() {
+        if a == b {
+            continue;
+        }
+        diff_lines += 1;
+        total_diff_bytes += a.iter().zip(b.iter()).filter(|(x, y)| x != y).count();
+
+        if reported < MAX_DIFF_LINES {
+            let offset = idx * CACHE_LINE;
+            log::error!(
+                "{} gpa={:#x} offset={:#x} pre={} post={}",
+                tag,
+                gpa,
+                offset,
+                HexBytes(a),
+                HexBytes(b),
+            );
+            reported += 1;
+        }
+    }
+
+    log::error!(
+        "{}_SUMMARY gpa={:#x} len={:#x} diff_cache_lines={} diff_bytes={} reported={}",
+        tag,
+        gpa,
+        pre.len(),
+        diff_lines,
+        total_diff_bytes,
+        reported,
+    );
+}
+
+/// Log the first `HEAD_BYTES` of the chunk at `gpa` as hex. Useful when only
+/// the current (Phase D) content is available, since it lets us see whether
+/// the offending chunk is all zeros, all 0xff, or otherwise recognisable
+/// (initrd cpio header, ELF magic, etc.) without exposing the whole chunk.
+fn diag_dump_head(tag: &str, gpa: u64, data: &[u8]) {
+    const HEAD_BYTES: usize = 128;
+    let head = &data[..data.len().min(HEAD_BYTES)];
+    log::error!(
+        "{} gpa={:#x} head_len={:#x} head={}",
+        tag,
+        gpa,
+        head.len(),
+        HexBytes(head),
+    );
+}
+
+/// Called from `verify_imported_regions_hash` when the combined Phase-D hash
+/// does not match the expected measured value. Reports:
+/// - Whether the running combined Phase-A hash matches expected. If it does,
+///   the host supplied correct bytes and something in the shim corrupted them.
+///   If it doesn't, the host loaded bad data.
+/// - Per-chunk Phase-D vs Phase-A comparison to identify which chunk(s) drifted
+///   between the shared read and the final verify.
+fn diag_report_phase_d(expected_combined: &[u8]) {
+    let combined_a = DIAG_RUNNING_A.0.borrow_mut().take().map(|h| {
+        let out: [u8; 48] = h.finalize().into();
+        out
+    });
+
+    match combined_a {
+        Some(combined_a) => {
+            if combined_a.as_slice() == expected_combined {
+                log::error!(
+                    "DIAG_VERDICT combined_phase_a matches expected: {} \
+                     (host-supplied shared data was correct; corruption occurred at or after acceptance)",
+                    HexBytes(&combined_a),
+                );
+            } else {
+                log::error!(
+                    "DIAG_VERDICT combined_phase_a differs from expected: \
+                     phase_a={} expected={} \
+                     (host loaded incorrect data into shared pages)",
+                    HexBytes(&combined_a),
+                    HexBytes(expected_combined),
+                );
+            }
+        }
+        None => {
+            log::error!("DIAG_VERDICT combined_phase_a not captured (no chunks recorded)");
+        }
+    }
+
+    let chunks = DIAG_CHUNK_HASHES.0.borrow();
+    let total = chunks.len();
+    let mut mismatches: usize = 0;
+    for (idx, c) in chunks.iter().enumerate() {
+        // SAFETY: The GPA and length were recorded from a range that the shim
+        // itself just accepted as private VTL2 RAM, and remain identity-mapped
+        // for the duration of the shim.
+        let data = unsafe { core::slice::from_raw_parts(c.gpa as *const u8, c.len as usize) };
+        let mut h = Sha384::new();
+        h.update(data);
+        let hash_d: [u8; 48] = h.finalize().into();
+        if hash_d != c.phase_a_hash {
+            mismatches += 1;
+            log::error!(
+                "DIAG_POST_ACCEPT_MISMATCH idx={} gpa={:#x} len={:#x} phase_a={} phase_d={}",
+                idx,
+                c.gpa,
+                c.len,
+                HexBytes(&c.phase_a_hash),
+                HexBytes(&hash_d),
+            );
+            // We no longer have the Phase-A bytes (they lived in `ram_buffer`
+            // which has been reused). Log the head of the current (Phase D)
+            // content so we can eyeball whether the chunk was zeroed,
+            // substituted, or contains plausible data.
+            diag_dump_head("DIAG_POST_ACCEPT_HEAD", c.gpa, data);
+        }
+    }
+    if mismatches == 0 {
+        log::error!(
+            "DIAG_VERDICT all {} tracked chunks unchanged phase_a -> phase_d \
+             (combined mismatch is likely a layout/order/hashing disagreement)",
+            total,
+        );
+    } else {
+        log::error!(
+            "DIAG_VERDICT {} of {} tracked chunks changed between phase_a and phase_d",
+            mismatches,
+            total,
+        );
+    }
+}
 
 /// On isolated systems, transitions all VTL2 RAM to be private and accepted, with the appropriate
 /// VTL permissions applied.
@@ -318,6 +577,12 @@ fn accept_pending_vtl2_memory(
                     }
                 }
 
+                // DIAG: record the SHA-384 of this chunk while it's still the
+                // shared/host-loaded content, and feed it into a running
+                // combined Phase-A hash for later comparison against the
+                // measured expected hash.
+                diag_record_phase_a(range.start(), &ram_buffer[..]);
+
                 // Change visibility on the pages for this iteration.
                 match isolation_type {
                     IsolationType::Snp => {
@@ -353,6 +618,22 @@ fn accept_pending_vtl2_memory(
                     };
 
                     mapping.copy_from_slice(ram_buffer);
+                }
+
+                // DIAG: re-hash the chunk from the freshly written private
+                // page (Phase C) and compare against the Phase-A bytes still
+                // sitting in `ram_buffer`. A mismatch here means the accept/
+                // copy-back path corrupted this chunk; hex diffs of the first
+                // few differing cache lines are logged.
+                {
+                    // SAFETY: Same memory just written above; identity mapped.
+                    let post = unsafe {
+                        core::slice::from_raw_parts(
+                            range.start() as *const u8,
+                            range.len() as usize,
+                        )
+                    };
+                    diag_verify_phase_c(range.start(), &ram_buffer[..post.len()], post);
                 }
             }
         }
@@ -390,7 +671,15 @@ pub fn verify_imported_regions_hash(shim_params: &ShimParams) {
             hasher.update(mapping);
         });
 
-    if hasher.finalize().as_slice() != shim_params.imported_regions_hash() {
+    let final_hash: [u8; 48] = hasher.finalize().into();
+    let expected = shim_params.imported_regions_hash();
+    if final_hash.as_slice() != expected {
+        log::error!(
+            "DIAG_COMBINED_PHASE_D combined_phase_d={} expected={}",
+            HexBytes(&final_hash),
+            HexBytes(expected),
+        );
+        diag_report_phase_d(expected);
         panic!("Imported regions hash mismatch");
     }
 }

--- a/openhcl/openhcl_boot/src/arch/x86_64/memory.rs
+++ b/openhcl/openhcl_boot/src/arch/x86_64/memory.rs
@@ -80,11 +80,87 @@ const DIAG_MAX_BAD_PAGE_HASHES: usize = 32;
 /// kernel + initrd (~80 MB), giving ~40 chunks; leave generous headroom.
 const DIAG_MAX_CHUNKS: usize = 256;
 
+/// Maximum number of individual 4 KB pages we can track for per-page
+/// expected-hash comparison. Sized with headroom over the current
+/// shared-page count observed in soaks (~20 K pages = 40 x 2 MB chunks).
+const DIAG_MAX_HASH_PAGES: usize = 32 * 1024;
+const DIAG_HASH_BITMAP_WORDS: usize = DIAG_MAX_HASH_PAGES / 64;
+
+/// Number of corrupt pages for which we save the full 4 KB contents so
+/// we can hex-dump them on final report.
+const DIAG_MAX_SAVED_BAD_PAGES: usize = 3;
+
 #[derive(Copy, Clone)]
 struct DiagChunkHash {
     gpa: u64,
     len: u32,
     phase_a_hash: [u8; 48],
+}
+
+/// One corrupt page's full 4 KB contents plus the shim vs loader hashes,
+/// captured during Phase A when we first noticed the mismatch.
+#[derive(Copy, Clone)]
+struct DiagSavedBadPage {
+    /// Global page index in the shim's iteration order.
+    page_idx: u32,
+    /// Guest physical address of the page.
+    gpa: u64,
+    /// SHA-384 the shim computed over the host-loaded bytes.
+    shim_hash: [u8; 48],
+    /// SHA-384 the loader recorded at IGVM build time.
+    expected_hash: [u8; 48],
+    /// Full 4 KB page contents (as the shim saw them at Phase A).
+    contents: [u8; DIAG_PAGE_SIZE],
+}
+
+const DIAG_EMPTY_SAVED_PAGE: DiagSavedBadPage = DiagSavedBadPage {
+    page_idx: 0,
+    gpa: 0,
+    shim_hash: [0; 48],
+    expected_hash: [0; 48],
+    contents: [0; DIAG_PAGE_SIZE],
+};
+
+/// Per-page expected-hash tracking state. Populated during Phase A capture
+/// as each 4 KB shared page is compared against the loader's per-page
+/// SHA-384 baked into the measured expected-page-hashes region.
+struct DiagPerPageState {
+    /// Cached slice from `ShimParams::expected_page_hashes()`. `None` if
+    /// the IGVM has no expected-page-hashes region (older loader) or the
+    /// region magic/version mismatched -- per-page compare is disabled.
+    expected: Option<&'static [loader_defs::paravisor::ExpectedPageHash]>,
+    /// Number of 4 KB pages Phase A has processed so far.
+    seen: u32,
+    /// Number of pages whose Phase A hash did not match `expected[i]`.
+    bad: u32,
+    /// True if the shim hashed more pages than the loader emitted hashes
+    /// for; per-page compare stops for the tail of the walk when this
+    /// flips true.
+    overflow: bool,
+    /// Bitmap of mismatched pages indexed by shim page index (bit i set
+    /// = page i differed from `expected[i]`). Capped at
+    /// `DIAG_MAX_HASH_PAGES` positions -- anything beyond is not
+    /// tracked in the bitmap (still counted in `bad`).
+    bitmap: [u64; DIAG_HASH_BITMAP_WORDS],
+    /// Number of entries populated in `saved`.
+    saved_count: u32,
+    /// Full 4 KB contents of the first `DIAG_MAX_SAVED_BAD_PAGES` bad
+    /// pages, so we can hex-dump them for byte-level inspection.
+    saved: [DiagSavedBadPage; DIAG_MAX_SAVED_BAD_PAGES],
+}
+
+impl DiagPerPageState {
+    const fn new_const() -> Self {
+        Self {
+            expected: None,
+            seen: 0,
+            bad: 0,
+            overflow: false,
+            bitmap: [0; DIAG_HASH_BITMAP_WORDS],
+            saved_count: 0,
+            saved: [DIAG_EMPTY_SAVED_PAGE; DIAG_MAX_SAVED_BAD_PAGES],
+        }
+    }
 }
 
 static DIAG_CHUNK_HASHES: SingleThreaded<RefCell<ArrayVec<DiagChunkHash, DIAG_MAX_CHUNKS>>> =
@@ -98,6 +174,11 @@ static DIAG_RUNNING_A: SingleThreaded<RefCell<Option<Sha384>>> = SingleThreaded(
 /// full dump. Keeps COM3 quiet even when many chunks are corrupted.
 static DIAG_FULL_PAGE_DUMPED: SingleThreaded<core::cell::Cell<bool>> =
     SingleThreaded(core::cell::Cell::new(false));
+
+/// Per-page expected-hash tracking (populated in `diag_record_phase_a` and
+/// reported in `diag_report_per_page_expected`).
+static DIAG_PER_PAGE: SingleThreaded<RefCell<DiagPerPageState>> =
+    SingleThreaded(RefCell::new(DiagPerPageState::new_const()));
 
 /// Returns true and latches on the first call; returns false thereafter.
 fn diag_claim_full_page_dump() -> bool {
@@ -196,7 +277,12 @@ impl core::fmt::Display for RleRanges<'_> {
 /// Record the Phase-A hash of a chunk that was just copied out of a shared
 /// page into `ram_buffer`. Also feeds the bytes into a running combined
 /// Phase-A hasher so it can be compared against `imported_regions_hash()`
-/// on final mismatch.
+/// on final mismatch. Additionally walks the chunk at 4 KB page
+/// granularity and compares each page's SHA-384 against the loader-emitted
+/// per-page expected hash (if `diag_init_expected_hashes` cached one) --
+/// mismatches are recorded in a bitmap plus a small buffer of the first N
+/// bad pages' full contents so `diag_report_per_page_expected` can dump
+/// them on final panic.
 fn diag_record_phase_a(gpa: u64, data: &[u8]) {
     {
         let mut running = DIAG_RUNNING_A.0.borrow_mut();
@@ -224,6 +310,56 @@ fn diag_record_phase_a(gpa: u64, data: &[u8]) {
             gpa,
             data.len(),
         );
+    }
+    drop(chunks);
+
+    // Per-page comparison against the loader-emitted expected hashes.
+    // Each 4 KB page in the chunk gets its own SHA-384; on mismatch we
+    // set a bit in the bitmap and, for the first N cases, snapshot the
+    // full 4 KB of host-loaded bytes so we can hex-dump them at report
+    // time. Skips silently if `diag_init_expected_hashes` did not cache
+    // a slice (older IGVM or region magic/version mismatch).
+    let mut state = DIAG_PER_PAGE.0.borrow_mut();
+    let expected_opt = state.expected;
+    if let Some(expected) = expected_opt {
+        for (page_off, page) in data.chunks(DIAG_PAGE_SIZE).enumerate() {
+            if page.len() < DIAG_PAGE_SIZE {
+                // Runt tail (shouldn't happen for page-aligned shared
+                // regions, but be defensive).
+                break;
+            }
+            let idx = state.seen as usize;
+            let page_gpa = gpa + (page_off * DIAG_PAGE_SIZE) as u64;
+
+            let mut ph = Sha384::new();
+            ph.update(page);
+            let shim_hash: [u8; 48] = ph.finalize().into();
+
+            if idx >= expected.len() {
+                state.overflow = true;
+            } else {
+                let expected_hash = expected[idx].sha384_hash;
+                if shim_hash != expected_hash {
+                    state.bad = state.bad.saturating_add(1);
+                    if idx < DIAG_MAX_HASH_PAGES {
+                        let word = idx / 64;
+                        let bit = idx % 64;
+                        state.bitmap[word] |= 1u64 << bit;
+                    }
+                    let slot_idx = state.saved_count as usize;
+                    if slot_idx < DIAG_MAX_SAVED_BAD_PAGES {
+                        let slot = &mut state.saved[slot_idx];
+                        slot.page_idx = idx as u32;
+                        slot.gpa = page_gpa;
+                        slot.shim_hash = shim_hash;
+                        slot.expected_hash = expected_hash;
+                        slot.contents.copy_from_slice(page);
+                        state.saved_count += 1;
+                    }
+                }
+            }
+            state.seen = state.seen.saturating_add(1);
+        }
     }
 }
 
@@ -273,6 +409,95 @@ fn diag_dump_full_page_single(page_gpa: u64, phase: &str, data: &[u8]) {
         );
     }
     log::error!("DIAG_FIRST_BAD_PAGE_END page_gpa={:#x}", page_gpa);
+}
+
+/// Emit a saved corrupt page (captured in Phase A) as hex, one log line
+/// per 64-byte cache line, along with the shim vs loader hashes.
+fn diag_dump_saved_page(saved: &DiagSavedBadPage) {
+    log::error!(
+        "DIAG_PAGE_HASH_BAD_BEGIN idx={} gpa={:#x} shim_hash={} expected_hash={} len={:#x}",
+        saved.page_idx,
+        saved.gpa,
+        HexBytes(&saved.shim_hash),
+        HexBytes(&saved.expected_hash),
+        DIAG_PAGE_SIZE,
+    );
+    for (line_idx, line) in saved.contents.chunks(64).enumerate() {
+        let offset = line_idx * 64;
+        log::error!(
+            "DIAG_PAGE_HASH_BAD_LINE idx={} gpa={:#x} offset={:#06x} bytes={}",
+            saved.page_idx,
+            saved.gpa,
+            offset,
+            HexBytes(line),
+        );
+    }
+    log::error!(
+        "DIAG_PAGE_HASH_BAD_END idx={} gpa={:#x}",
+        saved.page_idx,
+        saved.gpa,
+    );
+}
+
+/// Cache the loader-emitted per-page expected hashes so `diag_record_phase_a`
+/// can compare each 4 KB page against them. Must be called once, before the
+/// acceptance loop in `setup_vtl2_memory`. If the IGVM doesn't have the
+/// expected-page-hashes region (older loader) or the region magic/version
+/// mismatched, per-page compare is left disabled and `diag_record_phase_a`
+/// silently skips the per-page work.
+fn diag_init_expected_hashes(shim_params: &ShimParams) {
+    let expected = shim_params.expected_page_hashes();
+    if expected.is_empty() {
+        log::info!(
+            "DIAG_EXPECTED_HASHES_META loader_count=0 \
+             (region absent or magic/version mismatch; per-page compare disabled)"
+        );
+        return;
+    }
+    DIAG_PER_PAGE.0.borrow_mut().expected = Some(expected);
+    log::info!("DIAG_EXPECTED_HASHES_META loader_count={}", expected.len(),);
+}
+
+/// Emit the per-page expected-hash comparison summary, corrupt-page bitmap,
+/// RLE ranges, and full 4 KB dumps of the first `DIAG_MAX_SAVED_BAD_PAGES`
+/// corrupt pages. Called from `diag_report_phase_c` (i.e. after the
+/// combined hash mismatch has been detected and just before panic).
+fn diag_report_per_page_expected() {
+    let state = DIAG_PER_PAGE.0.borrow();
+    let loader_count = state.expected.map(|s| s.len()).unwrap_or(0);
+    log::error!(
+        "DIAG_PAGE_HASH_SUMMARY shim_seen={} bad={} loader_count={} overflow={}",
+        state.seen,
+        state.bad,
+        loader_count,
+        state.overflow,
+    );
+    if state.expected.is_none() {
+        // Per-page compare was disabled; nothing more to report.
+        return;
+    }
+    let bitmap_total = (state.seen as usize).min(DIAG_MAX_HASH_PAGES);
+    log::error!(
+        "DIAG_PAGE_HASH_BITMAP total_pages={} bad={} bitmap={}",
+        bitmap_total,
+        state.bad,
+        BitmapHex {
+            bitmap: &state.bitmap,
+            total_pages: bitmap_total,
+        },
+    );
+    log::error!(
+        "DIAG_PAGE_HASH_RANGES total_pages={} bad={} ranges={}",
+        bitmap_total,
+        state.bad,
+        RleRanges {
+            bitmap: &state.bitmap,
+            total_pages: bitmap_total,
+        },
+    );
+    for i in 0..(state.saved_count as usize) {
+        diag_dump_saved_page(&state.saved[i]);
+    }
 }
 
 /// Immediately after the shared -> private transition and copy-back, compare
@@ -493,6 +718,12 @@ fn diag_report_phase_c(expected_combined: &[u8]) {
             total,
         );
     }
+
+    // Per-page comparison against the loader-emitted expected hashes.
+    // Emits the shim-vs-loader page count, the corrupt-page bitmap and
+    // RLE ranges, and full 4 KB dumps of the first
+    // `DIAG_MAX_SAVED_BAD_PAGES` corrupt pages.
+    diag_report_per_page_expected();
 }
 
 /// On isolated systems, transitions all VTL2 RAM to be private and accepted, with the appropriate
@@ -511,6 +742,12 @@ pub fn setup_vtl2_memory(
     if let IsolationType::None = shim_params.isolation_type {
         return;
     }
+
+    // DIAG: cache the loader-emitted per-page expected hashes (from the
+    // measured expected-page-hashes region) so that as Phase A captures
+    // each 4 KB shared page we can compare it against the loader's
+    // baseline. Silently no-ops on older IGVMs without the region.
+    diag_init_expected_hashes(shim_params);
 
     if let IsolationType::Vbs = shim_params.isolation_type {
         // Enable VTL protection so that vtl 2 protections can be applied. All other config

--- a/openhcl/openhcl_boot/src/arch/x86_64/memory.rs
+++ b/openhcl/openhcl_boot/src/arch/x86_64/memory.rs
@@ -64,8 +64,7 @@ struct DiagChunkHash {
 static DIAG_CHUNK_HASHES: SingleThreaded<RefCell<ArrayVec<DiagChunkHash, DIAG_MAX_CHUNKS>>> =
     SingleThreaded(RefCell::new(ArrayVec::new_const()));
 
-static DIAG_RUNNING_A: SingleThreaded<RefCell<Option<Sha384>>> =
-    SingleThreaded(RefCell::new(None));
+static DIAG_RUNNING_A: SingleThreaded<RefCell<Option<Sha384>>> = SingleThreaded(RefCell::new(None));
 
 /// `core::fmt::Display` adapter that prints a byte slice as lowercase hex,
 /// no separators. Convenient for hashes in log lines.
@@ -162,7 +161,11 @@ fn diag_dump_first_diffs(tag: &str, gpa: u64, pre: &[u8], post: &[u8]) {
     let mut diff_lines: usize = 0;
     let mut reported: usize = 0;
 
-    for (idx, (a, b)) in pre.chunks(CACHE_LINE).zip(post.chunks(CACHE_LINE)).enumerate() {
+    for (idx, (a, b)) in pre
+        .chunks(CACHE_LINE)
+        .zip(post.chunks(CACHE_LINE))
+        .enumerate()
+    {
         if a == b {
             continue;
         }

--- a/openhcl/openhcl_boot/src/arch/x86_64/memory.rs
+++ b/openhcl/openhcl_boot/src/arch/x86_64/memory.rs
@@ -37,18 +37,44 @@ use zerocopy::FromZeros;
 // ============================================================================
 //
 // This is a temporary debugging aid intended for local investigation of a rare
-// mismatch seen on SNP boots. It computes SHA-384 of every 2 MB accept chunk
-// at three points to isolate which phase corruption occurs in:
-//   Phase A: bytes as read from the shared (host-visible) page, before the
-//            shared -> private transition.
-//   Phase C: bytes as read from the same GPA immediately after the transition
-//            (via the C=1 identity map), i.e. after accept + copy-back.
-//   Phase D: bytes as read from the same GPA at final verify time.
-// A running combined Phase-A hash is also accumulated to compare against
-// `imported_regions_hash()` to distinguish "host loaded bad data" from
-// "shim mangled it".
+// mismatch seen on SNP boots. It computes SHA-384 hashes at three points to
+// isolate which phase corruption occurs in:
+//   Phase A: bytes captured out of the shared (host-visible) page into
+//            `ram_buffer` just before the shared -> private transition.
+//   Phase B: bytes as read from the same GPA immediately after the
+//            transition (via the C=1 identity map), i.e. after accept +
+//            copy-back.
+//   Phase C: bytes as read from the same GPA at final verify time.
+//
+// Granularity:
+//   - Phase A capture: 2 MB accept-chunk (records one SHA-384 per chunk) plus
+//     a running combined hash for compare against `imported_regions_hash()`.
+//   - Phase A -> B compare: 4 KB PAGE granularity (per Jon's feedback). On
+//     mismatch we emit a bitmap of corrupt pages, RLE ranges, per-page pre/
+//     post SHA-384 (capped), and a full 4 KB hex dump of the first bad page.
+//   - Phase A -> C compare: per-chunk (interim). Once the loader is updated
+//     to emit per-page expected hashes, Phase C can also do per-page.
+//
+// Full-page dumps are strictly one-shot per soak (see DIAG_FULL_PAGE_DUMPED)
+// -- one sample is enough to eyeball whether corruption is a bit flip, a
+// zeroed page, a substituted page, etc., and we don't want to spam COM3 with
+// 64 lines per mismatched chunk.
 //
 // Not intended for check-in.
+
+/// Diagnostic page size == HV page size (4 KB).
+const DIAG_PAGE_SIZE: usize = hvdef::HV_PAGE_SIZE as usize;
+
+/// Max pages we can bitmap in a single 2 MB accept chunk (2 MB / 4 KB = 512).
+const DIAG_MAX_PAGES_PER_CHUNK: usize = X64_LARGE_PAGE_SIZE as usize / DIAG_PAGE_SIZE;
+const _: () = assert!(DIAG_MAX_PAGES_PER_CHUNK <= 512);
+
+/// Bitmap word count (u64s) for one 2 MB chunk.
+const DIAG_BITMAP_WORDS: usize = DIAG_MAX_PAGES_PER_CHUNK / 64;
+
+/// Cap on how many per-bad-page SHA-384 lines we emit per Phase B mismatch,
+/// so a wholly-corrupt chunk doesn't spam thousands of log lines.
+const DIAG_MAX_BAD_PAGE_HASHES: usize = 32;
 
 /// Maximum number of 2 MB chunks we track. Debug builds hash roughly
 /// kernel + initrd (~80 MB), giving ~40 chunks; leave generous headroom.
@@ -66,6 +92,22 @@ static DIAG_CHUNK_HASHES: SingleThreaded<RefCell<ArrayVec<DiagChunkHash, DIAG_MA
 
 static DIAG_RUNNING_A: SingleThreaded<RefCell<Option<Sha384>>> = SingleThreaded(RefCell::new(None));
 
+/// One-shot latch guarding the full 4 KB hex dump of a corrupted page.
+/// Whichever phase (B or C) trips a mismatch first gets to dump; every
+/// subsequent detection just logs the header/bitmap/hashes and skips the
+/// full dump. Keeps COM3 quiet even when many chunks are corrupted.
+static DIAG_FULL_PAGE_DUMPED: SingleThreaded<core::cell::Cell<bool>> =
+    SingleThreaded(core::cell::Cell::new(false));
+
+/// Returns true and latches on the first call; returns false thereafter.
+fn diag_claim_full_page_dump() -> bool {
+    if DIAG_FULL_PAGE_DUMPED.0.get() {
+        return false;
+    }
+    DIAG_FULL_PAGE_DUMPED.0.set(true);
+    true
+}
+
 /// `core::fmt::Display` adapter that prints a byte slice as lowercase hex,
 /// no separators. Convenient for hashes in log lines.
 struct HexBytes<'a>(&'a [u8]);
@@ -73,6 +115,79 @@ impl core::fmt::Display for HexBytes<'_> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         for b in self.0 {
             write!(f, "{:02x}", b)?;
+        }
+        Ok(())
+    }
+}
+
+/// `core::fmt::Display` adapter that prints a page-bitmap (little-endian
+/// per byte within each u64 word) as a compact hex string. One hex char per
+/// 4 pages, so a full 2 MB / 4 KB = 512-page chunk fits in 128 hex chars.
+struct BitmapHex<'a> {
+    bitmap: &'a [u64],
+    total_pages: usize,
+}
+impl core::fmt::Display for BitmapHex<'_> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let bits = self.total_pages.min(self.bitmap.len() * 64);
+        let bytes = bits.div_ceil(8);
+        for byte_idx in 0..bytes {
+            let word = byte_idx / 8;
+            let byte_in_word = byte_idx % 8;
+            let b = ((self.bitmap[word] >> (byte_in_word * 8)) & 0xff) as u8;
+            write!(f, "{:02x}", b)?;
+        }
+        Ok(())
+    }
+}
+
+/// `core::fmt::Display` adapter that walks a page-bitmap and emits corrupt
+/// page-index ranges in the form `0x8-0xa,0x11,0x20-0x21`. Human-readable
+/// alternative to the raw hex bitmap.
+struct RleRanges<'a> {
+    bitmap: &'a [u64],
+    total_pages: usize,
+}
+impl core::fmt::Display for RleRanges<'_> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let mut first = true;
+        let mut run_start: Option<usize> = None;
+        let mut prev_bit: bool = false;
+        for idx in 0..self.total_pages {
+            let word = idx / 64;
+            let bit = idx % 64;
+            let set = word < self.bitmap.len() && (self.bitmap[word] >> bit) & 1 == 1;
+            if set && !prev_bit {
+                run_start = Some(idx);
+            }
+            if !set && prev_bit {
+                let start = run_start.unwrap();
+                let end = idx - 1;
+                if !first {
+                    write!(f, ",")?;
+                }
+                first = false;
+                if start == end {
+                    write!(f, "{:#x}", start)?;
+                } else {
+                    write!(f, "{:#x}-{:#x}", start, end)?;
+                }
+                run_start = None;
+            }
+            prev_bit = set;
+        }
+        // Handle a run that reaches the last page.
+        if prev_bit {
+            let start = run_start.unwrap();
+            let end = self.total_pages - 1;
+            if !first {
+                write!(f, ",")?;
+            }
+            if start == end {
+                write!(f, "{:#x}", start)?;
+            } else {
+                write!(f, "{:#x}-{:#x}", start, end)?;
+            }
         }
         Ok(())
     }
@@ -112,12 +227,69 @@ fn diag_record_phase_a(gpa: u64, data: &[u8]) {
     }
 }
 
+/// Emit a full 4 KB page as hex, one log line per 64-byte cache line, with
+/// pre and post side by side. Used when we have both Phase-A and Phase-C
+/// bytes for the first corrupted page.
+fn diag_dump_full_page_diff(page_gpa: u64, phase: &str, pre: &[u8], post: &[u8]) {
+    debug_assert_eq!(pre.len(), DIAG_PAGE_SIZE);
+    debug_assert_eq!(post.len(), DIAG_PAGE_SIZE);
+    log::error!(
+        "DIAG_FIRST_BAD_PAGE_BEGIN page_gpa={:#x} phase={} len={:#x}",
+        page_gpa,
+        phase,
+        DIAG_PAGE_SIZE,
+    );
+    for (line_idx, (pre_line, post_line)) in pre.chunks(64).zip(post.chunks(64)).enumerate() {
+        let offset = line_idx * 64;
+        log::error!(
+            "DIAG_FIRST_BAD_PAGE_LINE page_gpa={:#x} offset={:#06x} pre={} post={}",
+            page_gpa,
+            offset,
+            HexBytes(pre_line),
+            HexBytes(post_line),
+        );
+    }
+    log::error!("DIAG_FIRST_BAD_PAGE_END page_gpa={:#x}", page_gpa);
+}
+
+/// Emit a full 4 KB page as hex, one log line per 64-byte cache line. Used
+/// when only the current (Phase-D) bytes are available for the first bad
+/// page and there is no pre-image to compare side by side.
+fn diag_dump_full_page_single(page_gpa: u64, phase: &str, data: &[u8]) {
+    debug_assert!(data.len() >= DIAG_PAGE_SIZE);
+    log::error!(
+        "DIAG_FIRST_BAD_PAGE_BEGIN page_gpa={:#x} phase={} len={:#x}",
+        page_gpa,
+        phase,
+        DIAG_PAGE_SIZE,
+    );
+    for (line_idx, line) in data[..DIAG_PAGE_SIZE].chunks(64).enumerate() {
+        let offset = line_idx * 64;
+        log::error!(
+            "DIAG_FIRST_BAD_PAGE_LINE page_gpa={:#x} offset={:#06x} bytes={}",
+            page_gpa,
+            offset,
+            HexBytes(line),
+        );
+    }
+    log::error!("DIAG_FIRST_BAD_PAGE_END page_gpa={:#x}", page_gpa);
+}
+
 /// Immediately after the shared -> private transition and copy-back, compare
 /// the same chunk (via the identity map) against the Phase-A bytes we captured
-/// before the transition. Logs eagerly on mismatch, including hex diffs of the
-/// first few differing 64-byte cache lines, so we know acceptance corrupted
-/// this chunk right when it happened and what the corruption looks like.
-fn diag_verify_phase_c(gpa: u64, pre: &[u8], post: &[u8]) {
+/// before the transition, at 4 KB PAGE granularity. On mismatch, emits:
+///  - `DIAG_TRANSITION_MISMATCH` header with total/bad page counts and per-
+///    chunk pre/post SHA-384.
+///  - `DIAG_TRANSITION_BITMAP` (hex) and `DIAG_TRANSITION_PAGES` (RLE) so we
+///    can see the distribution of corrupt pages within the chunk.
+///  - `DIAG_BAD_PAGE_HASH` per corrupt page (capped at
+///    DIAG_MAX_BAD_PAGE_HASHES) with SHA-384 of both pre and post.
+///  - Full 4 KB hex dump of the FIRST corrupt page via
+///    `DIAG_FIRST_BAD_PAGE_{BEGIN,LINE,END}` -- but ONLY if no previous
+///    call (from any chunk or from Phase C) has already claimed the
+///    one-shot dump latch. One sample is enough to characterise the
+///    corruption pattern.
+fn diag_verify_phase_b(gpa: u64, pre: &[u8], post: &[u8]) {
     if pre.len() != post.len() {
         log::error!(
             "DIAG_TRANSITION_LEN_MISMATCH gpa={:#x} pre_len={:#x} post_len={:#x}",
@@ -131,96 +303,120 @@ fn diag_verify_phase_c(gpa: u64, pre: &[u8], post: &[u8]) {
         return;
     }
 
-    let mut ha = Sha384::new();
-    ha.update(pre);
-    let hash_a: [u8; 48] = ha.finalize().into();
-    let mut hc = Sha384::new();
-    hc.update(post);
-    let hash_c: [u8; 48] = hc.finalize().into();
+    // Bitmap of mismatched pages within this chunk. Chunks are <= 2 MB
+    // = 512 pages, so DIAG_BITMAP_WORDS u64s suffice.
+    let mut bitmap = [0u64; DIAG_BITMAP_WORDS];
+    let mut bad_count: usize = 0;
+    let mut first_bad_page_idx: Option<usize> = None;
+    let mut bad_hashes: ArrayVec<(u64, [u8; 48], [u8; 48]), DIAG_MAX_BAD_PAGE_HASHES> =
+        ArrayVec::new();
+    let total_pages = pre.len().div_ceil(DIAG_PAGE_SIZE);
 
-    log::error!(
-        "DIAG_TRANSITION_MISMATCH gpa={:#x} len={:#x} phase_a={} phase_c={}",
-        gpa,
-        pre.len(),
-        HexBytes(&hash_a),
-        HexBytes(&hash_c),
-    );
-    diag_dump_first_diffs("DIAG_TRANSITION_DIFF", gpa, pre, post);
-}
-
-/// Log the first `MAX_DIFF_LINES` 64-byte cache lines that differ between
-/// `pre` and `post`, along with byte counts. Keeps log volume bounded even
-/// when the whole chunk differs.
-fn diag_dump_first_diffs(tag: &str, gpa: u64, pre: &[u8], post: &[u8]) {
-    const CACHE_LINE: usize = 64;
-    const MAX_DIFF_LINES: usize = 8;
-
-    debug_assert_eq!(pre.len(), post.len());
-
-    let mut total_diff_bytes: usize = 0;
-    let mut diff_lines: usize = 0;
-    let mut reported: usize = 0;
-
-    for (idx, (a, b)) in pre
-        .chunks(CACHE_LINE)
-        .zip(post.chunks(CACHE_LINE))
+    for (idx, (pre_pg, post_pg)) in pre
+        .chunks(DIAG_PAGE_SIZE)
+        .zip(post.chunks(DIAG_PAGE_SIZE))
         .enumerate()
     {
-        if a == b {
+        if pre_pg == post_pg {
             continue;
         }
-        diff_lines += 1;
-        total_diff_bytes += a.iter().zip(b.iter()).filter(|(x, y)| x != y).count();
+        bad_count += 1;
+        if first_bad_page_idx.is_none() {
+            first_bad_page_idx = Some(idx);
+        }
+        let word = idx / 64;
+        let bit = idx % 64;
+        if word < bitmap.len() {
+            bitmap[word] |= 1u64 << bit;
+        }
 
-        if reported < MAX_DIFF_LINES {
-            let offset = idx * CACHE_LINE;
-            log::error!(
-                "{} gpa={:#x} offset={:#x} pre={} post={}",
-                tag,
-                gpa,
-                offset,
-                HexBytes(a),
-                HexBytes(b),
-            );
-            reported += 1;
+        if bad_hashes.len() < DIAG_MAX_BAD_PAGE_HASHES {
+            let mut ha = Sha384::new();
+            ha.update(pre_pg);
+            let hash_a: [u8; 48] = ha.finalize().into();
+            let mut hc = Sha384::new();
+            hc.update(post_pg);
+            let hash_c: [u8; 48] = hc.finalize().into();
+            let _ = bad_hashes.try_push((gpa + (idx * DIAG_PAGE_SIZE) as u64, hash_a, hash_c));
         }
     }
 
+    // Overall pre/post SHA-384 for the whole chunk, for quick fingerprinting.
+    let mut ha = Sha384::new();
+    ha.update(pre);
+    let chunk_hash_a: [u8; 48] = ha.finalize().into();
+    let mut hb = Sha384::new();
+    hb.update(post);
+    let chunk_hash_b: [u8; 48] = hb.finalize().into();
+
     log::error!(
-        "{}_SUMMARY gpa={:#x} len={:#x} diff_cache_lines={} diff_bytes={} reported={}",
-        tag,
+        "DIAG_TRANSITION_MISMATCH gpa={:#x} chunk_len={:#x} total_pages={} bad_pages={} \
+         chunk_phase_a={} chunk_phase_b={}",
         gpa,
         pre.len(),
-        diff_lines,
-        total_diff_bytes,
-        reported,
+        total_pages,
+        bad_count,
+        HexBytes(&chunk_hash_a),
+        HexBytes(&chunk_hash_b),
     );
-}
-
-/// Log the first `HEAD_BYTES` of the chunk at `gpa` as hex. Useful when only
-/// the current (Phase D) content is available, since it lets us see whether
-/// the offending chunk is all zeros, all 0xff, or otherwise recognisable
-/// (initrd cpio header, ELF magic, etc.) without exposing the whole chunk.
-fn diag_dump_head(tag: &str, gpa: u64, data: &[u8]) {
-    const HEAD_BYTES: usize = 128;
-    let head = &data[..data.len().min(HEAD_BYTES)];
     log::error!(
-        "{} gpa={:#x} head_len={:#x} head={}",
-        tag,
+        "DIAG_TRANSITION_BITMAP gpa={:#x} total_pages={} bitmap={}",
         gpa,
-        head.len(),
-        HexBytes(head),
+        total_pages,
+        BitmapHex {
+            bitmap: &bitmap,
+            total_pages,
+        },
     );
+    log::error!(
+        "DIAG_TRANSITION_PAGES gpa={:#x} count={} ranges={}",
+        gpa,
+        bad_count,
+        RleRanges {
+            bitmap: &bitmap,
+            total_pages,
+        },
+    );
+
+    for (page_gpa, ha, hb) in &bad_hashes {
+        log::error!(
+            "DIAG_BAD_PAGE_HASH phase=A_vs_B chunk_gpa={:#x} page_gpa={:#x} phase_a={} phase_b={}",
+            gpa,
+            page_gpa,
+            HexBytes(ha),
+            HexBytes(hb),
+        );
+    }
+    if bad_count > bad_hashes.len() {
+        log::error!(
+            "DIAG_BAD_PAGE_HASH_TRUNCATED chunk_gpa={:#x} shown={} total_bad={}",
+            gpa,
+            bad_hashes.len(),
+            bad_count,
+        );
+    }
+
+    if let Some(idx) = first_bad_page_idx {
+        if diag_claim_full_page_dump() {
+            let offset = idx * DIAG_PAGE_SIZE;
+            let pre_pg = &pre[offset..offset + DIAG_PAGE_SIZE];
+            let post_pg = &post[offset..offset + DIAG_PAGE_SIZE];
+            diag_dump_full_page_diff(gpa + offset as u64, "A_vs_B", pre_pg, post_pg);
+        }
+    }
 }
 
-/// Called from `verify_imported_regions_hash` when the combined Phase-D hash
+/// Called from `verify_imported_regions_hash` when the combined Phase-C hash
 /// does not match the expected measured value. Reports:
 /// - Whether the running combined Phase-A hash matches expected. If it does,
 ///   the host supplied correct bytes and something in the shim corrupted them.
 ///   If it doesn't, the host loaded bad data.
-/// - Per-chunk Phase-D vs Phase-A comparison to identify which chunk(s) drifted
-///   between the shared read and the final verify.
-fn diag_report_phase_d(expected_combined: &[u8]) {
+/// - Per-chunk Phase-C vs Phase-A comparison to identify which chunk(s) drifted
+///   between the shared read and the final verify, plus a full 4 KB hex dump
+///   of the first page of the FIRST mismatched chunk (subject to the same
+///   one-shot latch as Phase B -- one sample is enough). Once the loader is
+///   updated to emit per-page expected hashes we can do per-page here too.
+fn diag_report_phase_c(expected_combined: &[u8]) {
     let combined_a = DIAG_RUNNING_A.0.borrow_mut().take().map(|h| {
         let out: [u8; 48] = h.finalize().into();
         out
@@ -259,33 +455,40 @@ fn diag_report_phase_d(expected_combined: &[u8]) {
         let data = unsafe { core::slice::from_raw_parts(c.gpa as *const u8, c.len as usize) };
         let mut h = Sha384::new();
         h.update(data);
-        let hash_d: [u8; 48] = h.finalize().into();
-        if hash_d != c.phase_a_hash {
+        let hash_c: [u8; 48] = h.finalize().into();
+        if hash_c != c.phase_a_hash {
             mismatches += 1;
             log::error!(
-                "DIAG_POST_ACCEPT_MISMATCH idx={} gpa={:#x} len={:#x} phase_a={} phase_d={}",
+                "DIAG_POST_ACCEPT_MISMATCH idx={} gpa={:#x} len={:#x} phase_a={} phase_c={}",
                 idx,
                 c.gpa,
                 c.len,
                 HexBytes(&c.phase_a_hash),
-                HexBytes(&hash_d),
+                HexBytes(&hash_c),
             );
             // We no longer have the Phase-A bytes (they lived in `ram_buffer`
-            // which has been reused). Log the head of the current (Phase D)
-            // content so we can eyeball whether the chunk was zeroed,
-            // substituted, or contains plausible data.
-            diag_dump_head("DIAG_POST_ACCEPT_HEAD", c.gpa, data);
+            // which has been reused). Full 4 KB dump of the first page of the
+            // first mismatched chunk lets us eyeball whether the chunk was
+            // zeroed, substituted with a different page, or has a subtle bit
+            // flip. One-shot: once we've dumped a page (here or in Phase B),
+            // subsequent mismatches only log the hash lines.
+            // TODO(item 5): once the loader emits per-page expected hashes,
+            // iterate the chunk at 4 KB granularity here and identify exactly
+            // which pages diverged (like diag_verify_phase_b does).
+            if data.len() >= DIAG_PAGE_SIZE && diag_claim_full_page_dump() {
+                diag_dump_full_page_single(c.gpa, "C", data);
+            }
         }
     }
     if mismatches == 0 {
         log::error!(
-            "DIAG_VERDICT all {} tracked chunks unchanged phase_a -> phase_d \
+            "DIAG_VERDICT all {} tracked chunks unchanged phase_a -> phase_c \
              (combined mismatch is likely a layout/order/hashing disagreement)",
             total,
         );
     } else {
         log::error!(
-            "DIAG_VERDICT {} of {} tracked chunks changed between phase_a and phase_d",
+            "DIAG_VERDICT {} of {} tracked chunks changed between phase_a and phase_c",
             mismatches,
             total,
         );
@@ -624,10 +827,11 @@ fn accept_pending_vtl2_memory(
                 }
 
                 // DIAG: re-hash the chunk from the freshly written private
-                // page (Phase C) and compare against the Phase-A bytes still
+                // page (Phase B) and compare against the Phase-A bytes still
                 // sitting in `ram_buffer`. A mismatch here means the accept/
-                // copy-back path corrupted this chunk; hex diffs of the first
-                // few differing cache lines are logged.
+                // copy-back path corrupted this chunk; per-page bitmap, RLE
+                // ranges, per-corrupt-page SHA-384s, and (once, globally) a
+                // full 4 KB dump of the first bad page are logged.
                 {
                     // SAFETY: Same memory just written above; identity mapped.
                     let post = unsafe {
@@ -636,7 +840,7 @@ fn accept_pending_vtl2_memory(
                             range.len() as usize,
                         )
                     };
-                    diag_verify_phase_c(range.start(), &ram_buffer[..post.len()], post);
+                    diag_verify_phase_b(range.start(), &ram_buffer[..post.len()], post);
                 }
             }
         }
@@ -678,11 +882,11 @@ pub fn verify_imported_regions_hash(shim_params: &ShimParams) {
     let expected = shim_params.imported_regions_hash();
     if final_hash.as_slice() != expected {
         log::error!(
-            "DIAG_COMBINED_PHASE_D combined_phase_d={} expected={}",
+            "DIAG_COMBINED_PHASE_C combined_phase_c={} expected={}",
             HexBytes(&final_hash),
             HexBytes(expected),
         );
-        diag_report_phase_d(expected);
+        diag_report_phase_c(expected);
         panic!("Imported regions hash mismatch");
     }
 }

--- a/openhcl/openhcl_boot/src/host_params/shim_params.rs
+++ b/openhcl/openhcl_boot/src/host_params/shim_params.rs
@@ -298,4 +298,43 @@ impl ShimParams {
             &header.sha384_hash
         }
     }
+
+    /// Expected SHA-384 hashes for each 4 KB unmeasured (shared) page in the
+    /// IGVM, in the same order the shim walks
+    /// `imported_regions().filter(!already_accepted)` pages in ascending GPA
+    /// order. Populated by the IGVM file loader and measured; used by the
+    /// boot shim's `verify_imported_regions_hash` diagnostic path to
+    /// identify which specific pages diverged on a hash mismatch.
+    ///
+    /// Returns an empty slice if the region header magic/version don't match
+    /// (older IGVM without the region, or a future incompatible layout);
+    /// callers should treat that as "no per-page baseline available" and
+    /// fall back to the combined-hash check.
+    #[cfg(target_arch = "x86_64")]
+    #[allow(dead_code)] // consumed in a follow-up that updates verify_imported_regions_hash
+    pub fn expected_page_hashes(&self) -> &'static [loader_defs::paravisor::ExpectedPageHash] {
+        use loader_defs::paravisor::{
+            EXPECTED_PAGE_HASH_MAX_COUNT, EXPECTED_PAGE_HASHES_MAGIC, EXPECTED_PAGE_HASHES_VERSION,
+            ExpectedPageHash, ExpectedPageHashesHeader,
+            PARAVISOR_MEASURED_VTL2_CONFIG_PAGE_HASHES_PAGE_INDEX,
+        };
+
+        let header_start = self.parameter_region_start
+            + (PARAVISOR_MEASURED_VTL2_CONFIG_PAGE_HASHES_PAGE_INDEX * hvdef::HV_PAGE_SIZE);
+
+        // SAFETY: header_start is a measured address inside the parameter
+        // region reserved for this purpose at IGVM build time.
+        let header = unsafe { &*(header_start as *const ExpectedPageHashesHeader) };
+        if header.magic != EXPECTED_PAGE_HASHES_MAGIC
+            || header.version != EXPECTED_PAGE_HASHES_VERSION
+        {
+            return &[];
+        }
+        let count = (header.page_hash_count as usize).min(EXPECTED_PAGE_HASH_MAX_COUNT);
+        let entries_start = header_start + size_of::<ExpectedPageHashesHeader>() as u64;
+
+        // SAFETY: `count` is bounded above by the measured region capacity;
+        // the region is contiguous and identity-mapped.
+        unsafe { slice::from_raw_parts(entries_start as *const ExpectedPageHash, count) }
+    }
 }

--- a/openhcl/openhcl_boot/src/host_params/shim_params.rs
+++ b/openhcl/openhcl_boot/src/host_params/shim_params.rs
@@ -311,7 +311,6 @@ impl ShimParams {
     /// callers should treat that as "no per-page baseline available" and
     /// fall back to the combined-hash check.
     #[cfg(target_arch = "x86_64")]
-    #[expect(dead_code)] // consumed in a follow-up that updates verify_imported_regions_hash
     pub fn expected_page_hashes(&self) -> &'static [loader_defs::paravisor::ExpectedPageHash] {
         use loader_defs::paravisor::{
             EXPECTED_PAGE_HASH_MAX_COUNT, EXPECTED_PAGE_HASHES_MAGIC, EXPECTED_PAGE_HASHES_VERSION,

--- a/openhcl/openhcl_boot/src/host_params/shim_params.rs
+++ b/openhcl/openhcl_boot/src/host_params/shim_params.rs
@@ -311,7 +311,7 @@ impl ShimParams {
     /// callers should treat that as "no per-page baseline available" and
     /// fall back to the combined-hash check.
     #[cfg(target_arch = "x86_64")]
-    #[allow(dead_code)] // consumed in a follow-up that updates verify_imported_regions_hash
+    #[expect(dead_code)] // consumed in a follow-up that updates verify_imported_regions_hash
     pub fn expected_page_hashes(&self) -> &'static [loader_defs::paravisor::ExpectedPageHash] {
         use loader_defs::paravisor::{
             EXPECTED_PAGE_HASH_MAX_COUNT, EXPECTED_PAGE_HASHES_MAGIC, EXPECTED_PAGE_HASHES_VERSION,

--- a/openhcl/openhcl_boot/src/main.rs
+++ b/openhcl/openhcl_boot/src/main.rs
@@ -555,10 +555,7 @@ fn get_ref_time(isolation: IsolationType) -> Option<u64> {
     }
 }
 
-/// Build a compact one-shot diagnostic string describing an initrd CRC
-/// mismatch, sized to fit in the 512-byte enlightened-panic buffer so it
-/// survives via whatever channel currently delivers the assert message
-/// (Hyper-V crash MSRs / serial / in-memory bootshim log).
+/// Dump diagnostics when initrd CRC32 does not match the build-time value.
 ///
 /// Contents:
 ///
@@ -581,9 +578,10 @@ fn get_ref_time(isolation: IsolationType) -> Option<u64> {
 fn build_initrd_crc_diagnostic(p: &ShimParams, first_computed_crc: u32) -> ArrayString<384> {
     let initrd_bytes = p.initrd();
 
-    // Second read of the same virtual range. Compared against the first
-    // read to distinguish stable data corruption from read-time
-    // instability.
+    // A second read from the same VA. If this differs from the first read,
+    // the initrd memory is not being read consistently, which typically
+    // indicates stale/mismatched cache lines rather than actual data
+    // corruption.
     let second_computed_crc = crc32fast::hash(initrd_bytes);
 
     // First 16 and last 16 bytes, as fixed-size arrays so we can rely on
@@ -616,8 +614,6 @@ fn build_initrd_crc_diagnostic(p: &ShimParams, first_computed_crc: u32) -> Array
     }
 
     let mut buf = ArrayString::<384>::new();
-    // Best-effort: if any write hits the cap, truncated output is still
-    // better than nothing.
     let _ = write!(
         &mut buf,
         "initrd crc mismatch: iso={:?} base={:#x} size={:#x} \
@@ -804,19 +800,16 @@ fn shim_main(shim_params_raw_offset: isize) -> ! {
     let initrd = p.initrd_base..p.initrd_base + p.initrd_size;
 
     // Validate the initrd crc matches what was put at file generation time.
-    //
-    // SNP TODO: this is intentionally emitted as a single panic string
-    // (rather than an `assert_eq!`) so the full diagnostic rides along on
-    // the same channel that currently delivers the panic message (Hyper-V
-    // crash MSRs / serial / in-memory bootshim log) instead of relying on
-    // multi-line log output that may not be captured before the shim
-    // faults.
     let computed_crc = crc32fast::hash(p.initrd());
-    if computed_crc != p.initrd_crc {
+    if computed_crc != p.initrd_crc && is_confidential_debug {
         let diag = build_initrd_crc_diagnostic(&p, computed_crc);
         log::error!("{}", diag.as_str());
         panic!("{}", diag.as_str());
     }
+    assert_eq!(
+        computed_crc, p.initrd_crc,
+        "computed initrd crc does not match build time calculated crc"
+    );
 
     #[cfg(target_arch = "x86_64")]
     let boot_params = x86_boot::build_boot_params(

--- a/openhcl/openhcl_boot/src/main.rs
+++ b/openhcl/openhcl_boot/src/main.rs
@@ -555,6 +555,94 @@ fn get_ref_time(isolation: IsolationType) -> Option<u64> {
     }
 }
 
+/// Build a compact one-shot diagnostic string describing an initrd CRC
+/// mismatch, sized to fit in the 512-byte enlightened-panic buffer so it
+/// survives via whatever channel currently delivers the assert message
+/// (Hyper-V crash MSRs / serial / in-memory bootshim log).
+///
+/// Contents:
+///
+/// - `base` / `size` / `expected` (build-time) / `got` (first read)
+///   CRCs.
+/// - `got2` — a second CRC re-computed immediately from the same virtual
+///   range. If `got2 != got`, initrd memory is not being read consistently
+///   (typical symptom of stale/mismatched cache lines after the SNP shared
+///   -> private transition, rather than data being wrong in memory).
+/// - `head` / `tail` — first and last 16 bytes as hex, to fingerprint what
+///   is actually in memory.
+/// - `eighths` — CRC32 of eight roughly-equal slices of the initrd. This
+///   is a coarse "which region diverges" locator that is cheap to compute
+///   and stable across boots, so it can be compared with a known-good
+///   build without needing a per-page dump (which would blow the log
+///   budget for real-sized initrds).
+//
+// SNP TODO: temporary diagnostic; remove once the SNP initrd CRC mismatch
+// is root-caused.
+fn build_initrd_crc_diagnostic(p: &ShimParams, first_computed_crc: u32) -> ArrayString<384> {
+    let initrd_bytes = p.initrd();
+
+    // Second read of the same virtual range. Compared against the first
+    // read to distinguish stable data corruption from read-time
+    // instability.
+    let second_computed_crc = crc32fast::hash(initrd_bytes);
+
+    // First 16 and last 16 bytes, as fixed-size arrays so we can rely on
+    // Debug's `{:02x?}` slice formatting.
+    let mut head = [0u8; 16];
+    let head_len = head.len().min(initrd_bytes.len());
+    head[..head_len].copy_from_slice(&initrd_bytes[..head_len]);
+
+    let mut tail = [0u8; 16];
+    let tail_len = tail.len().min(initrd_bytes.len());
+    if tail_len > 0 {
+        let start = initrd_bytes.len() - tail_len;
+        tail[..tail_len].copy_from_slice(&initrd_bytes[start..]);
+    }
+
+    // Split the initrd into (up to) 8 roughly-equal slices and CRC each.
+    // Bytes past the aligned slices go into the last chunk.
+    let mut eighths = [0u32; 8];
+    let n = initrd_bytes.len();
+    if n > 0 {
+        let step = n.div_ceil(8);
+        for (i, e) in eighths.iter_mut().enumerate() {
+            let start = i * step;
+            if start >= n {
+                break;
+            }
+            let end = ((i + 1) * step).min(n);
+            *e = crc32fast::hash(&initrd_bytes[start..end]);
+        }
+    }
+
+    let mut buf = ArrayString::<384>::new();
+    // Best-effort: if any write hits the cap, truncated output is still
+    // better than nothing.
+    let _ = write!(
+        &mut buf,
+        "initrd crc mismatch: iso={:?} base={:#x} size={:#x} \
+         exp={:#x} got={:#x} got2={:#x} head={:02x?} tail={:02x?} \
+         eighths=[{:#x},{:#x},{:#x},{:#x},{:#x},{:#x},{:#x},{:#x}]",
+        p.isolation_type,
+        p.initrd_base,
+        p.initrd_size,
+        p.initrd_crc,
+        first_computed_crc,
+        second_computed_crc,
+        &head[..head_len],
+        &tail[..tail_len],
+        eighths[0],
+        eighths[1],
+        eighths[2],
+        eighths[3],
+        eighths[4],
+        eighths[5],
+        eighths[6],
+        eighths[7],
+    );
+    buf
+}
+
 fn shim_main(shim_params_raw_offset: isize) -> ! {
     let p = shim_parameters(shim_params_raw_offset);
     if p.isolation_type == IsolationType::None {
@@ -716,11 +804,19 @@ fn shim_main(shim_params_raw_offset: isize) -> ! {
     let initrd = p.initrd_base..p.initrd_base + p.initrd_size;
 
     // Validate the initrd crc matches what was put at file generation time.
+    //
+    // SNP TODO: this is intentionally emitted as a single panic string
+    // (rather than an `assert_eq!`) so the full diagnostic rides along on
+    // the same channel that currently delivers the panic message (Hyper-V
+    // crash MSRs / serial / in-memory bootshim log) instead of relying on
+    // multi-line log output that may not be captured before the shim
+    // faults.
     let computed_crc = crc32fast::hash(p.initrd());
-    assert_eq!(
-        computed_crc, p.initrd_crc,
-        "computed initrd crc does not match build time calculated crc"
-    );
+    if computed_crc != p.initrd_crc {
+        let diag = build_initrd_crc_diagnostic(&p, computed_crc);
+        log::error!("{}", diag.as_str());
+        panic!("{}", diag.as_str());
+    }
 
     #[cfg(target_arch = "x86_64")]
     let boot_params = x86_boot::build_boot_params(

--- a/vm/loader/igvmfilegen/src/file_loader.rs
+++ b/vm/loader/igvmfilegen/src/file_loader.rs
@@ -99,6 +99,7 @@ pub struct IgvmLoader<R: VbsRegister + GuestArch> {
     isolation_type: LoaderIsolationType,
     paravisor_present: bool,
     imported_regions_config_page: Option<u64>,
+    expected_page_hashes_config_page: Option<u64>,
 }
 
 pub struct IgvmVtlLoader<'a, R: VbsRegister + GuestArch> {
@@ -472,19 +473,31 @@ impl<R: IgvmLoaderRegister + GuestArch + 'static> IgvmLoader<R> {
             isolation_type,
             paravisor_present: with_paravisor,
             imported_regions_config_page: None,
+            expected_page_hashes_config_page: None,
         }
     }
 
-    fn generate_cryptographic_hash_of_shared_pages(&mut self) -> Vec<u8> {
-        // Sort the page data directives by GPA to ensure the hash is consistent.
+    /// Compute both the combined SHA-384 over all shared (unmeasured) pages
+    /// (matching the value stored in `ImportedRegionsPageHeader::sha384_hash`)
+    /// and a per-page array of SHA-384s (one entry per 4 KB shared page, in
+    /// ascending-GPA order) suitable for the expected-page-hashes region.
+    ///
+    /// The per-page array is what the boot shim uses to identify which
+    /// individual pages diverged from the measured baseline on a hash
+    /// mismatch.
+    fn generate_cryptographic_hashes_of_shared_pages(
+        &mut self,
+    ) -> (Vec<u8>, Vec<loader_defs::paravisor::ExpectedPageHash>) {
+        // Sort the page data directives by GPA to ensure the hashes are
+        // consistent and that the per-page array is in ascending-GPA order.
         self.page_data_directives
             .sort_unstable_by_key(|directive| match directive {
                 IgvmDirectiveHeader::PageData { gpa, .. } => *gpa,
                 _ => unreachable!("all directives should be IgvmDirectiveHeader::PageData"),
             });
 
-        // Generate the hash of the unaccepted pages.
-        let mut hasher = Sha384::new();
+        let mut combined = Sha384::new();
+        let mut per_page = Vec::new();
         self.page_data_directives.iter().for_each(|directive| {
             if let IgvmDirectiveHeader::PageData {
                 gpa: _,
@@ -506,11 +519,22 @@ impl<R: IgvmLoaderRegister + GuestArch + 'static> IgvmLoader<R> {
                         data
                     };
 
-                    hasher.update(data_to_hash);
+                    combined.update(data_to_hash);
+
+                    // Per-page hash: a fresh Sha384 fed the same zero-
+                    // extended page bytes.
+                    let mut per = Sha384::new();
+                    per.update(data_to_hash);
+                    let hash: [u8; 48] = per
+                        .finish()
+                        .as_bytes()
+                        .try_into()
+                        .expect("sha384 output should be 48 bytes");
+                    per_page.push(loader_defs::paravisor::ExpectedPageHash { sha384_hash: hash });
                 }
             }
         });
-        hasher.finish().to_vec()
+        (combined.finish().to_vec(), per_page)
     }
 
     /// Finalize the loader state, returning an IGVM file.
@@ -554,11 +578,14 @@ impl<R: IgvmLoaderRegister + GuestArch + 'static> IgvmLoader<R> {
             // so just sort by the base page number
             imported_regions_data.sort_by_key(|region| region.base_page_number);
 
-            // All shared pages have been imported. Generate the secure cryptographic hash of the unaccepted
-            // imported pages.
-            let hash = self.generate_cryptographic_hash_of_shared_pages();
+            // All shared pages have been imported. Generate both the combined
+            // cryptographic hash of the unaccepted (shared) imported pages
+            // (stored in the header) and the per-page hash array (imported
+            // separately below into the expected-page-hashes region).
+            let (combined_hash, per_page_hashes) =
+                self.generate_cryptographic_hashes_of_shared_pages();
             let page_header = loader_defs::paravisor::ImportedRegionsPageHeader {
-                sha384_hash: hash
+                sha384_hash: combined_hash
                     .as_bytes()
                     .try_into()
                     .expect("hash should be correct size"),
@@ -578,6 +605,56 @@ impl<R: IgvmLoaderRegister + GuestArch + 'static> IgvmLoader<R> {
                 imported_regions_page.as_bytes(),
             )
             .context("failed to import config regions")?;
+
+            // Emit the per-page expected-hashes region if the caller told us
+            // where it goes. This is a separate measured region rather than
+            // an extension of the imported-regions page header so that older
+            // consumers of `ImportedRegionsPageHeader` see the exact same
+            // layout as before.
+            if let Some(hashes_page_base) = self.expected_page_hashes_config_page {
+                use loader_defs::paravisor::{
+                    EXPECTED_PAGE_HASH_MAX_COUNT, EXPECTED_PAGE_HASHES_MAGIC,
+                    EXPECTED_PAGE_HASHES_VERSION, ExpectedPageHashesHeader,
+                    PARAVISOR_MEASURED_VTL2_CONFIG_PAGE_HASHES_SIZE_PAGES,
+                };
+
+                let count = per_page_hashes.len();
+                if count > EXPECTED_PAGE_HASH_MAX_COUNT {
+                    anyhow::bail!(
+                        "expected-page-hashes region overflow: {} pages > {} max \
+                         (increase PARAVISOR_MEASURED_VTL2_CONFIG_PAGE_HASHES_SIZE_PAGES)",
+                        count,
+                        EXPECTED_PAGE_HASH_MAX_COUNT,
+                    );
+                }
+
+                let hashes_header = ExpectedPageHashesHeader {
+                    magic: EXPECTED_PAGE_HASHES_MAGIC,
+                    version: EXPECTED_PAGE_HASHES_VERSION,
+                    page_hash_count: count as u32,
+                    reserved: 0,
+                };
+
+                let region_bytes_capacity = PARAVISOR_MEASURED_VTL2_CONFIG_PAGE_HASHES_SIZE_PAGES
+                    as usize
+                    * PAGE_SIZE_4K as usize;
+                let mut region = Vec::with_capacity(region_bytes_capacity);
+                region.extend_from_slice(hashes_header.as_bytes());
+                region.extend_from_slice(per_page_hashes.as_bytes());
+                // Zero-pad to fill the whole reserved region so measurement
+                // sees a deterministic image regardless of how many pages
+                // this build ended up with.
+                region.resize(region_bytes_capacity, 0);
+
+                self.import_pages(
+                    hashes_page_base,
+                    PARAVISOR_MEASURED_VTL2_CONFIG_PAGE_HASHES_SIZE_PAGES,
+                    "loader-expected-page-hashes",
+                    BootPageAcceptance::Exclusive,
+                    &region,
+                )
+                .context("failed to import expected-page-hashes region")?;
+            }
         }
 
         // Finalize parameter pages with insert directives.
@@ -1177,6 +1254,10 @@ impl<R: IgvmLoaderRegister + GuestArch + 'static> ImageLoad<R> for IgvmVtlLoader
 
     fn set_imported_regions_config_page(&mut self, page_base: u64) {
         self.loader.imported_regions_config_page = Some(page_base);
+    }
+
+    fn set_expected_page_hashes_config_page(&mut self, page_base: u64) {
+        self.loader.expected_page_hashes_config_page = Some(page_base);
     }
 }
 

--- a/vm/loader/igvmfilegen/src/file_loader.rs
+++ b/vm/loader/igvmfilegen/src/file_loader.rs
@@ -567,50 +567,25 @@ impl<R: IgvmLoaderRegister + GuestArch + 'static> IgvmLoader<R> {
 
         // Put list of accepted pages into the config region, if there
         if let Some(page_base) = self.imported_regions_config_page {
-            let mut imported_regions_data: Vec<_> = self.imported_regions();
-
-            // Add this config page as well
-            imported_regions_data.push(loader_defs::paravisor::ImportedRegionDescriptor::new(
-                page_base, 1, true,
-            ));
-
-            // The accepted regions have been guaranteed to not overlap,
-            // so just sort by the base page number
-            imported_regions_data.sort_by_key(|region| region.base_page_number);
-
             // All shared pages have been imported. Generate both the combined
             // cryptographic hash of the unaccepted (shared) imported pages
             // (stored in the header) and the per-page hash array (imported
             // separately below into the expected-page-hashes region).
             let (combined_hash, per_page_hashes) =
                 self.generate_cryptographic_hashes_of_shared_pages();
-            let page_header = loader_defs::paravisor::ImportedRegionsPageHeader {
-                sha384_hash: combined_hash
-                    .as_bytes()
-                    .try_into()
-                    .expect("hash should be correct size"),
-            };
 
-            let mut imported_regions_page = page_header.as_bytes().to_vec();
-
-            // Append the (sorted) imported region data.
-            imported_regions_page.extend_from_slice(imported_regions_data.as_bytes());
-
-            // This list should be measured
-            self.import_pages(
-                page_base,
-                1,
-                "loader-imported-regions",
-                BootPageAcceptance::Exclusive,
-                imported_regions_page.as_bytes(),
-            )
-            .context("failed to import config regions")?;
-
-            // Emit the per-page expected-hashes region if the caller told us
-            // where it goes. This is a separate measured region rather than
-            // an extension of the imported-regions page header so that older
-            // consumers of `ImportedRegionsPageHeader` see the exact same
-            // layout as before.
+            // Emit the per-page expected-hashes region *first* if we have
+            // one, so that when we snapshot `imported_regions_data` below
+            // the descriptor list already covers it. Otherwise the shim
+            // would see this Exclusive region in the RMP (loader-pvalidated)
+            // but not in its imported-regions list, and would try to
+            // PVALIDATE it again -- resulting in `MemorySecurityViolation
+            // { carry_flag: 1 }` at the first page of the region.
+            //
+            // This is a separate measured region rather than an extension
+            // of the imported-regions page header so that older consumers
+            // of `ImportedRegionsPageHeader` see the exact same layout as
+            // before.
             if let Some(hashes_page_base) = self.expected_page_hashes_config_page {
                 use loader_defs::paravisor::{
                     EXPECTED_PAGE_HASH_MAX_COUNT, EXPECTED_PAGE_HASHES_MAGIC,
@@ -655,6 +630,42 @@ impl<R: IgvmLoaderRegister + GuestArch + 'static> IgvmLoader<R> {
                 )
                 .context("failed to import expected-page-hashes region")?;
             }
+
+            // Snapshot accepted_ranges *after* the hashes region (if any)
+            // has been imported so it appears in the descriptor list.
+            let mut imported_regions_data: Vec<_> = self.imported_regions();
+
+            // Add this config page as well (still not in accepted_ranges
+            // until the import_pages below runs).
+            imported_regions_data.push(loader_defs::paravisor::ImportedRegionDescriptor::new(
+                page_base, 1, true,
+            ));
+
+            // The accepted regions have been guaranteed to not overlap,
+            // so just sort by the base page number
+            imported_regions_data.sort_by_key(|region| region.base_page_number);
+
+            let page_header = loader_defs::paravisor::ImportedRegionsPageHeader {
+                sha384_hash: combined_hash
+                    .as_bytes()
+                    .try_into()
+                    .expect("hash should be correct size"),
+            };
+
+            let mut imported_regions_page = page_header.as_bytes().to_vec();
+
+            // Append the (sorted) imported region data.
+            imported_regions_page.extend_from_slice(imported_regions_data.as_bytes());
+
+            // This list should be measured
+            self.import_pages(
+                page_base,
+                1,
+                "loader-imported-regions",
+                BootPageAcceptance::Exclusive,
+                imported_regions_page.as_bytes(),
+            )
+            .context("failed to import config regions")?;
         }
 
         // Finalize parameter pages with insert directives.

--- a/vm/loader/loader_defs/src/paravisor.rs
+++ b/vm/loader/loader_defs/src/paravisor.rs
@@ -79,10 +79,23 @@ pub const PARAVISOR_MEASURED_VTL2_CONFIG_ACCEPTED_MEMORY_SIZE_PAGES: u64 = 1;
 /// Size in pages of VTL2 specific measured config
 pub const PARAVISOR_MEASURED_VTL2_CONFIG_SIZE_PAGES: u64 = 1;
 
+/// Size in pages for the per-page expected-hashes region. Holds one
+/// SHA-384 (48 bytes) per unmeasured (shared) 4 KB page in the IGVM, so the
+/// boot shim can identify which individual pages diverged from the
+/// measured baseline rather than only knowing "the combined hash was
+/// wrong". Sized generously: 256 pages = 1 MB / 48 B per hash = 21_845
+/// hashes max, comfortably above the ~16 K unmeasured pages on debug SNP
+/// images. Placed after PARAVISOR_MEASURED_VTL2_CONFIG_SIZE_PAGES so that
+/// PARAVISOR_MEASURED_VTL2_CONFIG_PAGE_INDEX stays where existing
+/// consumers expect it and only new readers need to know about the new
+/// region.
+pub const PARAVISOR_MEASURED_VTL2_CONFIG_PAGE_HASHES_SIZE_PAGES: u64 = 256;
+
 /// Count for vtl 2 measured config region size.
 pub const PARAVISOR_MEASURED_VTL2_CONFIG_REGION_PAGE_COUNT: u64 =
     PARAVISOR_MEASURED_VTL2_CONFIG_ACCEPTED_MEMORY_SIZE_PAGES
-        + PARAVISOR_MEASURED_VTL2_CONFIG_SIZE_PAGES;
+        + PARAVISOR_MEASURED_VTL2_CONFIG_SIZE_PAGES
+        + PARAVISOR_MEASURED_VTL2_CONFIG_PAGE_HASHES_SIZE_PAGES;
 
 // Measured config comes after the unmeasured config
 /// The page index to the list of accepted pages
@@ -94,6 +107,18 @@ pub const PARAVISOR_MEASURED_VTL2_CONFIG_ACCEPTED_MEMORY_PAGE_INDEX: u64 =
 pub const PARAVISOR_MEASURED_VTL2_CONFIG_PAGE_INDEX: u64 =
     PARAVISOR_MEASURED_VTL2_CONFIG_ACCEPTED_MEMORY_PAGE_INDEX
         + PARAVISOR_MEASURED_VTL2_CONFIG_ACCEPTED_MEMORY_SIZE_PAGES;
+
+/// The page index for the per-page expected-hashes region.
+///
+/// Deliberately placed AFTER `PARAVISOR_MEASURED_VTL2_CONFIG_PAGE_INDEX`
+/// (rather than between it and the accepted-memory page): this keeps
+/// `PARAVISOR_MEASURED_VTL2_CONFIG_PAGE_INDEX` at exactly the same offset
+/// as before this region was added, so any consumer that only reads the
+/// existing measured config page continues to work unchanged. Only
+/// consumers that opt in to reading per-page expected hashes need to
+/// know this index exists.
+pub const PARAVISOR_MEASURED_VTL2_CONFIG_PAGE_HASHES_PAGE_INDEX: u64 =
+    PARAVISOR_MEASURED_VTL2_CONFIG_PAGE_INDEX + PARAVISOR_MEASURED_VTL2_CONFIG_SIZE_PAGES;
 
 /// The maximum size in pages out of all isolation architectures.
 pub const PARAVISOR_VTL2_CONFIG_REGION_PAGE_COUNT_MAX: u64 =
@@ -273,6 +298,54 @@ impl ImportedRegionDescriptor {
         }
     }
 }
+
+/// Magic identifier at the start of the per-page expected-hashes region.
+/// Chosen so an older tool inspecting the region can recognise it. Bytes
+/// spell `EPHS` in ASCII, little-endian encoded.
+pub const EXPECTED_PAGE_HASHES_MAGIC: u32 = u32::from_le_bytes(*b"EPHS");
+
+/// Current layout version of `ExpectedPageHashesHeader` + its trailing
+/// array. Bumped only on incompatible changes.
+pub const EXPECTED_PAGE_HASHES_VERSION: u32 = 1;
+
+/// Header at page 0 of the measured per-page expected-hashes region
+/// (`PARAVISOR_MEASURED_VTL2_CONFIG_PAGE_HASHES_PAGE_INDEX`). Followed
+/// immediately by an array of `ExpectedPageHash` entries. Contents are
+/// zero-padded to fill the region.
+///
+/// Entry ordering: matches the shim's walk of
+/// `imported_regions().filter(!already_accepted)`, one entry per 4 KB
+/// page in ascending GPA order.
+#[repr(C)]
+#[derive(Copy, Clone, Debug, IntoBytes, Immutable, KnownLayout, FromBytes, PartialEq)]
+pub struct ExpectedPageHashesHeader {
+    /// `EXPECTED_PAGE_HASHES_MAGIC`.
+    pub magic: u32,
+    /// `EXPECTED_PAGE_HASHES_VERSION`.
+    pub version: u32,
+    /// Number of `ExpectedPageHash` entries that follow.
+    pub page_hash_count: u32,
+    /// Reserved, must be zero.
+    pub reserved: u32,
+}
+
+/// SHA-384 of one 4 KB unmeasured (shared) IGVM page, zero-extended to 4
+/// KB before hashing (matching the combined hash in
+/// `ImportedRegionsPageHeader::sha384_hash`).
+#[repr(C)]
+#[derive(Copy, Clone, Debug, IntoBytes, Immutable, KnownLayout, FromBytes, PartialEq)]
+pub struct ExpectedPageHash {
+    /// SHA-384 of the page contents.
+    pub sha384_hash: [u8; 48],
+}
+
+/// Maximum number of `ExpectedPageHash` entries the region can hold,
+/// given `PARAVISOR_MEASURED_VTL2_CONFIG_PAGE_HASHES_SIZE_PAGES` pages
+/// minus the header.
+pub const EXPECTED_PAGE_HASH_MAX_COUNT: usize =
+    (PARAVISOR_MEASURED_VTL2_CONFIG_PAGE_HASHES_SIZE_PAGES as usize * HV_PAGE_SIZE as usize
+        - size_of::<ExpectedPageHashesHeader>())
+        / size_of::<ExpectedPageHash>();
 
 /// Measured config about linux loaded into VTL0.
 #[repr(C)]

--- a/vm/loader/src/importer.rs
+++ b/vm/loader/src/importer.rs
@@ -535,4 +535,18 @@ where
     /// [`loader_defs::paravisor::ImportedRegionDescriptor`] with a page count
     /// of 0 indicates the end of the list.
     fn set_imported_regions_config_page(&mut self, page_base: u64);
+
+    /// Lets the loader know the base page of the measured region that will
+    /// carry an [`loader_defs::paravisor::ExpectedPageHashesHeader`] followed
+    /// by an array of
+    /// [`loader_defs::paravisor::ExpectedPageHash`] entries -- one SHA-384
+    /// per unmeasured (shared) 4 KB page, in the same order the boot shim
+    /// walks `imported_regions().filter(!already_accepted)`. Lets the boot
+    /// shim identify which individual pages diverged from the measured
+    /// baseline (rather than only knowing "the combined hash was wrong").
+    ///
+    /// Default implementation is a no-op: only the IGVM file loader
+    /// materially populates this region; runtime loaders that don't emit an
+    /// IGVM can ignore it.
+    fn set_expected_page_hashes_config_page(&mut self, _page_base: u64) {}
 }

--- a/vm/loader/src/paravisor.rs
+++ b/vm/loader/src/paravisor.rs
@@ -983,6 +983,14 @@ where
         config_region_page_base + PARAVISOR_MEASURED_VTL2_CONFIG_ACCEPTED_MEMORY_PAGE_INDEX;
 
     importer.set_imported_regions_config_page(imported_region_base);
+
+    // Also announce the per-page expected-hashes region. The IGVM file
+    // loader populates it in finalize alongside the imported-regions page
+    // (both regions are derived from the same set of shared pages). See
+    // `openhcl_boot::verify_imported_regions_hash` diagnostic changes.
+    let expected_page_hashes_base =
+        config_region_page_base + PARAVISOR_MEASURED_VTL2_CONFIG_PAGE_HASHES_PAGE_INDEX;
+    importer.set_expected_page_hashes_config_page(expected_page_hashes_base);
     Ok(())
 }
 
@@ -1552,6 +1560,12 @@ where
         config_region_page_base + PARAVISOR_MEASURED_VTL2_CONFIG_ACCEPTED_MEMORY_PAGE_INDEX;
 
     importer.set_imported_regions_config_page(imported_region_base);
+
+    // Also announce the per-page expected-hashes region (see comments in
+    // the x86 sibling above).
+    let expected_page_hashes_base =
+        config_region_page_base + PARAVISOR_MEASURED_VTL2_CONFIG_PAGE_HASHES_PAGE_INDEX;
+    importer.set_expected_page_hashes_config_page(expected_page_hashes_base);
 
     Ok(())
 }


### PR DESCRIPTION
Temporary diagnostics to collect data on imported regions hash mismatch failure. 