### PR TITLE
chipset_device_worker: Fix potential race in reset.

### DIFF
--- a/workers/chipset_device_worker/src/proxy.rs
+++ b/workers/chipset_device_worker/src/proxy.rs
@@ -278,13 +278,14 @@ impl ChangeDeviceState for ChipsetDeviceProxy {
     }
 
     async fn reset(&mut self) {
-        self.in_flight_reads.clear();
-        self.in_flight_writes.clear();
-
         self.req_send
             .call(DeviceRequest::Reset, ())
             .await
-            .expect("failed to reset remote device")
+            .expect("failed to reset remote device");
+
+        self.in_flight_reads.clear();
+        self.in_flight_writes.clear();
+        while self.resp_recv.try_recv().is_ok() {}
     }
 }
 


### PR DESCRIPTION
Previously it was possible for a remote device to send a deferred completion while the vmm-side proxy was sending a reset, causing the proxy to then read this deferred completion after the reset was complete, causing a panic. Fix this by only clearing the proxy state after the reset has been confirmed by the remote worker, ensuring no more completions can be sent, and then also clearing any stale completions waiting in the channel.