### PR TITLE
flowey: repair incomplete rustup installations

### DIFF
--- a/flowey/flowey_lib_common/src/install_rust.rs
+++ b/flowey/flowey_lib_common/src/install_rust.rs
@@ -107,12 +107,16 @@ impl FlowNodeWithConfig for Node {
 
         let rust_toolchain = (!ignore_version).then_some(rust_toolchain);
 
+        // `toolchain_only` restricts the check to "is a suitable Rust
+        // toolchain installed", skipping the target-triple / component
+        // checks. This is what lets the install step below distinguish
+        // "Rust is missing" from "Rust is fine, but a target is missing".
         let check_rust_install = {
             let rust_toolchain = rust_toolchain.clone();
             let additional_target_triples = additional_target_triples.clone();
             let additional_components = additional_components.clone();
 
-            move |rt: &mut RustRuntimeServices<'_>| {
+            move |rt: &mut RustRuntimeServices<'_>, toolchain_only: bool| {
                 if flowey::shell_cmd!(rt, "cargo --version").run().is_err() {
                     anyhow::bail!("did not find `cargo` on $PATH");
                 }
@@ -140,6 +144,10 @@ impl FlowNodeWithConfig for Node {
                     }
                 } else {
                     flowey::shell_cmd!(rt, "rustc -vV").run()?;
+                }
+
+                if toolchain_only {
+                    return anyhow::Ok(());
                 }
 
                 // make sure the additional target triples were installed
@@ -242,18 +250,22 @@ impl FlowNodeWithConfig for Node {
                             }
 
                             let rust_toolchain = rust_toolchain.clone();
-                            if check_rust_install.clone()(rt).is_ok() {
+                            if check_rust_install(rt, false).is_ok() {
                                 return Ok(());
                             }
 
-                            // If cargo is already on PATH but rustup is not then assume
-                            // rust is being managed manually (Nix for example) and bail
+                            // Something is missing. Every remaining path below
+                            // - `rustup-init`, `rustup target add`, `rustup
+                            // component add` - needs rustup. If cargo is
+                            // already on PATH but rustup is not then assume
+                            // rust is being managed manually (Nix for example)
+                            // and bail with a clear message, rather than
+                            // failing later on a missing `rustup` binary.
                             let cargo_available =
                                 flowey::shell_cmd!(rt, "cargo --version").run().is_ok();
                             let rustup_available =
                                 flowey::shell_cmd!(rt, "rustup --version").run().is_ok();
-                            if cargo_available && !rustup_available
-                            {
+                            if cargo_available && !rustup_available {
                                 anyhow::bail!(
                                     "Rust installation check failed and rustup is \
                                      not available; Rust appears to be externally \
@@ -261,52 +273,61 @@ impl FlowNodeWithConfig for Node {
                                 );
                             }
 
-                            match rt.platform() {
-                                FlowPlatform::Linux(_) => {
-                                    let interactive_prompt = Some("-y");
-                                    let mut default_toolchain = Vec::new();
-                                    if let Some(ver) = rust_toolchain {
-                                        default_toolchain.push("--default-toolchain".into());
-                                        default_toolchain.push(ver)
-                                    };
+                            // The check above also fails when Rust itself is
+                            // fine and only a target triple / component is
+                            // missing. `rustup-init` refuses to run over an
+                            // existing installation ("cannot install while
+                            // Rust is installed"), so only run it when the
+                            // toolchain check fails on its own - otherwise
+                            // fall through to `rustup {target,component} add`.
+                            if check_rust_install(rt, true).is_err() {
+                                match rt.platform() {
+                                    FlowPlatform::Linux(_) => {
+                                        let interactive_prompt = Some("-y");
+                                        let mut default_toolchain = Vec::new();
+                                        if let Some(ver) = rust_toolchain {
+                                            default_toolchain.push("--default-toolchain".into());
+                                            default_toolchain.push(ver)
+                                        };
 
-                                    flowey::shell_cmd!(
-                                        rt,
-                                        "curl --fail --proto =https --tlsv1.2 -sSf https://sh.rustup.rs -o rustup-init.sh"
-                                    )
-                                    .run()?;
-                                    flowey::shell_cmd!(rt, "chmod +x ./rustup-init.sh").run()?;
-                                    flowey::shell_cmd!(
-                                        rt,
-                                        "./rustup-init.sh {interactive_prompt...} {default_toolchain...}"
-                                    )
-                                    .run()?;
+                                        flowey::shell_cmd!(
+                                            rt,
+                                            "curl --fail --proto =https --tlsv1.2 -sSf https://sh.rustup.rs -o rustup-init.sh"
+                                        )
+                                        .run()?;
+                                        flowey::shell_cmd!(rt, "chmod +x ./rustup-init.sh").run()?;
+                                        flowey::shell_cmd!(
+                                            rt,
+                                            "./rustup-init.sh {interactive_prompt...} {default_toolchain...}"
+                                        )
+                                        .run()?;
+                                    }
+                                    FlowPlatform::Windows => {
+                                        let interactive_prompt = Some("-y");
+                                        let mut default_toolchain = Vec::new();
+                                        if let Some(ver) = rust_toolchain {
+                                            default_toolchain.push("--default-toolchain".into());
+                                            default_toolchain.push(ver)
+                                        };
+
+                                        let arch = match rt.arch() {
+                                            FlowArch::X86_64 => "x86_64",
+                                            FlowArch::Aarch64 => "aarch64",
+                                            arch => anyhow::bail!("unsupported arch {arch}"),
+                                        };
+
+                                        flowey::shell_cmd!(
+                                            rt,
+                                            "curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/{arch}"
+                                        ).run()?;
+                                        flowey::shell_cmd!(
+                                            rt,
+                                            "./rustup-init.exe {interactive_prompt...} {default_toolchain...}"
+                                        )
+                                        .run()?;
+                                    },
+                                    platform => anyhow::bail!("unsupported platform {platform}"),
                                 }
-                                FlowPlatform::Windows => {
-                                    let interactive_prompt = Some("-y");
-                                    let mut default_toolchain = Vec::new();
-                                    if let Some(ver) = rust_toolchain {
-                                        default_toolchain.push("--default-toolchain".into());
-                                        default_toolchain.push(ver)
-                                    };
-
-                                    let arch = match rt.arch() {
-                                        FlowArch::X86_64 => "x86_64",
-                                        FlowArch::Aarch64 => "aarch64",
-                                        arch => anyhow::bail!("unsupported arch {arch}"),
-                                    };
-
-                                    flowey::shell_cmd!(
-                                        rt,
-                                        "curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/{arch}"
-                                    ).run()?;
-                                    flowey::shell_cmd!(
-                                        rt,
-                                        "./rustup-init.exe {interactive_prompt...} {default_toolchain...}"
-                                    )
-                                    .run()?;
-                                },
-                                platform => anyhow::bail!("unsupported platform {platform}"),
                             }
 
                             if !additional_target_triples.is_empty() {
@@ -332,7 +353,7 @@ impl FlowNodeWithConfig for Node {
                                 )),
                             );
 
-                            check_rust_install(rt)?;
+                            check_rust_install(rt, false)?;
                             Ok(())
                         }
                     })

--- a/flowey/flowey_lib_common/src/install_rust.rs
+++ b/flowey/flowey_lib_common/src/install_rust.rs
@@ -250,6 +250,19 @@ impl FlowNodeWithConfig for Node {
                             }
 
                             let rust_toolchain = rust_toolchain.clone();
+
+                            // `rustup {target,component} add` act on rustup's
+                            // *default* toolchain, whereas the checks above
+                            // inspect the configured one (`rustup +{ver} ...`).
+                            // Without this selector, a pinned toolchain would
+                            // have its targets installed somewhere else, and
+                            // the later `cargo +{ver}` build would still fail
+                            // on a missing target. Computed here because the
+                            // platform match below consumes `rust_toolchain`.
+                            let toolchain_flag =
+                                rust_toolchain.as_ref().map(|s| format!("+{s}"));
+                            let toolchain_flag = toolchain_flag.as_ref();
+
                             if check_rust_install(rt, false).is_ok() {
                                 return Ok(());
                             }
@@ -331,11 +344,11 @@ impl FlowNodeWithConfig for Node {
                             }
 
                             if !additional_target_triples.is_empty() {
-                                flowey::shell_cmd!(rt, "rustup target add {additional_target_triples...}")
+                                flowey::shell_cmd!(rt, "rustup {toolchain_flag...} target add {additional_target_triples...}")
                                     .run()?;
                             }
                             if !additional_components.is_empty() {
-                                flowey::shell_cmd!(rt, "rustup component add {additional_components...}")
+                                flowey::shell_cmd!(rt, "rustup {toolchain_flag...} component add {additional_components...}")
                                     .run()?;
                             }
 


### PR DESCRIPTION
`install_rust` previously treated any failed installation check as if Rust were completely absent and fell through to `rustup-init`. That is wrong when rustup already exists but the configured toolchain, default toolchain, target triple, or component is missing: `rustup-init` refuses to run over an existing installation, and bare `rustup target add` can modify the wrong toolchain.

## Fix

The install path now distinguishes a usable configured toolchain from a complete installation:

- If rustup is absent, bootstrap it with `rustup-init` as before.
- If rustup exists but the configured toolchain is missing, install it with `rustup toolchain install`.
- If cargo is unavailable because no default toolchain is configured, make the installed toolchain the default.
- Install requested targets and components into the configured toolchain with `rustup +<toolchain> ...`.
- Re-run the appropriate checks after installation so the step cannot report success while Rust remains unusable.

This fixes local Flowey runs with `auto_install` enabled, including cross-compilation scenarios used by `build-igvm`, `build-opentmk`, `vmm-tests-run`, and the local hotpatch DLL builds.

## Validation

Verified locally on Windows across missing-target and incomplete-rustup scenarios. A missing `aarch64-pc-windows-msvc` target is now added to the configured toolchain instead of attempting to reinstall Rust.