### PR TITLE
openhcl: fix lower vtl permissions guard drop order and new failures

### DIFF
--- a/openhcl/lower_vtl_permissions_guard/src/device_dma.rs
+++ b/openhcl/lower_vtl_permissions_guard/src/device_dma.rs
@@ -18,9 +18,12 @@ use user_driver::memory::MemoryBlock;
 /// access to all VTLs.
 #[derive(Inspect)]
 pub struct LowerVtlDmaBuffer {
+    // NOTE: This must be dropped first to restore VTL protections to the
+    // underlying pages before we free the MemoryBlock and return any pages to
+    // be allocated again.
+    pub(crate) _vtl_guard: PagesAccessibleToLowerVtl,
     #[inspect(skip)]
     pub(crate) block: MemoryBlock,
-    pub(crate) _vtl_guard: PagesAccessibleToLowerVtl,
 }
 
 // SAFETY: The underlying MemoryBlock is providing the implementation for this

--- a/openhcl/lower_vtl_permissions_guard/src/lib.rs
+++ b/openhcl/lower_vtl_permissions_guard/src/lib.rs
@@ -35,15 +35,22 @@ impl PagesAccessibleToLowerVtl {
         vtl_protect: Arc<dyn VtlMemoryProtection + Send + Sync>,
         pages: &[u64],
     ) -> Result<Self> {
+        // Track pages that we have successfully lowered the VTL permissions on,
+        // so that we can restore them if any subsequent pages fail.
+        let mut guard = Self {
+            vtl_protect,
+            pages: Vec::with_capacity(pages.len()),
+        };
+
         for pfn in pages {
-            vtl_protect
+            guard
+                .vtl_protect
                 .modify_vtl_page_setting(*pfn, hvdef::HV_MAP_GPA_PERMISSIONS_ALL)
                 .context("failed to update VTL protections on page")?;
+
+            guard.pages.push(*pfn);
         }
-        Ok(Self {
-            vtl_protect,
-            pages: pages.to_vec(),
-        })
+        Ok(guard)
     }
 }
 


### PR DESCRIPTION
Fix two bugs in lower vtl permissiosn guard. One is around drop ordering, where we must restore VTL protections to allocated pages before returning them to allocation pools, and the other is to handle partial failures on construction by rolling back protections. 