### PR TITLE
underhill_core: fix keepalive command line parsing

### DIFF
--- a/openhcl/underhill_core/src/options.rs
+++ b/openhcl/underhill_core/src/options.rs
@@ -130,6 +130,7 @@ impl FromStr for EfiDiagnosticsLogLevelCli {
 pub enum KeepAliveConfig {
     EnabledHostAndPrivatePoolPresent,
     DisabledHostAndPrivatePoolPresent,
+    EnabledHostAndPrivatePoolNotPresent,
     Disabled,
 }
 
@@ -139,6 +140,7 @@ impl FromStr for KeepAliveConfig {
     fn from_str(s: &str) -> Result<KeepAliveConfig, anyhow::Error> {
         match s.to_lowercase().as_str() {
             "host,privatepool" | "enabled" => Ok(KeepAliveConfig::EnabledHostAndPrivatePoolPresent),
+            "host,noprivatepool" => Ok(KeepAliveConfig::EnabledHostAndPrivatePoolNotPresent),
             "nohost,privatepool" => Ok(KeepAliveConfig::DisabledHostAndPrivatePoolPresent),
             "nohost,noprivatepool" => Ok(KeepAliveConfig::Disabled),
             x if x == "disabled" || x.starts_with("disabled,") => Ok(KeepAliveConfig::Disabled),
@@ -152,11 +154,12 @@ impl KeepAliveConfig {
         matches!(self, KeepAliveConfig::EnabledHostAndPrivatePoolPresent)
     }
 
-    /// Returns the string representation matching the inspect rename attributes.
+    /// Returns a canonical string representation accepted by the parser.
     pub fn as_str(&self) -> &'static str {
         match self {
             KeepAliveConfig::EnabledHostAndPrivatePoolPresent => "enabled",
             KeepAliveConfig::DisabledHostAndPrivatePoolPresent => "nohost,privatepool",
+            KeepAliveConfig::EnabledHostAndPrivatePoolNotPresent => "host,noprivatepool",
             KeepAliveConfig::Disabled => "disabled",
         }
     }
@@ -264,6 +267,7 @@ pub struct Options {
     /// Configure NVMe keep alive behavior when servicing.
     /// Options are:
     ///  - "host,privatepool" - Enable keep alive if both host and private pool support it.
+    ///  - "host,noprivatepool" - The host supports keepalive, but a private pool is not present. Keepalive is disabled.
     ///  - "nohost,privatepool" - Used when the host does not support keepalive, but a private pool is present. Keepalive is disabled.
     ///  - "nohost,noprivatepool" - Keepalive is disabled.
     ///  - "disabled, X, X" - Keepalive is disabled due to manual
@@ -274,6 +278,7 @@ pub struct Options {
     /// Configure MANA keep alive behavior when servicing.
     /// Options are:
     ///  - "host,privatepool" - Enable keep alive if both host and private pool support it.
+    ///  - "host,noprivatepool" - The host supports keepalive, but a private pool is not present. Keepalive is disabled.
     ///  - "nohost,privatepool" - Used when the host does not support keepalive, but a private pool is present. Keepalive is disabled.
     ///  - "nohost,noprivatepool" - Keepalive is disabled.
     ///  - "disabled, X, X" - TODO: This needs to be implemented for mana.


### PR DESCRIPTION
CVMs are passing the keepalive command line configuration "host,noprivatepool". Update underhill_core to parse this correctly.