### PR TITLE
petri/logview: bump nanoid to 3.3.18 for GHSA-2v37-7h3g-55p8

### DIFF
--- a/petri/logview/package-lock.json
+++ b/petri/logview/package-lock.json
@@ -1436,9 +1436,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -1446,6 +1446,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },


### PR DESCRIPTION
`npm audit` reports a high-severity advisory against `nanoid <3.3.17` ([GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8)): custom generators can loop indefinitely when size is zero.

Spotted in the `publish openvmm.dev` CI logs, which now surface audit output alongside `npm ci`.

## Impact

Low. `nanoid` is a **transitive dev dependency of postcss**, used at build time only -- it is not part of the shipped browser bundle, and nothing in logview calls it with a zero size. Worth fixing regardless so `npm audit` stays clean and a real advisory isn't lost in the noise later.

## Change

postcss's dependency range already permits the fix, so this is a **lockfile-only** bump (3.3.16 -> 3.3.18). No `package.json` change.

The diff is deliberately minimal -- 4 lines. Regenerating the lockfile with npm 11 also strips `peer: true` from 5 unrelated entries (`vite`, `jiti`, `browserslist`, `@types/react`, `tinyglobby/picomatch`), which is a formatting artifact of a different npm version rather than a real dependency change. I patched only the `nanoid` entry to avoid that noise.

## Validation

On Linux x64 / Node 22.22.0, from a clean tree:

- `npm ci` -> exit 0, 110 packages; installed `nanoid` confirmed 3.3.18
- `npm run build:ci` -> exit 0
- `npm audit` -> **found 0 vulnerabilities**