### PR TITLE
petri: Push boot event timeout handling into backends

### DIFF
--- a/petri/src/vm/hyperv/mod.rs
+++ b/petri/src/vm/hyperv/mod.rs
@@ -576,8 +576,11 @@ impl PetriVmRuntime for HyperVPetriRuntime {
         })
     }
 
-    async fn wait_for_boot_event(&mut self) -> anyhow::Result<FirmwareEvent> {
-        self.vm.wait_for_boot_event().await
+    async fn wait_for_boot_event(
+        &mut self,
+        timeout: Option<Duration>,
+    ) -> anyhow::Result<Option<FirmwareEvent>> {
+        self.vm.wait_for_boot_event(timeout).await
     }
 
     async fn wait_for_enlightened_shutdown_ready(&mut self) -> anyhow::Result<()> {

--- a/petri/src/vm/hyperv/vm.rs
+++ b/petri/src/vm/hyperv/vm.rs
@@ -27,6 +27,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::Weak;
 use std::time::Duration;
+use std::time::Instant;
 use tempfile::TempDir;
 
 /// A Hyper-V VM
@@ -176,9 +177,13 @@ impl HyperVVM {
     }
 
     /// Waits for an event emitted by the firmware about its boot status, and
-    /// returns that status.
-    pub async fn wait_for_boot_event(&mut self) -> anyhow::Result<FirmwareEvent> {
-        self.wait_for_off_or_internal(Self::boot_event).await
+    /// returns that status. Returns `None` if `timeout` elapsed first.
+    pub async fn wait_for_boot_event(
+        &mut self,
+        timeout: Option<Duration>,
+    ) -> anyhow::Result<Option<FirmwareEvent>> {
+        self.poll_until_off_or_timeout(timeout, Self::boot_event)
+            .await
     }
 
     async fn boot_event(&self) -> anyhow::Result<Option<FirmwareEvent>> {
@@ -497,6 +502,24 @@ impl HyperVVM {
         &mut self,
         f: impl AsyncFn(&Self) -> anyhow::Result<Option<T>>,
     ) -> anyhow::Result<T> {
+        let output = self.poll_until_off_or_timeout(None, f).await?;
+        Ok(output.expect("polling only gives up early when a timeout is set"))
+    }
+
+    /// Poll `f` until it produces a value, failing if the VM turns off first
+    /// and giving up once `timeout` has elapsed.
+    ///
+    /// A poll of `f` is always run to completion before the timeout is
+    /// considered, since a single poll can take longer than the timeout when
+    /// the host is loaded (`f` typically shells out to PowerShell). Cancelling
+    /// one would throw away the answer it was about to produce.
+    async fn poll_until_off_or_timeout<T>(
+        &mut self,
+        timeout: Option<Duration>,
+        f: impl AsyncFn(&Self) -> anyhow::Result<Option<T>>,
+    ) -> anyhow::Result<Option<T>> {
+        let start = Instant::now();
+
         // flush the logs every time we start waiting for something in case
         // they don't get flushed when the VM is destroyed.
         // TODO: run this periodically in a task.
@@ -512,7 +535,11 @@ impl HyperVVM {
         let mut timer = PolledTimer::new(&self.driver);
         loop {
             if let Some(output) = f(self).await? {
-                return Ok(output);
+                return Ok(Some(output));
+            }
+
+            if timeout.is_some_and(|timeout| start.elapsed() >= timeout) {
+                return Ok(None);
             }
 
             let off = self.state().await? == VmState::Off;

--- a/petri/src/vm/mod.rs
+++ b/petri/src/vm/mod.rs
@@ -1987,27 +1987,25 @@ impl<T: PetriVmmBackend> PetriVm<T> {
     async fn wait_for_boot_event(&mut self) -> anyhow::Result<FirmwareEvent> {
         tracing::info!("Waiting for boot event...");
         let boot_event = loop {
-            match CancelContext::new()
-                .with_timeout(self.vmm_quirks.flaky_boot.unwrap_or(Duration::MAX))
-                .until_cancelled(self.runtime.wait_for_boot_event())
-                .await
+            if let Some(event) = self
+                .runtime
+                .wait_for_boot_event(self.vmm_quirks.flaky_boot)
+                .await?
             {
-                Ok(res) => break res?,
-                Err(_) => {
-                    tracing::error!("Did not get boot event in required time, resetting...");
-                    if let Some(inspector) = self.runtime.inspector() {
-                        save_inspect(
-                            "vmm",
-                            Box::pin(async move { inspector.inspect("").await }),
-                            &self.resources.log_source,
-                        )
-                        .await;
-                    }
-
-                    self.runtime.reset().await?;
-                    continue;
-                }
+                break event;
             }
+
+            tracing::error!("Did not get boot event in required time, resetting...");
+            if let Some(inspector) = self.runtime.inspector() {
+                save_inspect(
+                    "vmm",
+                    Box::pin(async move { inspector.inspect("").await }),
+                    &self.resources.log_source,
+                )
+                .await;
+            }
+
+            self.runtime.reset().await?;
         };
         tracing::info!("Got boot event: {boot_event:?}");
         Ok(boot_event)
@@ -2203,8 +2201,11 @@ pub trait PetriVmRuntime: Send + Sync + 'static {
     /// Get an OpenHCL diagnostics handler for the VM
     fn openhcl_diag(&self) -> Option<OpenHclDiagHandler>;
     /// Waits for an event emitted by the firmware about its boot status, and
-    /// returns that status.
-    async fn wait_for_boot_event(&mut self) -> anyhow::Result<FirmwareEvent>;
+    /// returns that status. Returns `None` if `timeout` elapsed first.
+    async fn wait_for_boot_event(
+        &mut self,
+        timeout: Option<Duration>,
+    ) -> anyhow::Result<Option<FirmwareEvent>>;
     /// Waits for the Hyper-V shutdown IC to be ready
     // TODO: return a receiver that will be closed when it is no longer ready.
     async fn wait_for_enlightened_shutdown_ready(&mut self) -> anyhow::Result<()>;

--- a/petri/src/vm/openvmm/runtime.rs
+++ b/petri/src/vm/openvmm/runtime.rs
@@ -119,8 +119,18 @@ impl PetriVmRuntime for PetriVmOpenVmm {
         })
     }
 
-    async fn wait_for_boot_event(&mut self) -> anyhow::Result<FirmwareEvent> {
-        Self::wait_for_boot_event(self).await
+    async fn wait_for_boot_event(
+        &mut self,
+        timeout: Option<Duration>,
+    ) -> anyhow::Result<Option<FirmwareEvent>> {
+        // The event arrives on a channel, so cancelling the wait can't discard
+        // one that has already been delivered.
+        CancelContext::new()
+            .with_timeout(timeout.unwrap_or(Duration::MAX))
+            .until_cancelled(Self::wait_for_boot_event(self))
+            .await
+            .ok()
+            .transpose()
     }
 
     async fn wait_for_enlightened_shutdown_ready(&mut self) -> anyhow::Result<()> {


### PR DESCRIPTION
Currently it is possible for petri on the hyper-v backend to miss a boot event that has already arrived due to the cancel timeout killing the still-in-progress powershell query. Fix this by pushing the timeout handling into each backend, allowing the hyper-v backend to ensure an in-progress powershell query always finishes before checking the timeout.

Should fix the TDX pcat test failures we've seen recently.