### PR TITLE
vmbus_server: allow channels to require pinned memory

### DIFF
--- a/openhcl/underhill_core/src/lib.rs
+++ b/openhcl/underhill_core/src/lib.rs
@@ -330,6 +330,7 @@ async fn launch_workers(
         vmbus_max_version: opt.vmbus_max_version,
         vmbus_enable_mnf: opt.vmbus_enable_mnf,
         vmbus_force_confidential_external_memory: opt.vmbus_force_confidential_external_memory,
+        vmbus_force_gpa_pinning: opt.vmbus_force_gpa_pinning,
         vmbus_channel_unstick_delay: (opt.vmbus_channel_unstick_delay_ms != 0)
             .then(|| Duration::from_millis(opt.vmbus_channel_unstick_delay_ms)),
         cmdline_append: opt.cmdline_append.clone(),

--- a/openhcl/underhill_core/src/options.rs
+++ b/openhcl/underhill_core/src/options.rs
@@ -199,6 +199,10 @@ pub struct Options {
     /// N.B.: Not all vmbus devices support this feature, so enabling it may cause failures.
     pub vmbus_force_confidential_external_memory: bool,
 
+    /// (OPENHCL_VMBUS_FORCE_GPA_PINNING=1)
+    /// Force all vmbus channels to use pinned GPA ranges. Used for testing purposes only.
+    pub vmbus_force_gpa_pinning: bool,
+
     /// (OPENHCL_VMBUS_CHANNEL_UNSTICK_DELAY_MS=\<number\>) (default: 100)
     /// Delay before unsticking a vmbus channel after it has been opened, in milliseconds. Set to
     /// zero to disable unsticking.
@@ -446,6 +450,7 @@ impl Options {
             read_legacy_openhcl_env("OPENHCL_VMBUS_ENABLE_MNF").map(|v| parse_bool(Some(v)));
         let vmbus_force_confidential_external_memory =
             parse_env_bool("OPENHCL_VMBUS_FORCE_CONFIDENTIAL_EXTERNAL_MEMORY");
+        let vmbus_force_gpa_pinning = parse_env_bool("OPENHCL_VMBUS_FORCE_GPA_PINNING");
         let vmbus_channel_unstick_delay_ms =
             parse_legacy_env_number("OPENHCL_VMBUS_CHANNEL_UNSTICK_DELAY_MS")?;
         let cmdline_append = read_legacy_openhcl_env("OPENHCL_CMDLINE_APPEND")
@@ -584,6 +589,7 @@ impl Options {
             vmbus_max_version,
             vmbus_enable_mnf,
             vmbus_force_confidential_external_memory,
+            vmbus_force_gpa_pinning,
             vmbus_channel_unstick_delay_ms: vmbus_channel_unstick_delay_ms.unwrap_or(100),
             cmdline_append,
             vnc_port: vnc_port.unwrap_or(3),

--- a/openhcl/underhill_core/src/options.rs
+++ b/openhcl/underhill_core/src/options.rs
@@ -200,7 +200,8 @@ pub struct Options {
     pub vmbus_force_confidential_external_memory: bool,
 
     /// (OPENHCL_VMBUS_FORCE_GPA_PINNING=1)
-    /// Force all vmbus channels to use pinned GPA ranges. Used for testing purposes only.
+    /// Force all vmbus channels to use pinned GPA ranges if the guest supports that feature. Used
+    /// for testing purposes only.
     pub vmbus_force_gpa_pinning: bool,
 
     /// (OPENHCL_VMBUS_CHANNEL_UNSTICK_DELAY_MS=\<number\>) (default: 100)

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -3211,9 +3211,9 @@ async fn new_underhill_vm(
 
         // Enable the GPA pinning feature only if the hypercalls are available.
         #[cfg(not(guest_arch = "x86_64"))]
-        let use_gpa_pinning = false;
+        let support_gpa_pinning = false;
         #[cfg(guest_arch = "x86_64")]
-        let use_gpa_pinning = {
+        let support_gpa_pinning = {
             let result =
                 safe_intrinsics::cpuid(hvdef::HV_CPUID_FUNCTION_MS_HV_ENLIGHTENMENT_INFORMATION, 0);
             hvdef::HvEnlightenmentInformation::from(
@@ -3266,8 +3266,8 @@ async fn new_underhill_vm(
                 .force_confidential_external_memory(
                     env_cfg.vmbus_force_confidential_external_memory,
                 )
-                .support_gpa_pinning(use_gpa_pinning)
-                .force_gpa_pinning(use_gpa_pinning && env_cfg.vmbus_force_gpa_pinning)
+                .support_gpa_pinning(support_gpa_pinning)
+                .force_gpa_pinning(support_gpa_pinning && env_cfg.vmbus_force_gpa_pinning)
                 .channel_unstick_delay(env_cfg.vmbus_channel_unstick_delay)
                 // For saved-state compat with release/2411.
                 .send_messages_while_stopped(true)

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -3229,15 +3229,18 @@ async fn new_underhill_vm(
             .vmbus_max_version
             .map(vmbus_core::MaxVersionInfo::new)
             .or_else(|| {
-                // For compatibility with rollback, any additional features are currently disabled,
-                // except for isolated guests which do not support servicing.
+                // For compatibility with rollback, the max version should only include feature
+                // flags that are available in all in-service versions of OpenHCL.
+                // N.B. Isolated VMs do not support servicing, so they can use all flags.
+                // N.B. VM SKUs that support GPA pinning are guaranteed to use a compatible
+                //      version of OpenHCL so it can safely be enabled here.
                 (!hardware_isolated).then_some(vmbus_core::MaxVersionInfo {
                     version: vmbus_core::protocol::Version::Copper as u32,
                     feature_flags: vmbus_core::protocol::FeatureFlags::new()
                         .with_guest_specified_signal_parameters(true)
                         .with_channel_interrupt_redirection(true)
                         .with_modify_connection(true)
-                        .with_gpa_pinning(use_gpa_pinning),
+                        .with_gpa_pinning(true),
                 })
             });
 
@@ -3263,7 +3266,8 @@ async fn new_underhill_vm(
                 .force_confidential_external_memory(
                     env_cfg.vmbus_force_confidential_external_memory,
                 )
-                .force_gpa_pinning(env_cfg.vmbus_force_gpa_pinning)
+                .support_gpa_pinning(use_gpa_pinning)
+                .force_gpa_pinning(use_gpa_pinning && env_cfg.vmbus_force_gpa_pinning)
                 .channel_unstick_delay(env_cfg.vmbus_channel_unstick_delay)
                 // For saved-state compat with release/2411.
                 .send_messages_while_stopped(true)

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -259,6 +259,8 @@ pub struct UnderhillEnvCfg {
     pub vmbus_enable_mnf: Option<bool>,
     /// Force the use of confidential external memory for all non-relay vmbus channels.
     pub vmbus_force_confidential_external_memory: bool,
+    /// Force the use of GPA pinning for all vmbus channels.
+    pub vmbus_force_gpa_pinning: bool,
     /// Delay before unsticking a vmbus channel after it has been opened.
     pub vmbus_channel_unstick_delay: Option<Duration>,
     /// Command line to append to VTL0 command line. Only used for linux direct.
@@ -3207,6 +3209,22 @@ async fn new_underhill_vm(
             .unwrap_or(!controllers.mana.is_empty());
         tracing::info!(CVM_ALLOWED, enable_mnf, "Underhill MNF enabled?");
 
+        // Enable the GPA pinning feature only if the hypercalls are available.
+        #[cfg(not(guest_arch = "x86_64"))]
+        let use_gpa_pinning = false;
+        #[cfg(guest_arch = "x86_64")]
+        let use_gpa_pinning = {
+            let result =
+                safe_intrinsics::cpuid(hvdef::HV_CPUID_FUNCTION_MS_HV_ENLIGHTENMENT_INFORMATION, 0);
+            hvdef::HvEnlightenmentInformation::from(
+                result.eax as u128
+                    | (result.ebx as u128) << 32
+                    | (result.ecx as u128) << 64
+                    | (result.edx as u128) << 96,
+            )
+            .use_gpa_pinning_hypercall()
+        };
+
         let max_version = env_cfg
             .vmbus_max_version
             .map(vmbus_core::MaxVersionInfo::new)
@@ -3218,7 +3236,8 @@ async fn new_underhill_vm(
                     feature_flags: vmbus_core::protocol::FeatureFlags::new()
                         .with_guest_specified_signal_parameters(true)
                         .with_channel_interrupt_redirection(true)
-                        .with_modify_connection(true),
+                        .with_modify_connection(true)
+                        .with_gpa_pinning(use_gpa_pinning),
                 })
             });
 
@@ -3244,6 +3263,7 @@ async fn new_underhill_vm(
                 .force_confidential_external_memory(
                     env_cfg.vmbus_force_confidential_external_memory,
                 )
+                .force_gpa_pinning(env_cfg.vmbus_force_gpa_pinning)
                 .channel_unstick_delay(env_cfg.vmbus_channel_unstick_delay)
                 // For saved-state compat with release/2411.
                 .send_messages_while_stopped(true)

--- a/vm/devices/net/netvsp/src/test.rs
+++ b/vm/devices/net/netvsp/src/test.rs
@@ -702,6 +702,7 @@ impl TestNicDevice {
             interrupt: host_to_guest_interrupt,
             use_confidential_ring: false,
             use_confidential_external_memory: false,
+            is_external_memory_pinned: false,
         };
 
         let open_response = self
@@ -753,6 +754,7 @@ impl TestNicDevice {
             interrupt: host_to_guest_interrupt,
             use_confidential_ring: false,
             use_confidential_external_memory: false,
+            is_external_memory_pinned: false,
         };
 
         let open_response = self
@@ -879,6 +881,7 @@ impl TestNicDevice {
                                                 interrupt: host_to_guest_interrupt.clone(),
                                                 use_confidential_external_memory: false,
                                                 use_confidential_ring: false,
+                                                is_external_memory_pinned: false,
                                             }),
                                             gpadls,
                                         })

--- a/vm/devices/vmbus/vmbus_channel/src/bus.rs
+++ b/vm/devices/vmbus/vmbus_channel/src/bus.rs
@@ -209,6 +209,11 @@ pub struct OpenRequest {
     /// Indicates if the currently connected vmbus client, as well as the channel the request is
     /// for, supports the use of confidential external memory.
     pub use_confidential_external_memory: bool,
+    /// Indicates if the currently connected vmbus client is expected to pin any external memory
+    /// used by the channel. This is only true if the vmbus client supports GPA pinning and the
+    /// channel indicated it requires pinned external memory. It can only be true for paravisor
+    /// channels in a VM that supports the GPA pinning hypercalls.
+    pub is_external_memory_pinned: bool,
 }
 
 impl OpenRequest {
@@ -226,6 +231,8 @@ impl OpenRequest {
                 && offer_flags.confidential_ring_buffer(),
             use_confidential_external_memory: feature_flags.confidential_channels()
                 && offer_flags.confidential_external_memory(),
+            is_external_memory_pinned: feature_flags.gpa_pinning()
+                && offer_flags.require_pinned_external_memory(),
         }
     }
 }

--- a/vm/devices/vmbus/vmbus_core/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_core/src/lib.rs
@@ -81,13 +81,6 @@ impl MaxVersionInfo {
             feature_flags: protocol::FeatureFlags::new(),
         }
     }
-
-    pub fn unlimited() -> Self {
-        Self {
-            version: u32::MAX,
-            feature_flags: protocol::FeatureFlags::from_bits(u32::MAX),
-        }
-    }
 }
 
 impl From<VersionInfo> for MaxVersionInfo {

--- a/vm/devices/vmbus/vmbus_core/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_core/src/lib.rs
@@ -81,6 +81,13 @@ impl MaxVersionInfo {
             feature_flags: protocol::FeatureFlags::new(),
         }
     }
+
+    pub fn unlimited() -> Self {
+        Self {
+            version: u32::MAX,
+            feature_flags: protocol::FeatureFlags::from_bits(u32::MAX),
+        }
+    }
 }
 
 impl From<VersionInfo> for MaxVersionInfo {

--- a/vm/devices/vmbus/vmbus_core/src/protocol.rs
+++ b/vm/devices/vmbus/vmbus_core/src/protocol.rs
@@ -190,7 +190,11 @@ pub struct FeatureFlags {
     /// case the guest cannot cancel MNF interrupts from the host.
     pub server_specified_monitor_pages: bool, // 0x40
 
-    #[bits(25)]
+    /// The guest supports channels that require the use of pinned memory. This indicates that the
+    /// `require_pinned_external_memory` flag in the channel offer message is supported.
+    pub gpa_pinning: bool, // 0x80
+
+    #[bits(24)]
     _reserved: u32,
 }
 
@@ -553,9 +557,9 @@ pub struct OfferFlags {
     /// Indicates the channel must use encrypted additional GPADLs and GPA direct ranges on a
     /// hardware-isolated VM.
     pub confidential_external_memory: bool, // 0x4
-    #[bits(1)]
-    _reserved1: u16,
-    pub named_pipe_mode: bool, // 0x10
+    // Indicates that additional GPADLs and GPA direct packets must use pinned GPA ranges.
+    pub require_pinned_external_memory: bool, // 0x8
+    pub named_pipe_mode: bool,                // 0x10
     #[bits(8)]
     _reserved2: u16,
     pub tlnpi_provider: bool, // 0x2000

--- a/vm/devices/vmbus/vmbus_core/src/protocol.rs
+++ b/vm/devices/vmbus/vmbus_core/src/protocol.rs
@@ -557,9 +557,9 @@ pub struct OfferFlags {
     /// Indicates the channel must use encrypted additional GPADLs and GPA direct ranges on a
     /// hardware-isolated VM.
     pub confidential_external_memory: bool, // 0x4
-    // Indicates that additional GPADLs and GPA direct packets must use pinned GPA ranges.
+    /// Indicates that additional GPADLs and GPA direct packets must use pinned GPA ranges.
     pub require_pinned_external_memory: bool, // 0x8
-    pub named_pipe_mode: bool,                // 0x10
+    pub named_pipe_mode: bool,            // 0x10
     #[bits(8)]
     _reserved2: u16,
     pub tlnpi_provider: bool, // 0x2000

--- a/vm/devices/vmbus/vmbus_server/src/channels.rs
+++ b/vm/devices/vmbus/vmbus_server/src/channels.rs
@@ -3974,6 +3974,10 @@ impl<N: Notifier> MessageSender<'_, N> {
             flags.set_confidential_external_memory(false);
         }
 
+        if !connection_info.version.feature_flags.gpa_pinning() {
+            flags.set_require_pinned_external_memory(false);
+        }
+
         // Send the monitor ID only if the guest supports MNF. MNF may also be disabled if the guest
         // provided monitor pages but this server can only use server-allocated monitor pages
         // (typically the case for OpenHCL on a hardware-isolated VM), but the guest didn't support

--- a/vm/devices/vmbus/vmbus_server/src/channels.rs
+++ b/vm/devices/vmbus/vmbus_server/src/channels.rs
@@ -1329,7 +1329,8 @@ const SUPPORTED_FEATURE_FLAGS: FeatureFlags = FeatureFlags::new()
     .with_modify_connection(true)
     .with_client_id(true)
     .with_pause_resume(true)
-    .with_server_specified_monitor_pages(true);
+    .with_server_specified_monitor_pages(true)
+    .with_gpa_pinning(true);
 
 /// Trait for sending requests to devices and the guest.
 pub trait Notifier: Send {
@@ -2282,14 +2283,6 @@ impl<'a, N: 'a + Notifier> ServerWithNotifier<'a, N> {
             return;
         };
 
-        tracelimit::info_ratelimited!(
-            vtl,
-            ?version,
-            client_id = ?request.client_id,
-            trusted = request.trusted,
-            "Guest negotiated version"
-        );
-
         // Make sure we can receive incoming interrupts on the monitor page. The parent to child
         // page is not used as this server doesn't send monitored interrupts.
         let monitor_page = match request.monitor_page {
@@ -2365,7 +2358,8 @@ impl<'a, N: 'a + Notifier> ServerWithNotifier<'a, N> {
         //      supported.
         const LOCAL_FEATURE_FLAGS: FeatureFlags = FeatureFlags::new()
             .with_client_id(true)
-            .with_confidential_channels(true);
+            .with_confidential_channels(true)
+            .with_gpa_pinning(true);
 
         let (relay_feature_flags, server_specified_monitor_page) = match response {
             // There is no relay, or it successfully processed our request.
@@ -2433,6 +2427,14 @@ impl<'a, N: 'a + Notifier> ServerWithNotifier<'a, N> {
                 .feature_flags
                 .set_server_specified_monitor_pages(false);
         }
+
+        tracelimit::info_ratelimited!(
+            vtl = self.inner.assigned_channels.vtl as u8,
+            version = ?info.version,
+            client_id = ?info.client_id,
+            trusted = info.trusted,
+            "guest negotiated version"
+        );
 
         let version = info.version;
         self.inner.state = ConnectionState::Connected(info);

--- a/vm/devices/vmbus/vmbus_server/src/channels.rs
+++ b/vm/devices/vmbus/vmbus_server/src/channels.rs
@@ -148,6 +148,7 @@ pub struct Server {
     // shared memory and we cannot set protections on shared memory.
     require_server_allocated_mnf: bool,
     use_absolute_channel_order: bool,
+    support_gpa_pinning: bool,
 }
 
 pub struct ServerWithNotifier<'a, T> {
@@ -1323,14 +1324,14 @@ static SUPPORTED_VERSIONS: &[Version] = &[
 
 // Feature flags that are always supported.
 // N.B. Confidential channels are conditionally supported if running in the paravisor.
+// N.B. GPA pinning is conditionally supported if the server is configured to support it.
 const SUPPORTED_FEATURE_FLAGS: FeatureFlags = FeatureFlags::new()
     .with_guest_specified_signal_parameters(true)
     .with_channel_interrupt_redirection(true)
     .with_modify_connection(true)
     .with_client_id(true)
     .with_pause_resume(true)
-    .with_server_specified_monitor_pages(true)
-    .with_gpa_pinning(true);
+    .with_server_specified_monitor_pages(true);
 
 /// Trait for sending requests to devices and the guest.
 pub trait Notifier: Send {
@@ -1374,6 +1375,7 @@ impl Server {
         child_connection_id: u32,
         channel_id_offset: u16,
         use_absolute_channel_order: bool,
+        support_gpa_pinning: bool,
     ) -> Self {
         Server {
             state: ConnectionState::Disconnected,
@@ -1389,6 +1391,7 @@ impl Server {
             pending_messages: PendingMessages(VecDeque::new()),
             require_server_allocated_mnf: false,
             use_absolute_channel_order,
+            support_gpa_pinning,
         }
     }
 
@@ -2464,8 +2467,9 @@ impl<'a, N: 'a + Notifier> ServerWithNotifier<'a, N> {
 
         let supported_flags = if version >= Version::Copper {
             // Confidential channels should only be enabled if the connection is trusted.
-            let max_supported_flags =
-                SUPPORTED_FEATURE_FLAGS.with_confidential_channels(request.trusted);
+            let max_supported_flags = SUPPORTED_FEATURE_FLAGS
+                .with_confidential_channels(request.trusted)
+                .with_gpa_pinning(self.inner.support_gpa_pinning);
 
             // The max features may be limited in order to test older protocol versions.
             if let Some(max_version) = self.inner.max_version {

--- a/vm/devices/vmbus/vmbus_server/src/channels.rs
+++ b/vm/devices/vmbus/vmbus_server/src/channels.rs
@@ -3971,6 +3971,8 @@ impl<N: Notifier> MessageSender<'_, N> {
     fn send_offer(&mut self, channel: &mut Channel, connection_info: &ConnectionInfo) {
         let info = channel.info.as_ref().expect("assigned");
         let mut flags = channel.offer.flags;
+
+        // Disable offer flags that are supported by the current set of feature flags.
         if !connection_info
             .version
             .feature_flags

--- a/vm/devices/vmbus/vmbus_server/src/channels.rs
+++ b/vm/devices/vmbus/vmbus_server/src/channels.rs
@@ -3972,7 +3972,7 @@ impl<N: Notifier> MessageSender<'_, N> {
         let info = channel.info.as_ref().expect("assigned");
         let mut flags = channel.offer.flags;
 
-        // Disable offer flags that are supported by the current set of feature flags.
+        // Disable offer flags that are not supported by the current set of feature flags.
         if !connection_info
             .version
             .feature_flags

--- a/vm/devices/vmbus/vmbus_server/src/channels/tests.rs
+++ b/vm/devices/vmbus/vmbus_server/src/channels/tests.rs
@@ -199,6 +199,35 @@ fn test_version_negotiation_feature_flags() {
 }
 
 #[test]
+fn test_version_negotiation_gpa_pinning_requires_server_support() {
+    let requested_features = FeatureFlags::new().with_gpa_pinning(true);
+    let target_info = TargetInfo::new()
+        .with_sint(VMBUS_SINT)
+        .with_vtl(0)
+        .with_feature_flags(requested_features.into());
+
+    let mut env = TestEnv::new();
+    test_initiate_contact(
+        &mut env,
+        TestVersion::Supported {
+            version: Version::Copper,
+            expected_features: 0,
+        },
+        target_info.into(),
+    );
+
+    let mut env = TestEnv::with_params(false, true);
+    test_initiate_contact(
+        &mut env,
+        TestVersion::Supported {
+            version: Version::Copper,
+            expected_features: requested_features.into(),
+        },
+        target_info.into(),
+    );
+}
+
+#[test]
 fn test_version_negotiation_interrupt_page() {
     let mut env = TestEnv::new();
     test_initiate_contact(
@@ -2062,7 +2091,7 @@ fn test_channel_id_order() {
 
 #[test]
 fn test_channel_id_order_absolute() {
-    let mut env = TestEnv::with_params(true);
+    let mut env = TestEnv::with_params(true, false);
 
     let _offer_id1 = env.offer_with_order(3, 3, Some(1));
     let _offer_id3 = env.offer_with_order(5, 5, Some(3));
@@ -2258,6 +2287,33 @@ fn test_confidential_channels_unsupported() {
 
     env.notifier
         .check_message(OutgoingMessage::new(&protocol::AllOffersDelivered {}));
+}
+
+#[test]
+fn test_offer_requires_pinning_only_when_negotiated() {
+    for negotiate_gpa_pinning in [false, true] {
+        let mut env = TestEnv::with_params(false, true);
+        env.connect(
+            Version::Copper,
+            FeatureFlags::new().with_gpa_pinning(negotiate_gpa_pinning),
+        );
+
+        env.offer_with_flags(
+            1,
+            OfferFlags::new().with_require_pinned_external_memory(true),
+        );
+        env.c().handle_request_offers().unwrap();
+
+        let offer = env.notifier.get_message::<protocol::OfferChannel>();
+        assert_eq!(offer.channel_id, ChannelId(1));
+        assert_eq!(
+            offer.flags,
+            OfferFlags::new().with_require_pinned_external_memory(negotiate_gpa_pinning)
+        );
+
+        env.notifier
+            .check_message(OutgoingMessage::new(&protocol::AllOffersDelivered {}));
+    }
 }
 
 #[test]
@@ -2727,16 +2783,17 @@ struct TestEnv {
 
 impl TestEnv {
     fn new() -> Self {
-        Self::with_params(false)
+        Self::with_params(false, false)
     }
 
-    fn with_params(assign_channel_id_on_offer: bool) -> Self {
+    fn with_params(assign_channel_id_on_offer: bool, support_gpa_pinning: bool) -> Self {
         let (notifier, recv) = TestNotifier::new();
         let server = Server::new(
             Vtl::Vtl0,
             MESSAGE_CONNECTION_ID,
             0,
             assign_channel_id_on_offer,
+            support_gpa_pinning,
         );
         Self {
             server,

--- a/vm/devices/vmbus/vmbus_server/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_server/src/lib.rs
@@ -313,11 +313,11 @@ impl<T: SpawnDriver + Clone> VmbusServerBuilder<T> {
             max_restore_version: None,
             enable_mnf: false,
             force_confidential_external_memory: false,
+            support_gpa_pinning: false,
             force_gpa_pinning: false,
             send_messages_while_stopped: false,
             channel_unstick_delay: Some(Duration::from_millis(100)),
             use_absolute_channel_order: false,
-            support_gpa_pinning: false,
         }
     }
 
@@ -433,7 +433,8 @@ impl<T: SpawnDriver + Clone> VmbusServerBuilder<T> {
         self
     }
 
-    /// Indicates the current VM environment supports GPA pinning.
+    /// Indicates the current VM environment supports GPA pinning so the relevant feature flag can
+    /// be used.
     pub fn support_gpa_pinning(mut self, support: bool) -> Self {
         self.support_gpa_pinning = support;
         self

--- a/vm/devices/vmbus/vmbus_server/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_server/src/lib.rs
@@ -139,6 +139,7 @@ pub struct VmbusServerBuilder<T: SpawnDriver> {
     max_restore_version: Option<MaxVersionInfo>,
     enable_mnf: bool,
     force_confidential_external_memory: bool,
+    support_gpa_pinning: bool,
     force_gpa_pinning: bool,
     send_messages_while_stopped: bool,
     channel_unstick_delay: Option<Duration>,
@@ -316,6 +317,7 @@ impl<T: SpawnDriver + Clone> VmbusServerBuilder<T> {
             send_messages_while_stopped: false,
             channel_unstick_delay: Some(Duration::from_millis(100)),
             use_absolute_channel_order: false,
+            support_gpa_pinning: false,
         }
     }
 
@@ -431,6 +433,12 @@ impl<T: SpawnDriver + Clone> VmbusServerBuilder<T> {
         self
     }
 
+    /// Indicates the current VM environment supports GPA pinning.
+    pub fn support_gpa_pinning(mut self, support: bool) -> Self {
+        self.support_gpa_pinning = support;
+        self
+    }
+
     /// Force all channels to use pinned GPA ranges. Used for testing purposes only.
     pub fn force_gpa_pinning(mut self, force: bool) -> Self {
         self.force_gpa_pinning = force;
@@ -537,6 +545,7 @@ impl<T: SpawnDriver + Clone> VmbusServerBuilder<T> {
             connection_id,
             self.channel_id_offset,
             self.use_absolute_channel_order,
+            self.support_gpa_pinning,
         );
 
         // If MNF is handled by this server and this is a paravisor for an isolated VM, the monitor

--- a/vm/devices/vmbus/vmbus_server/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_server/src/lib.rs
@@ -139,6 +139,7 @@ pub struct VmbusServerBuilder<T: SpawnDriver> {
     max_restore_version: Option<MaxVersionInfo>,
     enable_mnf: bool,
     force_confidential_external_memory: bool,
+    force_gpa_pinning: bool,
     send_messages_while_stopped: bool,
     channel_unstick_delay: Option<Duration>,
     use_absolute_channel_order: bool,
@@ -311,6 +312,7 @@ impl<T: SpawnDriver + Clone> VmbusServerBuilder<T> {
             max_restore_version: None,
             enable_mnf: false,
             force_confidential_external_memory: false,
+            force_gpa_pinning: false,
             send_messages_while_stopped: false,
             channel_unstick_delay: Some(Duration::from_millis(100)),
             use_absolute_channel_order: false,
@@ -429,6 +431,12 @@ impl<T: SpawnDriver + Clone> VmbusServerBuilder<T> {
         self
     }
 
+    /// Force all channels to use pinned GPA ranges. Used for testing purposes only.
+    pub fn force_gpa_pinning(mut self, force: bool) -> Self {
+        self.force_gpa_pinning = force;
+        self
+    }
+
     /// Send messages to the partition even while stopped, which can cause
     /// corrupted synic states across VM reset.
     ///
@@ -521,6 +529,7 @@ impl<T: SpawnDriver + Clone> VmbusServerBuilder<T> {
             send: offer_send,
             use_event: self.synic.prefer_os_events(),
             force_confidential_external_memory: self.force_confidential_external_memory,
+            force_gpa_pinning: self.force_gpa_pinning,
         });
 
         let mut server = channels::Server::new(
@@ -2064,12 +2073,25 @@ pub struct VmbusServerControl {
     send: mesh::Sender<OfferRequest>,
     use_event: bool,
     force_confidential_external_memory: bool,
+    force_gpa_pinning: bool,
 }
 
 impl VmbusServerControl {
     /// Offers a channel to the vmbus server, where the flags and user_defined data are already set.
     /// This is used by the relay to forward the host's parameters.
-    pub async fn offer_core(&self, offer_info: OfferInfo) -> anyhow::Result<OfferResources> {
+    pub async fn offer_core(&self, mut offer_info: OfferInfo) -> anyhow::Result<OfferResources> {
+        if self.force_gpa_pinning {
+            tracing::warn!(
+                key = %offer_info.params.key(),
+                "forcing GPA pinning for channel"
+            );
+
+            offer_info
+                .params
+                .flags
+                .set_require_pinned_external_memory(true);
+        }
+
         let flags = offer_info.params.flags;
         self.send
             .call_failable(OfferRequest::Offer, offer_info)


### PR DESCRIPTION
This changes adds the ability for a channel to specify, as part of its offer flags, that it requires all external memory used (GPA direct packets and non-ring-buffer GPADLs) to be pinned. This can be used by OpenHCL in case some or all of the VM's memory is VA-backed.

Devices that require pinned memory will have to be updated to set this flag, which is not done in this change. This change only provides the VMBus protocol support, and an environment variable used for testing that enables it for all channels.