### PR TITLE
petri/logview: document npm ci for dependency install

### DIFF
--- a/petri/logview/README.md
+++ b/petri/logview/README.md
@@ -19,9 +19,13 @@ Navigate to the project directory and install all required packages:
 # Navigate to the logview directory
 cd .\petri\logview
 
-# Install all dependencies
-npm install
+# Install all dependencies exactly as locked
+npm ci
 ```
+
+`npm ci` installs the exact versions recorded in `package-lock.json`, which is
+what CI runs. Use `npm install` only when you intend to add or update a
+dependency, and commit the resulting `package-lock.json` changes.
 
 ### 2. Verify Installation
 
@@ -82,7 +86,7 @@ logview/
 
 ### Common Issues
 
-1. **Module not found errors**: Ensure all dependencies are installed with `npm install`
+1. **Module not found errors**: Ensure all dependencies are installed with `npm ci`
 2. **TypeScript errors**: Make sure both `tsconfig.json` and `tsconfig.node.json` are present
 3. **Port already in use**: The dev server uses port 3000 by default. You can change this in `vite.config.ts`
 


### PR DESCRIPTION
CI builds the logview site with `npm ci` (enforced in `build_test_results_website` as of #4198), but the README still told contributors to run `npm install`.

That mismatch matters: `npm install` silently repairs a lockfile that has drifted out of sync with `package.json`, which is exactly how the uninstallable `package-lock.json` fixed in #4198 went unnoticed for so long. Anyone following the README would never have reproduced the failure.

This points the setup and troubleshooting steps at `npm ci`, and notes that `npm install` is for intentionally adding or updating a dependency (with the resulting lockfile change committed).

Docs-only change; no code affected.

## Validation

Verified the documented command actually works on a CI-like environment (Linux x64, Node 22.22.0 matching `engines.node`), from a clean tree:

- `npm ci` -> exit 0, 110 packages
- correct native bindings resolved (`@rolldown/binding-linux-x64-gnu`, `binding-linux-x64-musl`); the optional wasm/`@emnapi` fallback correctly not installed
- `npm run build:ci` -> exit 0, built in 974ms