### PR TITLE
[release/1.8.2607] chipset_device_worker: Fix potential race in reset.

### DIFF
--- a/workers/chipset_device_worker/src/proxy.rs
+++ b/workers/chipset_device_worker/src/proxy.rs
@@ -278,13 +278,14 @@ impl ChangeDeviceState for ChipsetDeviceProxy {
     }
 
     async fn reset(&mut self) {
-        self.in_flight_reads.clear();
-        self.in_flight_writes.clear();
-
         self.req_send
             .call(DeviceRequest::Reset, ())
             .await
-            .expect("failed to reset remote device")
+            .expect("failed to reset remote device");
+
+        self.in_flight_reads.clear();
+        self.in_flight_writes.clear();
+        while self.resp_recv.try_recv().is_ok() {}
     }
 }
 


### PR DESCRIPTION
Backport of #4214 to `release/1.8.2607`.

Cherry-picked commit `1be23730f42640f3ec45907739199797b1ccafeb`. The cherry-pick applied cleanly with no conflicts and no manual edits.

---
_This pull request was created by an AI agent (GitHub Copilot) on behalf of @smalis-msft._