### PR TITLE
vmbus_server: preserve proxy pipe offer data

### DIFF
--- a/vm/devices/get/guest_crash_device/src/lib.rs
+++ b/vm/devices/get/guest_crash_device/src/lib.rs
@@ -148,7 +148,11 @@ impl SimpleVmbusDevice for GuestCrashDevice {
             interface_name: "guest_crash".into(),
             instance_id: CRASHDUMP_GUID,
             interface_id: CRASHDUMP_GUID,
-            channel_type: vmbus_channel::bus::ChannelType::Pipe { message_mode: true },
+            channel_type: vmbus_channel::bus::ChannelType::Pipe {
+                message_mode: true,
+                user_defined: Default::default(),
+                pipe_flags: Default::default(),
+            },
             ..Default::default()
         }
     }

--- a/vm/devices/get/guest_emulation_device/src/lib.rs
+++ b/vm/devices/get/guest_emulation_device/src/lib.rs
@@ -297,7 +297,11 @@ impl SimpleVmbusDevice for GuestEmulationDevice {
             interface_name: "get".to_owned(),
             interface_id: get_protocol::GUEST_EMULATION_INTERFACE_TYPE,
             instance_id: get_protocol::GUEST_EMULATION_INTERFACE_INSTANCE,
-            channel_type: ChannelType::Pipe { message_mode: true },
+            channel_type: ChannelType::Pipe {
+                message_mode: true,
+                user_defined: Default::default(),
+                pipe_flags: Default::default(),
+            },
             ..Default::default()
         }
     }

--- a/vm/devices/get/guest_emulation_log/src/lib.rs
+++ b/vm/devices/get/guest_emulation_log/src/lib.rs
@@ -63,7 +63,11 @@ impl SimpleVmbusDevice for GuestEmulationLog {
             interface_name: "gel".to_owned(),
             interface_id: get_protocol::GUEST_EMULATION_INTERFACE_TYPE,
             instance_id: get_protocol::GET_LOG_INTERFACE_GUID,
-            channel_type: ChannelType::Pipe { message_mode: true },
+            channel_type: ChannelType::Pipe {
+                message_mode: true,
+                user_defined: Default::default(),
+                pipe_flags: Default::default(),
+            },
             ..Default::default()
         }
     }

--- a/vm/devices/hyperv_ic/src/kvp.rs
+++ b/vm/devices/hyperv_ic/src/kvp.rs
@@ -101,7 +101,11 @@ impl SimpleVmbusDevice for KvpIc {
             interface_name: "kvp_ic".to_owned(),
             instance_id: proto::INSTANCE_ID,
             interface_id: proto::INTERFACE_ID,
-            channel_type: ChannelType::Pipe { message_mode: true },
+            channel_type: ChannelType::Pipe {
+                message_mode: true,
+                user_defined: Default::default(),
+                pipe_flags: Default::default(),
+            },
             ..Default::default()
         }
     }

--- a/vm/devices/hyperv_ic/src/shutdown.rs
+++ b/vm/devices/hyperv_ic/src/shutdown.rs
@@ -242,7 +242,11 @@ impl SimpleVmbusDevice for ShutdownIc {
             interface_name: "shutdown_ic".to_owned(),
             instance_id: hyperv_ic_protocol::shutdown::INSTANCE_ID,
             interface_id: hyperv_ic_protocol::shutdown::INTERFACE_ID,
-            channel_type: ChannelType::Pipe { message_mode: true },
+            channel_type: ChannelType::Pipe {
+                message_mode: true,
+                user_defined: Default::default(),
+                pipe_flags: Default::default(),
+            },
             ..Default::default()
         }
     }

--- a/vm/devices/hyperv_ic/src/timesync.rs
+++ b/vm/devices/hyperv_ic/src/timesync.rs
@@ -106,7 +106,11 @@ impl SimpleVmbusDevice for TimesyncIc {
             interface_name: "timesync_ic".to_owned(),
             instance_id: proto::INSTANCE_ID,
             interface_id: proto::INTERFACE_ID,
-            channel_type: ChannelType::Pipe { message_mode: true },
+            channel_type: ChannelType::Pipe {
+                message_mode: true,
+                user_defined: Default::default(),
+                pipe_flags: Default::default(),
+            },
             ..Default::default()
         }
     }

--- a/vm/devices/serial/vmbus_serial_host/src/lib.rs
+++ b/vm/devices/serial/vmbus_serial_host/src/lib.rs
@@ -126,7 +126,11 @@ impl SimpleVmbusDevice for Serial {
             interface_name,
             interface_id: protocol::UART_INTERFACE_TYPE,
             instance_id,
-            channel_type: ChannelType::Pipe { message_mode: true },
+            channel_type: ChannelType::Pipe {
+                message_mode: true,
+                user_defined: Default::default(),
+                pipe_flags: Default::default(),
+            },
             ..Default::default()
         }
     }

--- a/vm/devices/vmbus/vmbus_channel/src/bus.rs
+++ b/vm/devices/vmbus/vmbus_channel/src/bus.rs
@@ -15,6 +15,8 @@ use std::fmt::Display;
 use std::time::Duration;
 use vmbus_core::protocol;
 use vmbus_core::protocol::GpadlId;
+use vmbus_core::protocol::PipeFlags;
+use vmbus_core::protocol::PipeUserDefinedData;
 use vmbus_core::protocol::UserDefinedData;
 use vmcore::interrupt::Interrupt;
 
@@ -323,6 +325,10 @@ pub enum ChannelType {
     Pipe {
         /// If true, the pipe uses message mode. Otherwise, it uses byte mode.
         message_mode: bool,
+        /// Provider-defined offer data.
+        user_defined: PipeUserDefinedData,
+        /// Pipe capabilities.
+        pipe_flags: PipeFlags,
     },
     /// A channel representing a Hyper-V socket.
     HvSocket {

--- a/vm/devices/vmbus/vmbus_core/src/protocol.rs
+++ b/vm/devices/vmbus/vmbus_core/src/protocol.rs
@@ -572,17 +572,73 @@ open_enum! {
     }
 }
 
-/// First 4 bytes of user_defined for named pipe offers.
+/// Provider-defined portion of the user-defined data for named pipe offers.
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    PartialEq,
+    Eq,
+    IntoBytes,
+    FromBytes,
+    Immutable,
+    KnownLayout,
+    Protobuf,
+    Inspect,
+)]
+#[repr(transparent)]
+#[mesh(transparent)]
+#[inspect(transparent)]
+pub struct PipeUserDefinedData([u8; 112]);
+
+impl From<[u8; 112]> for PipeUserDefinedData {
+    fn from(value: [u8; 112]) -> Self {
+        Self(value)
+    }
+}
+
+impl From<PipeUserDefinedData> for [u8; 112] {
+    fn from(value: PipeUserDefinedData) -> Self {
+        value.0
+    }
+}
+
+impl Default for PipeUserDefinedData {
+    fn default() -> Self {
+        Self::new_zeroed()
+    }
+}
+
+/// User-defined data layout for named pipe offers.
 #[repr(C)]
 #[derive(Copy, Clone, IntoBytes, FromBytes, Immutable, KnownLayout)]
 pub struct PipeUserDefinedParameters {
     pub pipe_type: PipeType,
+    pub user_defined: PipeUserDefinedData,
+    pub flags: PipeFlags,
+}
+
+static_assertions::const_assert_eq!(
+    size_of::<PipeUserDefinedParameters>(),
+    size_of::<UserDefinedData>()
+);
+
+/// Flags stored in the final 4 bytes of the named pipe user-defined data.
+#[derive(Inspect)]
+#[bitfield(u32)]
+#[derive(IntoBytes, FromBytes, Immutable, KnownLayout, PartialEq, Eq, Protobuf)]
+#[mesh(transparent)]
+pub struct PipeFlags {
+    /// Indicates that the pipe supports GPA-direct transfers.
+    pub gpa_direct: bool,
+    #[bits(31)]
+    _reserved: u32,
 }
 
 #[repr(C)]
 #[derive(Copy, Clone, IntoBytes, FromBytes, Immutable, KnownLayout)]
 pub struct HvsockUserDefinedParameters {
-    pub pipe_params: PipeUserDefinedParameters,
+    pub pipe_type: PipeType,
     pub is_for_guest_accept: u8,
     pub is_for_guest_container: u8,
     pub version: Unalign<HvsockParametersVersion>, // unaligned u32
@@ -593,9 +649,7 @@ pub struct HvsockUserDefinedParameters {
 impl HvsockUserDefinedParameters {
     pub fn new(is_for_guest_accept: bool, is_for_guest_container: bool, silo_id: Guid) -> Self {
         Self {
-            pipe_params: PipeUserDefinedParameters {
-                pipe_type: PipeType::BYTE,
-            },
+            pipe_type: PipeType::BYTE,
             is_for_guest_accept: is_for_guest_accept.into(),
             is_for_guest_container: is_for_guest_container.into(),
             version: Unalign::new(HvsockParametersVersion::RS5),

--- a/vm/devices/vmbus/vmbus_server/src/channels.rs
+++ b/vm/devices/vmbus/vmbus_server/src/channels.rs
@@ -692,13 +692,21 @@ impl From<OfferParams> for OfferParamsInternal {
                 flags.set_enumerate_device_interface(true);
                 user_defined = interface_user_defined;
             }
-            ChannelType::Pipe { message_mode } => {
+            ChannelType::Pipe {
+                message_mode,
+                user_defined: pipe_user_defined,
+                pipe_flags,
+            } => {
                 flags.set_enumerate_device_interface(true);
                 flags.set_named_pipe_mode(true);
-                user_defined.as_pipe_params_mut().pipe_type = if message_mode {
-                    protocol::PipeType::MESSAGE
-                } else {
-                    protocol::PipeType::BYTE
+                *user_defined.as_pipe_params_mut() = protocol::PipeUserDefinedParameters {
+                    pipe_type: if message_mode {
+                        protocol::PipeType::MESSAGE
+                    } else {
+                        protocol::PipeType::BYTE
+                    },
+                    user_defined: pipe_user_defined,
+                    flags: pipe_flags,
                 };
             }
             ChannelType::HvSocket {

--- a/vm/devices/vmbus/vmbus_server/src/channels/tests.rs
+++ b/vm/devices/vmbus/vmbus_server/src/channels/tests.rs
@@ -14,6 +14,31 @@ use vmbus_core::protocol::TargetInfo;
 use zerocopy::FromBytes;
 
 #[test]
+fn pipe_offer_data_is_encoded_in_user_defined_data() {
+    let pipe_flags = protocol::PipeFlags::new().with_gpa_direct(true);
+    let user_defined = protocol::PipeUserDefinedData::from([0x5a; 112]);
+    let params: OfferParamsInternal = OfferParams {
+        channel_type: ChannelType::Pipe {
+            message_mode: true,
+            user_defined,
+            pipe_flags,
+        },
+        ..Default::default()
+    }
+    .into();
+
+    assert_eq!(
+        params.user_defined.as_pipe_params().pipe_type,
+        protocol::PipeType::MESSAGE
+    );
+    assert_eq!(
+        params.user_defined.as_pipe_params().user_defined,
+        user_defined
+    );
+    assert_eq!(params.user_defined.as_pipe_params().flags, pipe_flags);
+}
+
+#[test]
 fn test_version_negotiation_not_supported() {
     let mut env = TestEnv::new();
 

--- a/vm/devices/vmbus/vmbus_server/src/proxyintegration.rs
+++ b/vm/devices/vmbus/vmbus_server/src/proxyintegration.rs
@@ -570,7 +570,11 @@ impl ProxyTask {
                         anyhow::bail!("unsupported offer pipe mode");
                     }
                 };
-                ChannelType::Pipe { message_mode }
+                ChannelType::Pipe {
+                    message_mode,
+                    user_defined: params.user_defined,
+                    pipe_flags: params.flags,
+                }
             } else {
                 ChannelType::Interface {
                     user_defined: offer.UserDefined,


### PR DESCRIPTION
## Problem

When relaying a named-pipe channel offer from `vmbusproxy`, `vmbus_server` converts the offer to `ChannelType::Pipe`. That type retains only whether the pipe uses byte or message mode.

Converting the resulting `OfferParams` to `OfferParamsInternal` therefore reconstructs `UserDefinedData` from zeroes and preserves only the pipe mode. Any additional pipe-specific offer data supplied by the channel provider is lost.

## Fix

For proxy-originated pipe channels, preserve the complete original `UserDefinedData` after performing the normal typed conversion and pipe-mode validation.

This keeps the existing semantic channel classification while ensuring the provider-owned offer payload is relayed unchanged.

The override is intentionally limited to this boundary:

- Native pipe offers continue to use canonical generated data.
- Interface offers already preserve their complete user-defined payload.
- Hyper-V socket translation remains typed and canonicalized.
- Other channel behavior and offer flags are unchanged.

This is implemented in the proxy integration rather than `From<OfferParams>` because `OfferParams::Pipe` no longer contains the original payload, and the generic conversion is also used by native channel providers.

The change was validated with a downlevel Windows guest scenario that previously failed during boot.
