### PR TITLE
netvsp: adding MANA VF keepalive diagnostic traces (#3938) on 1.8.2607

### DIFF
--- a/openhcl/underhill_core/src/dispatch/mod.rs
+++ b/openhcl/underhill_core/src/dispatch/mod.rs
@@ -464,6 +464,8 @@ impl LoadedVm {
                         correlation_id = %correlation_id,
                         timeout_hint_ms = timeout_hint.as_millis() as u64,
                         servicing_deadline = ?servicing_deadline,
+                        enable_nvme_keepalive = capabilities_flags.enable_nvme_keepalive(),
+                        enable_mana_keepalive = capabilities_flags.enable_mana_keepalive(),
                         "received servicing request from host"
                     );
 
@@ -937,7 +939,20 @@ impl LoadedVm {
         let mana_state = if let Some(network_settings) = &mut self.network_settings
             && mana_keepalive_mode.is_enabled()
         {
-            network_settings.save().await
+            let saved = network_settings
+                .save()
+                .instrument(tracing::info_span!(
+                    "mana_network_settings_save",
+                    CVM_ALLOWED,
+                    mana_keepalive_mode_enabled = mana_keepalive_mode.is_enabled()
+                ))
+                .await;
+            tracing::info!(
+                CVM_ALLOWED,
+                mana_devices_saved = saved.as_ref().map(|v| v.len()).unwrap_or(0),
+                "mana device state saved for keepalive"
+            );
+            saved
         } else {
             None
         };

--- a/openhcl/underhill_core/src/emuplat/netvsp.rs
+++ b/openhcl/underhill_core/src/emuplat/netvsp.rs
@@ -197,7 +197,7 @@ async fn try_create_mana_device(
     let vtl2_vfid = vfid_from_guid(vtl2_vf_instance_id);
     // Restore the device if we have saved state from servicing, otherwise create a new one.
     let device = if mana_state.is_some() {
-        tracing::debug!(vtl2_vfid, "Restoring VFIO device from saved state");
+        tracing::debug!(vtl2_vfid, pci_id, "Restoring VFIO device from saved state");
         VfioDevice::restore(driver_source, pci_id, true, dma_clients)
             .instrument(tracing::info_span!(
                 "restore_mana_vfio_device",
@@ -207,6 +207,11 @@ async fn try_create_mana_device(
             .await
             .with_context(|| format!("failed to restore vfio device for {}", pci_id))?
     } else {
+        tracing::debug!(
+            vtl2_vfid,
+            pci_id,
+            "Creating new VFIO device (no saved state)"
+        );
         VfioDevice::new(driver_source, pci_id, dma_clients)
             .instrument(tracing::info_span!(
                 "new_mana_vfio_device",
@@ -982,6 +987,11 @@ impl HclNetworkVFManagerWorker {
                         // Closing the VFIO device handle can take a long time.
                         // Leak the handle by stashing it away.
                         std::mem::forget(device);
+                        tracing::info!(
+                            vtl2_vfid,
+                            pci_id = %self.vtl2_pci_id,
+                            "MANA device state successfully saved for keepalive"
+                        );
                         VfManagerSaveResult::Saved(ManaSavedState {
                             mana_device: saved_state,
                             pci_id: self.vtl2_pci_id.clone(),

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -857,6 +857,18 @@ impl UhVmNetworkSettings {
             VfioDmaClients::EphemeralOnly(ephemeral_dma_client)
         };
 
+        tracing::info!(
+            CVM_ALLOWED,
+            pci_id = %nic_config.pci_id,
+            %instance_id,
+            keepalive_mode = ?keepalive_mode,
+            keepalive_enabled = keepalive_mode.is_enabled(),
+            has_saved_mana_state = saved_mana_state.is_some(),
+            saved_mana_state_pci_id = saved_mana_state.map(|s| s.pci_id.as_str()),
+            dma_clients_mode = if matches!(dma_clients, VfioDmaClients::Split { .. }) { "Split" } else { "EphemeralOnly" },
+            "checking for MANA VF keepalive prior to creating underhill NIC"
+        );
+
         let (vf_manager, endpoints, save_state) = HclNetworkVFManager::new(
             nic_config.instance_id,
             nic_config.pci_id,
@@ -3544,6 +3556,20 @@ async fn new_underhill_vm(
             } else {
                 None
             };
+
+            tracing::info!(
+                CVM_ALLOWED,
+                pci_id = %nic_config.pci_id,
+                instance_id = %nic_config.instance_id,
+                has_servicing_mana_state = servicing_state.mana_state.is_some(),
+                num_mana_devices = servicing_state
+                    .mana_state
+                    .as_ref()
+                    .map(|s| s.len())
+                    .unwrap_or(0),
+                has_nic_servicing_state = nic_servicing_state.is_some(),
+                "MANA keepalive: resolved saved state for NIC"
+            );
 
             let save_state = uh_network_settings
                 .add_network(


### PR DESCRIPTION
Clean cherry-pick of #3938

