### PR TITLE
[release/1.8.2607] petri: Fix reset race with flaky_boot quirk

### DIFF
--- a/petri/src/vm/hyperv/vm.rs
+++ b/petri/src/vm/hyperv/vm.rs
@@ -354,8 +354,15 @@ impl HyperVVM {
     }
 
     /// Issue a hard reset to the VM
-    pub async fn reset(&self) -> anyhow::Result<()> {
-        hvc::hvc_reset(&self.vmid).await.context("hvc_reset")
+    pub async fn reset(&mut self) -> anyhow::Result<()> {
+        hvc::hvc_reset(&self.vmid).await.context("hvc_reset")?;
+        // `hvc reset` only returns once the reset has been logged, so any
+        // event from here on belongs to the new boot. Advancing the window is
+        // required for correctness: otherwise the boot event from the boot
+        // being abandoned is still reported, and `boot_event` fails with "Got
+        // more than one boot event" as soon as the new boot logs its own.
+        self.last_start_time = Some(Timestamp::now());
+        Ok(())
     }
 
     /// return the named pipe path for the serial port.

--- a/petri/src/vm/openvmm/runtime.rs
+++ b/petri/src/vm/openvmm/runtime.rs
@@ -547,6 +547,9 @@ impl PetriVmInner {
     async fn reset(&mut self) -> anyhow::Result<()> {
         tracing::info!("Resetting VM");
         self.worker.reset().await?;
+        // Discard any firmware events from the boot that was abandoned, so
+        // that they aren't mistaken for the results of the new boot.
+        while self.resources.firmware_event_recv.try_recv().is_ok() {}
         // Guest state is lost on reset, so CIDATA needs to be remounted.
         self.cidata_mounted = false;
         // On linux direct, pipette won't auto-start unless it is the init


### PR DESCRIPTION
Backport of #4219 to `release/1.8.2607`.

Cherry-picked commit `ccf582524fff64e819e1a6742f815d3935d2a3f1`. The cherry-pick applied cleanly with no conflicts and no manual edits.

---
_This pull request was created by an AI agent (GitHub Copilot) on behalf of @smalis-msft._