### PR TITLE
flowey: bump mu_msvm UEFI firmware to 26.0.19 (#3977)

### DIFF
--- a/flowey/flowey_lib_hvlite/src/_jobs/cfg_versions.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/cfg_versions.rs
@@ -24,7 +24,7 @@ pub const GH_CLI: &str = "2.52.0";
 pub const MDBOOK: &str = "0.4.40";
 pub const MDBOOK_ADMONISH: &str = "1.18.0";
 pub const MDBOOK_MERMAID: &str = "0.14.0";
-pub const MU_MSVM: &str = "26.0.13";
+pub const MU_MSVM: &str = "26.0.19";
 pub const NEXTEST: &str = "0.9.133";
 pub const NODEJS: &str = "24.x";
 // N.B. Kernel version numbers for dev and stable branches are not directly

--- a/vmm_tests/vmm_tests/tests/tests/multiarch.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch.rs
@@ -596,14 +596,15 @@ async fn efi_diagnostics_info_level<T: PetriVmmBackend>(
         .run_without_agent()
         .await?;
 
-    // The last INFO-level entry emitted by the Hyper-V UEFI firmware right
-    // before it hands control to `firmware_uefi::service::diagnostics` to
-    // collect entries. It only appears in the trace stream when:
+    // The last INFO-level entry emitted by the Hyper-V UEFI firmware in this
+    // no-boot (frontpage) scenario, right before it hands control to
+    // `firmware_uefi::service::diagnostics` to collect entries. It only
+    // appears in the trace stream when:
     //   1. The diagnostics log level is INFO
     //   2. Rate limiting is disabled — UEFI emits ~1000 INFO entries in a
-    //      single burst, and this is one of the very last; with the default
-    //      rate limit it gets dropped.
-    const MARKER: &str = "Signaling BIOS device to collect EFI diagnostics";
+    //      single burst, and this is the very last; with the default rate
+    //      limit it gets dropped.
+    const MARKER: &str = "Signaling Unable To Boot event";
 
     let mut kmsg = vm.kmsg().await?;
 


### PR DESCRIPTION
Clean cherry pick of PR #3977

Advance the pinned mu_msvm UEFI firmware from 26.0.13 to 26.0.19. This lands the newer firmware release on its own so it can bake and be validated independently of the in-progress work to boot UEFI without hypervisor enlightenments, which relies on a SEC platform-type facility added in this build.

The bump also changes the firmware's diagnostics output, so update the efi_diagnostics_info_level test to match. The marker line it looks for to confirm the full INFO burst is captured with rate limiting disabled is no longer "Signaling BIOS device to collect EFI diagnostics"; the last INFO entry before control passes to the diagnostics collector is now "Signaling Unable To Boot event" in the no-boot frontpage scenario the test uses, so point the marker there.
