### PR TITLE
virt: add loader-supplied SNP VMSA support

### DIFF
--- a/openvmm/openvmm_core/src/worker/dispatch.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch.rs
@@ -3168,26 +3168,32 @@ impl LoadedVmInner {
                     isolation: self.hypervisor_cfg.with_isolation,
                     snp_c_bit: self.partition.caps().snp_c_bit,
                 };
-                super::vm_loaders::linux::load_linux_x86(&kernel_config, &self.gm, |gpa| {
-                    let tables = acpi_builder.build_acpi_tables(gpa, |dsdt| {
-                        add_devices_to_dsdt_x64(
-                            dsdt,
-                            &self.chipset_cfg,
-                            &self.chipset_capabilities,
-                            enable_serial,
-                            self.vmbus_server.is_some(),
-                            &self.chipset_mmio,
-                            self.virtio_mmio_region,
-                            self.virtio_mmio_irq,
-                            &self.pci_legacy_interrupts,
-                        )
-                    });
+                super::vm_loaders::linux::load_linux_x86(
+                    &kernel_config,
+                    &self.gm,
+                    self.partition.caps(),
+                    &self.processor_topology.vp_arch(VpIndex::BSP),
+                    |gpa| {
+                        let tables = acpi_builder.build_acpi_tables(gpa, |dsdt| {
+                            add_devices_to_dsdt_x64(
+                                dsdt,
+                                &self.chipset_cfg,
+                                &self.chipset_capabilities,
+                                enable_serial,
+                                self.vmbus_server.is_some(),
+                                &self.chipset_mmio,
+                                self.virtio_mmio_region,
+                                self.virtio_mmio_irq,
+                                &self.pci_legacy_interrupts,
+                            )
+                        });
 
-                    loader::linux::AcpiTables {
-                        rsdp: tables.rsdp,
-                        tables: tables.tables,
-                    }
-                })?
+                        loader::linux::AcpiTables {
+                            rsdp: tables.rsdp,
+                            tables: tables.tables,
+                        }
+                    },
+                )?
             }
             #[cfg(guest_arch = "aarch64")]
             &LoadMode::Linux {

--- a/openvmm/openvmm_core/src/worker/vm_loaders/linux.rs
+++ b/openvmm/openvmm_core/src/worker/vm_loaders/linux.rs
@@ -36,6 +36,8 @@ pub enum Error {
     Efi(#[source] guestmem::GuestMemoryError),
     #[error("missing SNP C-bit CPUID information")]
     MissingSnpCBit,
+    #[error("failed to finalize SNP VMSA")]
+    SnpVmsa(#[source] anyhow::Error),
 }
 
 struct Aarch64EfiInfo {
@@ -126,6 +128,8 @@ fn default_smbios_tables() -> loader::smbios::SmbiosTables<'static> {
 pub fn load_linux_x86(
     cfg: &KernelConfig<'_>,
     gm: &GuestMemory,
+    caps: &virt::x86::X86PartitionCapabilities,
+    bsp: &vm_topology::processor::x86::X86VpInfo,
     acpi_at_gpa: impl FnOnce(u64) -> loader::linux::AcpiTables,
 ) -> Result<InitialLoad<X86Register>, Error> {
     let mut kernel_file = cfg.kernel;
@@ -169,6 +173,12 @@ pub fn load_linux_x86(
         snp_boot,
     )
     .map_err(Error::Loader)?;
+
+    if cfg.isolation == Some(IsolationType::Snp) {
+        loader
+            .finalize_snp_vmsa(caps, bsp)
+            .map_err(Error::SnpVmsa)?;
+    }
 
     let InitialLoad {
         regs,

--- a/vm/loader/src/linux.rs
+++ b/vm/loader/src/linux.rs
@@ -275,7 +275,7 @@ pub struct SnpBootConfig {
     pub c_bit: u8,
 }
 
-const SNP_BOOT_PAGE_COUNT: u64 = 4;
+const SNP_BOOT_PAGE_COUNT: u64 = 5;
 
 /// The GPA of the SMBIOS structure table: immediately above the ACPI tables in
 /// the low reserved area. Only the `_SM3_` anchor stays in the F-segment; the
@@ -354,6 +354,7 @@ fn import_snp_boot_pages(
     let cpuid_address = range.start() + HV_PAGE_SIZE;
     let cc_blob_address = range.start() + 2 * HV_PAGE_SIZE;
     let cc_setup_data_address = range.start() + 3 * HV_PAGE_SIZE;
+    let vmsa_address = range.start() + 4 * HV_PAGE_SIZE;
 
     importer
         .import_pages(
@@ -414,6 +415,10 @@ fn import_snp_boot_pages(
             BootPageAcceptance::Exclusive,
             cc_setup_data.as_bytes(),
         )
+        .map_err(Error::Importer)?;
+
+    importer
+        .set_vp_context_page(vmsa_address / HV_PAGE_SIZE)
         .map_err(Error::Importer)?;
 
     Ok(cc_setup_data_address)
@@ -1291,6 +1296,7 @@ mod tests {
         /// `(debug_tag, page_base, page_count)` for each imported region.
         pages: Vec<(String, u64, u64)>,
         imports: Vec<ImportRecord>,
+        vp_context_page: Option<u64>,
     }
 
     #[derive(Debug)]
@@ -1381,8 +1387,9 @@ mod tests {
             Ok(())
         }
 
-        fn set_vp_context_page(&mut self, _page_base: u64) -> anyhow::Result<()> {
-            unimplemented!()
+        fn set_vp_context_page(&mut self, page_base: u64) -> anyhow::Result<()> {
+            self.vp_context_page = Some(page_base);
+            Ok(())
         }
 
         fn relocation_region(
@@ -1631,7 +1638,14 @@ mod tests {
             cc_setup_data.cc_blob_address,
             u32::try_from(allocated_range.start() + 2 * HV_PAGE_SIZE).unwrap()
         );
-        assert_eq!(allocated_range.end(), cc_setup_data_address + HV_PAGE_SIZE,);
+        assert_eq!(
+            importer.vp_context_page,
+            Some(allocated_range.start() / HV_PAGE_SIZE + 4)
+        );
+        assert_eq!(
+            allocated_range.end(),
+            cc_setup_data_address + 2 * HV_PAGE_SIZE,
+        );
         assert!(allocated_range.end() <= RSDP_BASE);
 
         let smbios_reserved = &boot_params.e820_map[2];

--- a/vmm_core/virt/src/x86/mod.rs
+++ b/vmm_core/virt/src/x86/mod.rs
@@ -4,6 +4,7 @@
 //! x86-specific state.
 
 pub mod apic_software_device;
+pub mod snp;
 pub mod topology;
 pub mod vm;
 pub mod vp;

--- a/vmm_core/virt/src/x86/snp.rs
+++ b/vmm_core/virt/src/x86/snp.rs
@@ -1,0 +1,232 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! SEV-SNP initial VMSA conversion.
+//!
+//! [`vmsa_from_initial_regs`] is used by the shared direct-boot loader for SNP
+//! backends, including KVM and MSHV. [`state_from_vmsa`] is currently used by
+//! KVM to apply the loader-built VMSA through KVM's register-based launch path;
+//! MSHV imports the VMSA page directly.
+
+use super::SegmentRegister;
+use super::TableRegister;
+use super::X86InitialRegs;
+use super::vp;
+use thiserror::Error;
+use x86defs::SegmentAttributes;
+use x86defs::snp::SevSelector;
+use x86defs::snp::SevVmsa;
+use zerocopy::FromZeros;
+
+const _: () = assert!(size_of::<SevVmsa>() <= hvdef::HV_PAGE_SIZE as usize);
+
+/// The subset of initial VP state represented by a direct-boot SNP VMSA.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct SnpVmsaState {
+    /// Architectural register state.
+    pub registers: vp::Registers,
+    /// Page attribute table state.
+    pub pat: u64,
+    /// Extended control register 0.
+    pub xcr0: u64,
+}
+
+/// An error parsing a direct-boot SNP VMSA.
+#[derive(Debug, Error)]
+pub enum SnpVmsaError {
+    /// The VMSA contains state outside the supported direct-boot contract.
+    #[error("unsupported SNP VMSA state")]
+    UnsupportedState,
+}
+
+/// Builds the direct-boot SNP VMSA corresponding to `initial`.
+pub fn vmsa_from_initial_regs(initial: &X86InitialRegs) -> SevVmsa {
+    vmsa_from_state(&SnpVmsaState {
+        registers: initial.registers,
+        pat: initial.pat.value,
+        xcr0: x86defs::xsave::XFEATURE_X87,
+    })
+}
+
+/// Parses and validates a direct-boot SNP VMSA.
+pub fn state_from_vmsa(vmsa: &SevVmsa) -> Result<SnpVmsaState, SnpVmsaError> {
+    let state = SnpVmsaState {
+        registers: vp::Registers {
+            rax: vmsa.rax,
+            rcx: vmsa.rcx,
+            rdx: vmsa.rdx,
+            rbx: vmsa.rbx,
+            rbp: vmsa.rbp,
+            rsp: vmsa.rsp,
+            rsi: vmsa.rsi,
+            rdi: vmsa.rdi,
+            r8: vmsa.r8,
+            r9: vmsa.r9,
+            r10: vmsa.r10,
+            r11: vmsa.r11,
+            r12: vmsa.r12,
+            r13: vmsa.r13,
+            r14: vmsa.r14,
+            r15: vmsa.r15,
+            rip: vmsa.rip,
+            rflags: vmsa.rflags,
+            cs: segment_from_vmsa(vmsa.cs),
+            ds: segment_from_vmsa(vmsa.ds),
+            es: segment_from_vmsa(vmsa.es),
+            fs: segment_from_vmsa(vmsa.fs),
+            gs: segment_from_vmsa(vmsa.gs),
+            ss: segment_from_vmsa(vmsa.ss),
+            tr: segment_from_vmsa(vmsa.tr),
+            ldtr: segment_from_vmsa(vmsa.ldtr),
+            gdtr: table_from_vmsa(vmsa.gdtr),
+            idtr: table_from_vmsa(vmsa.idtr),
+            cr0: vmsa.cr0,
+            cr2: vmsa.cr2,
+            cr3: vmsa.cr3,
+            cr4: vmsa.cr4,
+            cr8: 0,
+            efer: vmsa.efer & !x86defs::X64_EFER_SVME,
+        },
+        pat: vmsa.pat,
+        xcr0: vmsa.xcr0,
+    };
+
+    if &vmsa_from_state(&state) != vmsa {
+        return Err(SnpVmsaError::UnsupportedState);
+    }
+
+    Ok(state)
+}
+
+fn vmsa_from_state(state: &SnpVmsaState) -> SevVmsa {
+    let registers = &state.registers;
+    let mut vmsa = SevVmsa::new_zeroed();
+
+    vmsa.es = segment_to_vmsa(registers.es);
+    vmsa.cs = segment_to_vmsa(registers.cs);
+    vmsa.ss = segment_to_vmsa(registers.ss);
+    vmsa.ds = segment_to_vmsa(registers.ds);
+    vmsa.fs = segment_to_vmsa(registers.fs);
+    vmsa.gs = segment_to_vmsa(registers.gs);
+    vmsa.gdtr = table_to_vmsa(registers.gdtr);
+    vmsa.ldtr = segment_to_vmsa(registers.ldtr);
+    vmsa.idtr = table_to_vmsa(registers.idtr);
+    vmsa.tr = segment_to_vmsa(registers.tr);
+    vmsa.cpl = SegmentAttributes::from(registers.cs.attributes).descriptor_privilege_level();
+    vmsa.efer = registers.efer | x86defs::X64_EFER_SVME;
+    vmsa.cr4 = registers.cr4;
+    vmsa.cr3 = registers.cr3;
+    vmsa.cr0 = registers.cr0;
+    vmsa.rflags = registers.rflags;
+    vmsa.rip = registers.rip;
+    vmsa.rsp = registers.rsp;
+    vmsa.rax = registers.rax;
+    vmsa.cr2 = registers.cr2;
+    vmsa.pat = state.pat;
+    vmsa.rcx = registers.rcx;
+    vmsa.rdx = registers.rdx;
+    vmsa.rbx = registers.rbx;
+    vmsa.rbp = registers.rbp;
+    vmsa.rsi = registers.rsi;
+    vmsa.rdi = registers.rdi;
+    vmsa.r8 = registers.r8;
+    vmsa.r9 = registers.r9;
+    vmsa.r10 = registers.r10;
+    vmsa.r11 = registers.r11;
+    vmsa.r12 = registers.r12;
+    vmsa.r13 = registers.r13;
+    vmsa.r14 = registers.r14;
+    vmsa.r15 = registers.r15;
+    vmsa.sev_features.set_snp(true);
+    vmsa.xcr0 = state.xcr0;
+
+    vmsa
+}
+
+fn segment_to_vmsa(register: SegmentRegister) -> SevSelector {
+    SevSelector {
+        selector: register.selector,
+        attrib: (register.attributes & 0xff) | ((register.attributes >> 4) & 0xf00),
+        limit: register.limit,
+        base: register.base,
+    }
+}
+
+fn segment_from_vmsa(selector: SevSelector) -> SegmentRegister {
+    SegmentRegister {
+        selector: selector.selector,
+        attributes: (selector.attrib & 0xff) | ((selector.attrib & 0xf00) << 4),
+        limit: selector.limit,
+        base: selector.base,
+    }
+}
+
+fn table_to_vmsa(register: TableRegister) -> SevSelector {
+    SevSelector {
+        selector: 0,
+        attrib: 0,
+        limit: register.limit as u32,
+        base: register.base,
+    }
+}
+
+fn table_from_vmsa(selector: SevSelector) -> TableRegister {
+    TableRegister {
+        limit: selector.limit as u16,
+        base: selector.base,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn direct_boot_vmsa_round_trips() {
+        let initial = X86InitialRegs {
+            registers: vp::Registers {
+                rax: 1,
+                rdx: 2,
+                rip: 0x100000,
+                rflags: 2,
+                cs: SegmentRegister {
+                    selector: 0x10,
+                    attributes: 0xa09b,
+                    limit: u32::MAX,
+                    base: 0,
+                },
+                efer: x86defs::X64_EFER_LME | x86defs::X64_EFER_LMA,
+                ..Default::default()
+            },
+            mtrrs: Default::default(),
+            pat: vp::Pat {
+                value: 0x7040600070406,
+            },
+        };
+
+        let vmsa = vmsa_from_initial_regs(&initial);
+        let state = state_from_vmsa(&vmsa).unwrap();
+
+        assert_eq!(state.registers, initial.registers);
+        assert_eq!(state.pat, initial.pat.value);
+        assert_eq!(state.xcr0, x86defs::xsave::XFEATURE_X87);
+        assert!(vmsa.sev_features.snp());
+        assert_ne!(vmsa.efer & x86defs::X64_EFER_SVME, 0);
+    }
+
+    #[test]
+    fn rejects_unsupported_state() {
+        let initial = X86InitialRegs {
+            registers: Default::default(),
+            mtrrs: Default::default(),
+            pat: Default::default(),
+        };
+        let mut vmsa = vmsa_from_initial_regs(&initial);
+        vmsa.virtual_tom = 0x1000;
+
+        assert!(matches!(
+            state_from_vmsa(&vmsa),
+            Err(SnpVmsaError::UnsupportedState)
+        ));
+    }
+}

--- a/vmm_core/virt_kvm/src/arch/x86_64/mod.rs
+++ b/vmm_core/virt_kvm/src/arch/x86_64/mod.rs
@@ -10,6 +10,9 @@ pub(crate) mod snp;
 mod vm_state;
 mod vp_state;
 
+pub(crate) use vp_state::seg_reg;
+pub(crate) use vp_state::table_reg;
+
 use crate::KvmError;
 use crate::KvmPartition;
 use crate::KvmPartitionInner;

--- a/vmm_core/virt_kvm/src/arch/x86_64/snp.rs
+++ b/vmm_core/virt_kvm/src/arch/x86_64/snp.rs
@@ -14,13 +14,16 @@ pub fn snp_launch_page_type(
     import_type: InitialPageImportType,
 ) -> Result<kvm::SevSnpPageType, KvmError> {
     match import_type {
-        InitialPageImportType::Normal => Ok(kvm::SevSnpPageType::Normal),
+        // KVM owns its runtime VMSA and has no SNP launch-update VMSA page
+        // type. This reserved guest page carries loader state to OpenVMM only;
+        // accept it as normal RAM after applying that state to the KVM vCPU.
+        InitialPageImportType::Normal | InitialPageImportType::VpContext => {
+            Ok(kvm::SevSnpPageType::Normal)
+        }
         InitialPageImportType::NormalUnmeasured => Ok(kvm::SevSnpPageType::Unmeasured),
         InitialPageImportType::Secrets => Ok(kvm::SevSnpPageType::Secrets),
         InitialPageImportType::Cpuid => Ok(kvm::SevSnpPageType::Cpuid),
-        InitialPageImportType::VpContext
-        | InitialPageImportType::Shared
-        | InitialPageImportType::CpuidExtendedState => {
+        InitialPageImportType::Shared | InitialPageImportType::CpuidExtendedState => {
             Err(KvmError::UnsupportedSnpPageImportType(import_type))
         }
     }
@@ -49,12 +52,15 @@ mod tests {
             snp_launch_page_type(InitialPageImportType::Cpuid).unwrap(),
             kvm::SevSnpPageType::Cpuid
         );
+        assert_eq!(
+            snp_launch_page_type(InitialPageImportType::VpContext).unwrap(),
+            kvm::SevSnpPageType::Normal
+        );
     }
 
     #[test]
     fn rejects_unsupported_imports() {
         for import_type in [
-            InitialPageImportType::VpContext,
             InitialPageImportType::Shared,
             InitialPageImportType::CpuidExtendedState,
         ] {

--- a/vmm_core/virt_kvm/src/arch/x86_64/vp_state.rs
+++ b/vmm_core/virt_kvm/src/arch/x86_64/vp_state.rs
@@ -95,7 +95,7 @@ impl KvmVpStateAccess<'_, '_> {
     }
 }
 
-fn seg_reg(reg: SegmentRegister) -> kvm::kvm_segment {
+pub(crate) fn seg_reg(reg: SegmentRegister) -> kvm::kvm_segment {
     let attributes = SegmentAttributes::from(reg.attributes);
     kvm::kvm_segment {
         base: reg.base,
@@ -116,7 +116,7 @@ fn seg_reg(reg: SegmentRegister) -> kvm::kvm_segment {
     }
 }
 
-fn seg_reg_from_kvm(reg: kvm::kvm_segment) -> SegmentRegister {
+pub(crate) fn seg_reg_from_kvm(reg: kvm::kvm_segment) -> SegmentRegister {
     // KVM forces the "accessed" bit (bit 0 of the segment type) on every
     // non-LDTR segment when unrestricted guest mode is active. For unusable
     // segments (`present == 0`) this bit is architecturally meaningless, but it
@@ -143,7 +143,7 @@ fn seg_reg_from_kvm(reg: kvm::kvm_segment) -> SegmentRegister {
     }
 }
 
-fn table_reg(reg: TableRegister) -> kvm::kvm_dtable {
+pub(crate) fn table_reg(reg: TableRegister) -> kvm::kvm_dtable {
     kvm::kvm_dtable {
         base: reg.base,
         limit: reg.limit,
@@ -151,7 +151,7 @@ fn table_reg(reg: TableRegister) -> kvm::kvm_dtable {
     }
 }
 
-fn table_reg_from_kvm(reg: kvm::kvm_dtable) -> TableRegister {
+pub(crate) fn table_reg_from_kvm(reg: kvm::kvm_dtable) -> TableRegister {
     TableRegister {
         base: reg.base,
         limit: reg.limit,

--- a/vmm_core/virt_kvm/src/lib.rs
+++ b/vmm_core/virt_kvm/src/lib.rs
@@ -56,6 +56,14 @@ pub enum KvmError {
     OpenSev(#[source] std::io::Error),
     #[error("unsupported SNP launch page import type: {0:?}")]
     UnsupportedSnpPageImportType(InitialPageImportType),
+    #[error("missing SNP VMSA import")]
+    MissingSnpVmsa,
+    #[error("multiple SNP VMSA imports")]
+    MultipleSnpVmsa,
+    #[error("invalid SNP VMSA")]
+    InvalidSnpVmsa(#[source] virt::x86::snp::SnpVmsaError),
+    #[error("failed to access SNP VMSA memory")]
+    SnpVmsaMemory(#[source] guestmem::GuestMemoryError),
     #[error("kvm error")]
     Kvm(#[from] kvm::Error),
     #[error("failed to stat /dev/kvm")]

--- a/vmm_core/virt_kvm/src/snp.rs
+++ b/vmm_core/virt_kvm/src/snp.rs
@@ -72,6 +72,7 @@ impl KvmPartitionInner {
         pages: &[virt::InitialPageImport],
     ) -> Result<(), KvmError> {
         let sev = self.sev.as_ref().ok_or(KvmError::IsolationNotSupported)?;
+        self.apply_snp_vmsa(pages)?;
         self.kvm.check_sev_snp_launch_extensions()?;
         let mut launch_start = kvm::kvm_sev_snp_launch_start {
             // TODO: This debug-capable policy is for bring-up.
@@ -122,6 +123,76 @@ impl KvmPartitionInner {
         tracing::debug!("KVM_SEV_SNP_LAUNCH_FINISH");
         self.kvm
             .sev_snp_launch_finish(sev.as_fd(), &mut Default::default())?;
+        Ok(())
+    }
+
+    // TODO: Remove this register translation once KVM supports importing a
+    // loader-provided VMSA directly.
+    fn apply_snp_vmsa(&self, pages: &[virt::InitialPageImport]) -> Result<(), KvmError> {
+        let mut vmsa_pages = pages
+            .iter()
+            .filter(|page| page.import_type == InitialPageImportType::VpContext);
+        let page = vmsa_pages.next().ok_or(KvmError::MissingSnpVmsa)?;
+        if vmsa_pages.next().is_some() {
+            return Err(KvmError::MultipleSnpVmsa);
+        }
+        if page.range.len() != hvdef::HV_PAGE_SIZE {
+            return Err(KvmError::InvalidSnpLaunchRange);
+        }
+
+        let vmsa = self
+            .gm
+            .read_plain::<x86defs::snp::SevVmsa>(page.range.start())
+            .map_err(KvmError::SnpVmsaMemory)?;
+        let state = virt::x86::snp::state_from_vmsa(&vmsa).map_err(KvmError::InvalidSnpVmsa)?;
+        let kvm_vp = self.vp_kvm(virt::VpIndex::BSP);
+        let registers = state.registers;
+        let regs = kvm::kvm_regs {
+            rax: registers.rax,
+            rbx: registers.rbx,
+            rcx: registers.rcx,
+            rdx: registers.rdx,
+            rsi: registers.rsi,
+            rdi: registers.rdi,
+            rsp: registers.rsp,
+            rbp: registers.rbp,
+            r8: registers.r8,
+            r9: registers.r9,
+            r10: registers.r10,
+            r11: registers.r11,
+            r12: registers.r12,
+            r13: registers.r13,
+            r14: registers.r14,
+            r15: registers.r15,
+            rip: registers.rip,
+            rflags: registers.rflags,
+        };
+        let old_sregs = kvm_vp.get_sregs()?;
+        let sregs = kvm::kvm_sregs {
+            cs: crate::arch::seg_reg(registers.cs),
+            ds: crate::arch::seg_reg(registers.ds),
+            es: crate::arch::seg_reg(registers.es),
+            fs: crate::arch::seg_reg(registers.fs),
+            gs: crate::arch::seg_reg(registers.gs),
+            ss: crate::arch::seg_reg(registers.ss),
+            tr: crate::arch::seg_reg(registers.tr),
+            ldt: crate::arch::seg_reg(registers.ldtr),
+            gdt: crate::arch::table_reg(registers.gdtr),
+            idt: crate::arch::table_reg(registers.idtr),
+            cr0: registers.cr0,
+            cr2: registers.cr2,
+            cr3: registers.cr3,
+            cr4: registers.cr4,
+            cr8: registers.cr8,
+            efer: registers.efer,
+            interrupt_bitmap: [0; 4],
+            ..old_sregs
+        };
+
+        kvm_vp.set_regs(&regs)?;
+        kvm_vp.set_sregs(&sregs)?;
+        kvm_vp.set_msrs(&[(x86defs::X86X_MSR_CR_PAT, state.pat)])?;
+        kvm_vp.set_xcr0(state.xcr0)?;
         Ok(())
     }
 

--- a/vmm_core/vm_loader/src/lib.rs
+++ b/vmm_core/vm_loader/src/lib.rs
@@ -16,6 +16,7 @@ use loader::importer::BootPageAcceptance;
 use loader::importer::GuestArch;
 use loader::importer::ImageLoad;
 use loader::importer::StartupMemoryType;
+use loader::importer::X86Register;
 use memory_range::MemoryRange;
 use range_map_vec::Entry;
 use range_map_vec::RangeMap;
@@ -47,6 +48,8 @@ pub struct Loader<'a, R> {
     mem_layout: &'a MemoryLayout,
     page_imports: RangeMap<u64, RangeInfo>,
     max_vtl: Vtl,
+    vp_context_page: Option<u64>,
+    snp_vmsa_finalized: bool,
 }
 
 impl<R> Loader<'_, R> {
@@ -57,6 +60,8 @@ impl<R> Loader<'_, R> {
             mem_layout,
             page_imports: RangeMap::new(),
             max_vtl,
+            vp_context_page: None,
+            snp_vmsa_finalized: false,
         }
     }
 
@@ -176,6 +181,10 @@ impl<R: Debug + GuestArch> ImageLoad<R> for Loader<'_, R> {
     }
 
     fn import_vp_register(&mut self, register: R) -> anyhow::Result<()> {
+        anyhow::ensure!(
+            !self.snp_vmsa_finalized,
+            "register imported after SNP VMSA was finalized"
+        );
         let entry = self.regs.entry(std::mem::discriminant(&register));
         match entry {
             std::collections::hash_map::Entry::Occupied(_) => {
@@ -262,8 +271,17 @@ impl<R: Debug + GuestArch> ImageLoad<R> for Loader<'_, R> {
         }
     }
 
-    fn set_vp_context_page(&mut self, _page_base: u64) -> anyhow::Result<()> {
-        unimplemented!()
+    fn set_vp_context_page(&mut self, page_base: u64) -> anyhow::Result<()> {
+        anyhow::ensure!(
+            self.vp_context_page.is_none(),
+            "VP context page was already set"
+        );
+        self.accept_new_range(page_base, 1, "snp-vmsa", BootPageAcceptance::VpContext)?;
+        self.gm
+            .fill_at(page_base * HV_PAGE_SIZE, 0, HV_PAGE_SIZE as usize)
+            .context("unable to zero VP context page")?;
+        self.vp_context_page = Some(page_base);
+        Ok(())
     }
 
     fn create_parameter_area(
@@ -320,6 +338,30 @@ impl<R: Debug + GuestArch> ImageLoad<R> for Loader<'_, R> {
 
     fn set_imported_regions_config_page(&mut self, _page_base: u64) {
         unimplemented!()
+    }
+}
+
+impl Loader<'_, X86Register> {
+    /// Finalizes the loader-provided SNP VMSA at the configured VP context page.
+    /// TODO: Remove this SNP-specific path from the generic loader if direct
+    /// boot moves to loading only IGVM files.
+    pub fn finalize_snp_vmsa(
+        &mut self,
+        caps: &virt::x86::X86PartitionCapabilities,
+        bsp: &vm_topology::processor::x86::X86VpInfo,
+    ) -> anyhow::Result<()> {
+        anyhow::ensure!(!self.snp_vmsa_finalized, "SNP VMSA was already finalized");
+        let page_base = self
+            .vp_context_page
+            .ok_or_else(|| anyhow::anyhow!("SNP VP context page was not configured"))?;
+        let regs = self.regs.values().copied().collect::<Vec<_>>();
+        let initial = initial_regs::x86_initial_regs(&regs, caps, bsp);
+        let vmsa = virt::x86::snp::vmsa_from_initial_regs(&initial);
+        self.gm
+            .write_plain(page_base * HV_PAGE_SIZE, &vmsa)
+            .context("unable to write SNP VMSA")?;
+        self.snp_vmsa_finalized = true;
+        Ok(())
     }
 }
 
@@ -394,6 +436,23 @@ mod tests {
             .unwrap_err();
 
         assert!(err.to_string().contains("duplicate register import"));
+    }
+
+    #[test]
+    fn register_import_after_snp_vmsa_finalization_returns_error() {
+        let gm = GuestMemory::allocate(0x10000);
+        let mem_layout = test_memory_layout();
+        let mut loader = Loader::<X86Register>::new(gm, &mem_layout, Vtl::Vtl0);
+        loader.snp_vmsa_finalized = true;
+
+        let err = loader
+            .import_vp_register(X86Register::Rip(0x100000))
+            .unwrap_err();
+
+        assert!(
+            err.to_string()
+                .contains("register imported after SNP VMSA was finalized")
+        );
     }
 
     #[test]


### PR DESCRIPTION
In preperation for IGVM loader support and MHSV support for SNP, generate VMSAs from the Linux loader path and consume them in virt_kvm. Note that KVM does not yet support supplied VMSAs from usermode, so it needs to be translated back to registers set calls along with breaking any measurements. A follow up change will enable both IGVM loader support and MSHV support for SNP. 