### PR TITLE
vmservice: Add processor topology overrides

### DIFF
--- a/openvmm/openvmm_entry/src/ttrpc/mod.rs
+++ b/openvmm/openvmm_entry/src/ttrpc/mod.rs
@@ -54,6 +54,7 @@ use net_backend_resources::consomme::HostPortConfig;
 use net_backend_resources::consomme::HostPortProtocol;
 use net_backend_resources::mac_address::MacAddress;
 use netvsp_resources::NetvspHandle;
+use openvmm_defs::config::ArchTopologyConfig;
 use openvmm_defs::config::Config;
 use openvmm_defs::config::DeviceVtl;
 use openvmm_defs::config::HypervisorConfig;
@@ -104,6 +105,53 @@ use vm_resource::kind::SerialBackendHandle;
 use vm_resource::kind::VirtioDeviceHandle;
 use vm_resource::kind::VmbusDeviceHandleKind;
 use vmcore::non_volatile_store::resources::EphemeralNonVolatileStoreHandle;
+
+#[cfg(guest_arch = "aarch64")]
+fn parse_aarch64_topology_overrides(
+    cfg: &vmservice::ProcessorAarch64Config,
+) -> Result<ArchTopologyConfig, anyhow::Error> {
+    use openvmm_defs::config as dc;
+    use vmservice::processor_aarch64_config as pc;
+
+    let mut topology_config = dc::Aarch64TopologyConfig::default();
+    if let Some(gic_msi) = &cfg.gic_msi_config {
+        match gic_msi {
+            pc::GicMsiConfig::MsiIts(_) => topology_config.gic_msi = dc::GicMsiConfig::Its,
+            pc::GicMsiConfig::MsiV2m(v2m) => {
+                topology_config.gic_msi = dc::GicMsiConfig::V2m {
+                    spi_count: v2m.spi_count,
+                }
+            }
+        }
+    }
+    Ok(ArchTopologyConfig::Aarch64(topology_config))
+}
+
+fn parse_arch_topology_overrides(
+    processor_cfg: Option<&vmservice::ProcessorConfig>,
+) -> Result<Option<ArchTopologyConfig>, anyhow::Error> {
+    use vmservice::processor_config::ArchConfig as ProtoArchConfig;
+
+    match processor_cfg.and_then(|cfg| cfg.arch_config.as_ref()) {
+        #[cfg(not(guest_arch = "x86_64"))]
+        Some(ProtoArchConfig::X86(_)) => {
+            bail!("x86 topology overrides not supported on current arch")
+        }
+        #[cfg(guest_arch = "x86_64")]
+        Some(ProtoArchConfig::X86(_x86cfg)) => {
+            Ok(None) // No overrides on type currently.
+        }
+        #[cfg(not(guest_arch = "aarch64"))]
+        Some(ProtoArchConfig::Aarch64(_)) => {
+            bail!("aarch64 topology overrides not supported on current arch")
+        }
+        #[cfg(guest_arch = "aarch64")]
+        Some(ProtoArchConfig::Aarch64(aarch64)) => {
+            Ok(Some(parse_aarch64_topology_overrides(aarch64)?))
+        }
+        None => Ok(None),
+    }
+}
 
 #[derive(mesh::MeshPayload)]
 pub struct Parameters {
@@ -876,6 +924,7 @@ impl VmService {
             .as_ref()
             .map(|c| c.processor_count)
             .unwrap_or(1);
+        let arch = parse_arch_topology_overrides(req_config.processor_config.as_ref())?;
 
         // Build the PCIe topology (root complexes, switches, and the devices
         // attached behind their ports).
@@ -902,7 +951,7 @@ impl VmService {
                 proc_count: config_proc_count,
                 vps_per_socket: None,
                 enable_smt: None,
-                arch: Default::default(),
+                arch,
             },
             hypervisor: HypervisorConfig {
                 with_hv: true,

--- a/openvmm/openvmm_ttrpc_vmservice/src/vmservice.proto
+++ b/openvmm/openvmm_ttrpc_vmservice/src/vmservice.proto
@@ -118,6 +118,46 @@ message ProcessorConfig {
     uint32 processor_count = 1;
     uint32 processor_weight = 2;
     uint32 processor_limit = 3;
+
+    // Optional arch specific topology overrides.
+    oneof arch_config {
+        ProcessorX86Config x86 = 4;
+        ProcessorAarch64Config aarch64 = 5;
+    }
+}
+
+// Reflects the overrides of the `X86TopologyConfig`.
+message ProcessorX86Config {
+}
+
+// Reflects the overrides of the `Aarch64TopologyConfig`.
+message ProcessorAarch64Config {
+    // MSI controller selection for aarch64 PCIe interrupt delivery.
+    //
+    // Optional.
+    //
+    // If left unset, automatically select the best available MSI controller:
+    // - `GicMsiItsConfig` when the hypervisor supports it,
+    // - otherwise `GicMsiV2mConfig`.
+    oneof gic_msi_config {
+        // Force GICv3 ITS for MSI delivery via LPIs.
+        GicMsiItsConfig msi_its = 5;
+        // Force GICv2m for MSI delivery via SPIs.
+        GicMsiV2mConfig msi_v2m = 6;
+    }
+}
+
+// GICv3-specific MSI delivery overrides.
+message GicMsiItsConfig {}
+
+// GICv2m-specific MSI delivery overrides.
+message GicMsiV2mConfig {
+    // Number of SPIs reserved for PCIe MSIs.
+    //
+    // Optional.
+    //
+    // When unset, will use a platform-specific default.
+    optional uint32 spi_count = 1;
 }
 
 message DevicesConfig {


### PR DESCRIPTION
Adds support to the VmService ttrpc interface when creating the config to override the processor topology arch specific defaults.