### PR TITLE
openhcl: write hibernate token to VMGS on power transitions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8929,6 +8929,7 @@ dependencies = [
  "disk_blockdevice",
  "disk_get_vmgs",
  "disk_nvme",
+ "disklayer_ram",
  "firmware_pcat",
  "firmware_uefi_resources",
  "framebuffer",

--- a/openhcl/underhill_core/Cargo.toml
+++ b/openhcl/underhill_core/Cargo.toml
@@ -188,6 +188,7 @@ aarch64defs.workspace = true
 firmware_pcat.workspace = true
 
 [dev-dependencies]
+disklayer_ram.workspace = true
 guest_emulation_transport = { workspace = true, features = ["test_utilities"] }
 test_with_tracing.workspace = true
 nvme_spec.workspace = true

--- a/openhcl/underhill_core/src/dispatch/mod.rs
+++ b/openhcl/underhill_core/src/dispatch/mod.rs
@@ -144,7 +144,7 @@ pub(crate) struct LoadedVm {
     /// The various guest memory objects.
     pub memory: underhill_mem::MemoryMappings,
     pub firmware_type: FirmwareType,
-    pub hibernate_token: Option<u64>,
+    pub hibernate_token: Option<crate::hibernate::HibernateToken>,
     pub isolation: IsolationType,
     // contain task handles which must be kept live
     pub chipset_devices: ChipsetDevices,
@@ -989,7 +989,9 @@ impl LoadedVm {
                 overlay_shutdown_device: self.shutdown_relay.is_some(),
                 hibernate: self
                     .hibernate_token
-                    .map(|token| servicing::HibernateSavedState { token }),
+                    .map(|token| servicing::HibernateSavedState {
+                        token: token.into(),
+                    }),
                 nvme_state,
                 dma_manager_state,
                 vmbus_client,

--- a/openhcl/underhill_core/src/dispatch/mod.rs
+++ b/openhcl/underhill_core/src/dispatch/mod.rs
@@ -144,7 +144,7 @@ pub(crate) struct LoadedVm {
     /// The various guest memory objects.
     pub memory: underhill_mem::MemoryMappings,
     pub firmware_type: FirmwareType,
-    pub hibernate_token: Option<crate::hibernate::HibernateToken>,
+    pub hibernate_token: Option<crate::hibernate::Token>,
     pub isolation: IsolationType,
     // contain task handles which must be kept live
     pub chipset_devices: ChipsetDevices,

--- a/openhcl/underhill_core/src/dispatch/mod.rs
+++ b/openhcl/underhill_core/src/dispatch/mod.rs
@@ -144,6 +144,7 @@ pub(crate) struct LoadedVm {
     /// The various guest memory objects.
     pub memory: underhill_mem::MemoryMappings,
     pub firmware_type: FirmwareType,
+    pub hibernate_token: Option<u64>,
     pub isolation: IsolationType,
     // contain task handles which must be kept live
     pub chipset_devices: ChipsetDevices,
@@ -986,6 +987,9 @@ impl LoadedVm {
                 flush_logs_result: None,
                 vmgs,
                 overlay_shutdown_device: self.shutdown_relay.is_some(),
+                hibernate: self
+                    .hibernate_token
+                    .map(|token| servicing::HibernateSavedState { token }),
                 nvme_state,
                 dma_manager_state,
                 vmbus_client,

--- a/openhcl/underhill_core/src/hibernate.rs
+++ b/openhcl/underhill_core/src/hibernate.rs
@@ -7,6 +7,8 @@
 //! major version and the low 8 bits are the minor version.
 
 use cvm_tracing::CVM_ALLOWED;
+use vmgs_broker::VmgsBrokerError;
+use vmgs_broker::VmgsClientError;
 
 /// Hibernate token values written to [`vmgs::FileId::HIBERNATION_TOKEN`].
 pub mod token {
@@ -55,40 +57,25 @@ pub async fn write_token(vmgs_client: &vmgs_broker::VmgsClient, token: u64) {
 /// Best-effort deletion of the hibernate token, clearing any prior hibernate
 /// marker. Never blocks the power transition.
 pub async fn delete_token(vmgs_client: &vmgs_broker::VmgsClient) {
-    // delete_file errors when the token is absent, the common no-hibernate case.
-    if vmgs_client
-        .get_file_info(vmgs::FileId::HIBERNATION_TOKEN)
-        .await
-        .is_err()
-    {
-        return;
-    }
-    if let Err(err) = vmgs_client
+    match vmgs_client
         .delete_file(vmgs::FileId::HIBERNATION_TOKEN)
         .await
     {
-        tracing::error!(
-            CVM_ALLOWED,
-            error = &err as &dyn std::error::Error,
-            "failed to delete hibernate token"
-        );
+        // An absent token is the common no-hibernate case.
+        Ok(()) | Err(VmgsClientError::Vmgs(VmgsBrokerError::FileInfoNotAllocated)) => {}
+        Err(err) => {
+            tracing::error!(
+                CVM_ALLOWED,
+                error = &err as &dyn std::error::Error,
+                "failed to delete hibernate token"
+            );
+        }
     }
 }
 
 /// At boot, record which hibernate token (if any) the previous session left
 /// behind.
 pub async fn read_token(vmgs_client: &vmgs_broker::VmgsClient) -> Option<u64> {
-    if vmgs_client
-        .get_file_info(vmgs::FileId::HIBERNATION_TOKEN)
-        .await
-        .is_err()
-    {
-        tracing::info!(
-            CVM_ALLOWED,
-            "hibernation enabled: no hibernation token found"
-        );
-        return None;
-    }
     match vmgs_client.read_file(vmgs::FileId::HIBERNATION_TOKEN).await {
         Ok(buf) => match buf.first_chunk::<8>() {
             Some(bytes) => {
@@ -108,6 +95,13 @@ pub async fn read_token(vmgs_client: &vmgs_broker::VmgsClient) -> Option<u64> {
                 None
             }
         },
+        Err(VmgsClientError::Vmgs(VmgsBrokerError::FileInfoNotAllocated)) => {
+            tracing::info!(
+                CVM_ALLOWED,
+                "hibernation enabled: no hibernation token found"
+            );
+            None
+        }
         Err(err) => {
             tracing::error!(
                 CVM_ALLOWED,

--- a/openhcl/underhill_core/src/hibernate.rs
+++ b/openhcl/underhill_core/src/hibernate.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-//! OpenHCL hibernate token handling: the [`HibernateToken`] recorded in
+//! OpenHCL hibernate token handling: the [`Token`] recorded in
 //! [`vmgs::FileId::HIBERNATION_TOKEN`] and helpers to read, write, and delete
 //! it.
 
@@ -18,7 +18,7 @@ use vmgs_broker::VmgsClientError;
 /// byte); any other value is kept verbatim as [`Self::Other`] so the full `u64`
 /// round-trips.
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
-pub enum HibernateToken {
+pub enum Token {
     /// Not hibernated; written on a clean power off / reset.
     NotHibernated,
     /// Hibernated under firmware version `major.minor`.
@@ -27,26 +27,24 @@ pub enum HibernateToken {
     Other(u64),
 }
 
-impl HibernateToken {
+impl Token {
     /// Written when the current firmware hibernates; bump per release.
     pub const CURRENT: Self = Self::Hibernated { major: 1, minor: 9 };
     /// Written when the firmware version is unknown (e.g. after servicing).
     pub const UNKNOWN: Self = Self::Hibernated { major: 1, minor: 0 };
 }
 
-impl From<HibernateToken> for u64 {
-    fn from(token: HibernateToken) -> Self {
+impl From<Token> for u64 {
+    fn from(token: Token) -> Self {
         match token {
-            HibernateToken::NotHibernated => 0,
-            HibernateToken::Hibernated { major, minor } => {
-                (u64::from(major) << 8) | u64::from(minor)
-            }
-            HibernateToken::Other(raw) => raw,
+            Token::NotHibernated => 0,
+            Token::Hibernated { major, minor } => (u64::from(major) << 8) | u64::from(minor),
+            Token::Other(raw) => raw,
         }
     }
 }
 
-impl From<u64> for HibernateToken {
+impl From<u64> for Token {
     fn from(raw: u64) -> Self {
         match raw {
             0 => Self::NotHibernated,
@@ -59,7 +57,7 @@ impl From<u64> for HibernateToken {
     }
 }
 
-impl fmt::Display for HibernateToken {
+impl fmt::Display for Token {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::NotHibernated => f.write_str("not-hibernated"),
@@ -75,12 +73,12 @@ pub struct HaltState {
     /// VMGS client used to persist the hibernate token.
     pub vmgs_client: vmgs_broker::VmgsClient,
     /// Token to write on hibernate.
-    pub current_token: HibernateToken,
+    pub current_token: Token,
 }
 
 /// Best-effort write of an 8-byte hibernate token to the VMGS. Failures are
 /// logged but never block the power transition.
-pub async fn write_token(vmgs_client: &vmgs_broker::VmgsClient, token: HibernateToken) {
+pub async fn write_token(vmgs_client: &vmgs_broker::VmgsClient, token: Token) {
     if let Err(err) = vmgs_client
         .write_file(
             vmgs::FileId::HIBERNATION_TOKEN,
@@ -118,11 +116,11 @@ pub async fn delete_token(vmgs_client: &vmgs_broker::VmgsClient) {
 
 /// At boot, record which hibernate token (if any) the previous session left
 /// behind.
-pub async fn read_token(vmgs_client: &vmgs_broker::VmgsClient) -> Option<HibernateToken> {
+pub async fn read_token(vmgs_client: &vmgs_broker::VmgsClient) -> Option<Token> {
     match vmgs_client.read_file(vmgs::FileId::HIBERNATION_TOKEN).await {
         Ok(buf) => match <[u8; 8]>::try_from(buf.as_slice()) {
             Ok(bytes) => {
-                let token = HibernateToken::from(u64::from_le_bytes(bytes));
+                let token = Token::from(u64::from_le_bytes(bytes));
                 tracing::info!(
                     CVM_ALLOWED,
                     %token,
@@ -182,8 +180,8 @@ mod tests {
     #[async_test]
     async fn write_read_delete(driver: DefaultDriver) {
         let (client, _task) = new_client(&driver).await;
-        write_token(&client, HibernateToken::CURRENT).await;
-        assert_eq!(read_token(&client).await, Some(HibernateToken::CURRENT));
+        write_token(&client, Token::CURRENT).await;
+        assert_eq!(read_token(&client).await, Some(Token::CURRENT));
         delete_token(&client).await;
         assert_eq!(read_token(&client).await, None);
     }
@@ -191,53 +189,41 @@ mod tests {
     #[async_test]
     async fn write_not_hibernated(driver: DefaultDriver) {
         let (client, _task) = new_client(&driver).await;
-        write_token(&client, HibernateToken::NotHibernated).await;
-        assert_eq!(
-            read_token(&client).await,
-            Some(HibernateToken::NotHibernated)
-        );
+        write_token(&client, Token::NotHibernated).await;
+        assert_eq!(read_token(&client).await, Some(Token::NotHibernated));
     }
 
     #[test]
     fn constants_encode_as_expected() {
-        assert_eq!(u64::from(HibernateToken::NotHibernated), 0);
-        assert_eq!(u64::from(HibernateToken::CURRENT), 0x0109);
-        assert_eq!(u64::from(HibernateToken::UNKNOWN), 0x0100);
+        assert_eq!(u64::from(Token::NotHibernated), 0);
+        assert_eq!(u64::from(Token::CURRENT), 0x0109);
+        assert_eq!(u64::from(Token::UNKNOWN), 0x0100);
     }
 
     #[test]
     fn classification_boundaries() {
         // 0 is the not-hibernated marker.
-        assert_eq!(HibernateToken::from(0), HibernateToken::NotHibernated);
+        assert_eq!(Token::from(0), Token::NotHibernated);
         // 1..=0xFFFF decode as firmware versions.
+        assert_eq!(Token::from(1), Token::Hibernated { major: 0, minor: 1 });
         assert_eq!(
-            HibernateToken::from(1),
-            HibernateToken::Hibernated { major: 0, minor: 1 }
-        );
-        assert_eq!(
-            HibernateToken::from(0xFFFF),
-            HibernateToken::Hibernated {
+            Token::from(0xFFFF),
+            Token::Hibernated {
                 major: 0xFF,
                 minor: 0xFF
             }
         );
         // The first value past the version range falls through to Other.
-        assert_eq!(
-            HibernateToken::from(0x1_0000),
-            HibernateToken::Other(0x1_0000)
-        );
-        assert_eq!(
-            HibernateToken::from(u64::MAX),
-            HibernateToken::Other(u64::MAX)
-        );
+        assert_eq!(Token::from(0x1_0000), Token::Other(0x1_0000));
+        assert_eq!(Token::from(u64::MAX), Token::Other(u64::MAX));
     }
 
     #[test]
     fn all_versions_round_trip() {
         // Exhaustively cover the entire firmware-version range.
         for raw in 1..=0xFFFFu64 {
-            let token = HibernateToken::from(raw);
-            assert!(matches!(token, HibernateToken::Hibernated { .. }));
+            let token = Token::from(raw);
+            assert!(matches!(token, Token::Hibernated { .. }));
             assert_eq!(u64::from(token), raw);
         }
     }
@@ -251,8 +237,8 @@ mod tests {
             cases.push(1u64 << shift);
         }
         for raw in cases {
-            let token = HibernateToken::from(raw);
-            assert_eq!(token, HibernateToken::Other(raw));
+            let token = Token::from(raw);
+            assert_eq!(token, Token::Other(raw));
             assert_eq!(u64::from(token), raw);
         }
     }

--- a/openhcl/underhill_core/src/hibernate.rs
+++ b/openhcl/underhill_core/src/hibernate.rs
@@ -3,9 +3,8 @@
 
 //! OpenHCL hibernate token handling: the values written to
 //! [`vmgs::FileId::HIBERNATION_TOKEN`] and helpers to read, write, and delete
-//! it, mirroring the legacy HCL `HclPowerServices` behavior. Tokens encode the
-//! firmware version in 16 bits: the high 8 bits are the major version and the
-//! low 8 bits are the minor version.
+//! it. Tokens encode the firmware version in 16 bits: the high 8 bits are the
+//! major version and the low 8 bits are the minor version.
 
 use cvm_tracing::CVM_ALLOWED;
 
@@ -77,7 +76,7 @@ pub async fn delete_token(vmgs_client: &vmgs_broker::VmgsClient) {
 }
 
 /// At boot, record which hibernate token (if any) the previous session left
-/// behind. Mirrors the legacy HCL `WriteUefiConfigBlob` telemetry.
+/// behind.
 pub async fn read_token(vmgs_client: &vmgs_broker::VmgsClient) -> Option<u64> {
     if vmgs_client
         .get_file_info(vmgs::FileId::HIBERNATION_TOKEN)

--- a/openhcl/underhill_core/src/hibernate.rs
+++ b/openhcl/underhill_core/src/hibernate.rs
@@ -1,0 +1,172 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! OpenHCL hibernate token handling: the values written to
+//! [`vmgs::FileId::HIBERNATION_TOKEN`] and helpers to read, write, and delete
+//! it, mirroring the legacy HCL `HclPowerServices` behavior. Tokens encode the
+//! firmware version in 16 bits: the high 8 bits are the major version and the
+//! low 8 bits are the minor version.
+
+use cvm_tracing::CVM_ALLOWED;
+
+/// Hibernate token values written to [`vmgs::FileId::HIBERNATION_TOKEN`].
+pub mod token {
+    /// Written on a clean power off / reset; the guest is not hibernated.
+    pub const NONE: u64 = 0x0;
+    /// Written when the firmware version is unknown (e.g. after servicing).
+    pub const HIBERNATED_UNKNOWN: u64 = 0x0100;
+    /// Written on hibernate under firmware version 1.7.
+    pub const HIBERNATED_1_7: u64 = (1 << 8) | 7;
+    /// Written on hibernate under firmware version 1.8.
+    pub const HIBERNATED_1_8: u64 = (1 << 8) | 8;
+    /// Written on hibernate under firmware version 1.9.
+    pub const HIBERNATED_1_9: u64 = (1 << 8) | 9;
+    /// The current firmware version's token, written on hibernate.
+    pub const DEFAULT: u64 = HIBERNATED_1_9;
+}
+
+/// Hibernation state the halt task needs to persist the token across a power
+/// transition. Present only when hibernation is enabled and VMGS is available.
+pub struct HaltState {
+    /// VMGS client used to persist the hibernate token.
+    pub vmgs_client: vmgs_broker::VmgsClient,
+    /// Token to write on hibernate.
+    pub current_token: u64,
+}
+
+/// Best-effort write of an 8-byte hibernate token to the VMGS. Failures are
+/// logged but never block the power transition.
+pub async fn write_token(vmgs_client: &vmgs_broker::VmgsClient, token: u64) {
+    if let Err(err) = vmgs_client
+        .write_file(
+            vmgs::FileId::HIBERNATION_TOKEN,
+            token.to_le_bytes().to_vec(),
+        )
+        .await
+    {
+        tracing::error!(
+            CVM_ALLOWED,
+            error = &err as &dyn std::error::Error,
+            token,
+            "failed to write hibernate token"
+        );
+    }
+}
+
+/// Best-effort deletion of the hibernate token, clearing any prior hibernate
+/// marker. Never blocks the power transition.
+pub async fn delete_token(vmgs_client: &vmgs_broker::VmgsClient) {
+    // delete_file errors when the token is absent, the common no-hibernate case.
+    if vmgs_client
+        .get_file_info(vmgs::FileId::HIBERNATION_TOKEN)
+        .await
+        .is_err()
+    {
+        return;
+    }
+    if let Err(err) = vmgs_client
+        .delete_file(vmgs::FileId::HIBERNATION_TOKEN)
+        .await
+    {
+        tracing::error!(
+            CVM_ALLOWED,
+            error = &err as &dyn std::error::Error,
+            "failed to delete hibernate token"
+        );
+    }
+}
+
+/// At boot, record which hibernate token (if any) the previous session left
+/// behind. Mirrors the legacy HCL `WriteUefiConfigBlob` telemetry.
+pub async fn read_token(vmgs_client: &vmgs_broker::VmgsClient) -> Option<u64> {
+    if vmgs_client
+        .get_file_info(vmgs::FileId::HIBERNATION_TOKEN)
+        .await
+        .is_err()
+    {
+        tracing::info!(
+            CVM_ALLOWED,
+            "hibernation enabled: no hibernation token found"
+        );
+        return None;
+    }
+    match vmgs_client.read_file(vmgs::FileId::HIBERNATION_TOKEN).await {
+        Ok(buf) => match buf.first_chunk::<8>() {
+            Some(bytes) => {
+                let token = u64::from_le_bytes(*bytes);
+                tracing::info!(
+                    CVM_ALLOWED,
+                    token = format_args!("{token:#x}"),
+                    "hibernation enabled: hibernation token found"
+                );
+                Some(token)
+            }
+            None => {
+                tracing::warn!(
+                    CVM_ALLOWED,
+                    "hibernation enabled: corrupt hibernation token found"
+                );
+                None
+            }
+        },
+        Err(err) => {
+            tracing::error!(
+                CVM_ALLOWED,
+                error = &err as &dyn std::error::Error,
+                "hibernation enabled: failed to read hibernation token"
+            );
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use disklayer_ram::ram_disk;
+    use pal_async::DefaultDriver;
+    use pal_async::async_test;
+    use pal_async::task::Task;
+    use vmgs::Vmgs;
+    use vmgs_broker::VmgsClient;
+    use vmgs_broker::spawn_vmgs_broker;
+
+    async fn new_client(driver: &DefaultDriver) -> (VmgsClient, Task<()>) {
+        let disk = ram_disk(4 * 1024 * 1024, false).unwrap();
+        let vmgs = Vmgs::format_new(disk, None).await.unwrap();
+        spawn_vmgs_broker(driver.clone(), vmgs)
+    }
+
+    #[async_test]
+    async fn read_absent_is_none(driver: DefaultDriver) {
+        let (client, _task) = new_client(&driver).await;
+        assert_eq!(read_token(&client).await, None);
+    }
+
+    #[async_test]
+    async fn write_read_delete(driver: DefaultDriver) {
+        let (client, _task) = new_client(&driver).await;
+        write_token(&client, token::DEFAULT).await;
+        assert_eq!(read_token(&client).await, Some(token::DEFAULT));
+        delete_token(&client).await;
+        assert_eq!(read_token(&client).await, None);
+    }
+
+    #[async_test]
+    async fn read_none_value(driver: DefaultDriver) {
+        let (client, _task) = new_client(&driver).await;
+        write_token(&client, token::NONE).await;
+        assert_eq!(read_token(&client).await, Some(token::NONE));
+    }
+
+    #[async_test]
+    async fn read_corrupt_is_none(driver: DefaultDriver) {
+        let (client, _task) = new_client(&driver).await;
+        // A token that is not exactly 8 bytes is treated as corrupt.
+        client
+            .write_file(vmgs::FileId::HIBERNATION_TOKEN, vec![1, 2, 3])
+            .await
+            .unwrap();
+        assert_eq!(read_token(&client).await, None);
+    }
+}

--- a/openhcl/underhill_core/src/hibernate.rs
+++ b/openhcl/underhill_core/src/hibernate.rs
@@ -1,31 +1,72 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-//! OpenHCL hibernate token handling: the values written to
+//! OpenHCL hibernate token handling: the [`HibernateToken`] recorded in
 //! [`vmgs::FileId::HIBERNATION_TOKEN`] and helpers to read, write, and delete
-//! it. Tokens encode the firmware version in 16 bits: the high 8 bits are the
-//! major version and the low 8 bits are the minor version.
+//! it.
 
 use cvm_tracing::CVM_ALLOWED;
+use std::fmt;
 use vmgs_broker::VmgsBrokerError;
 use vmgs_broker::VmgsClientError;
 
-/// Hibernate token values written to [`vmgs::FileId::HIBERNATION_TOKEN`].
-pub mod token {
-    /// Written on a clean power off / reset; the guest is not hibernated.
-    pub const NONE: u64 = 0x0;
+/// The hibernate marker recorded in [`vmgs::FileId::HIBERNATION_TOKEN`],
+/// decoupled from its on-disk encoding.
+///
+/// Stored as an 8-byte little-endian value. `0` is [`Self::NotHibernated`];
+/// `1..=0xFFFF` is a firmware version (major in the high byte, minor in the low
+/// byte); any other value is kept verbatim as [`Self::Other`] so the full `u64`
+/// round-trips.
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+pub enum HibernateToken {
+    /// Not hibernated; written on a clean power off / reset.
+    NotHibernated,
+    /// Hibernated under firmware version `major.minor`.
+    Hibernated { major: u8, minor: u8 },
+    /// An unrecognized value, preserved verbatim.
+    Other(u64),
+}
+
+impl HibernateToken {
+    /// Written when the current firmware hibernates; bump per release.
+    pub const CURRENT: Self = Self::Hibernated { major: 1, minor: 9 };
     /// Written when the firmware version is unknown (e.g. after servicing).
-    pub const HIBERNATED_UNKNOWN: u64 = 0x0100;
-    /// Written on hibernate under firmware version 1.7.
-    #[expect(dead_code, reason = "reserved firmware version, not yet written")]
-    pub const HIBERNATED_1_7: u64 = (1 << 8) | 7;
-    /// Written on hibernate under firmware version 1.8.
-    #[expect(dead_code, reason = "reserved firmware version, not yet written")]
-    pub const HIBERNATED_1_8: u64 = (1 << 8) | 8;
-    /// Written on hibernate under firmware version 1.9.
-    pub const HIBERNATED_1_9: u64 = (1 << 8) | 9;
-    /// The current firmware version's token, written on hibernate.
-    pub const DEFAULT: u64 = HIBERNATED_1_9;
+    pub const UNKNOWN: Self = Self::Hibernated { major: 1, minor: 0 };
+}
+
+impl From<HibernateToken> for u64 {
+    fn from(token: HibernateToken) -> Self {
+        match token {
+            HibernateToken::NotHibernated => 0,
+            HibernateToken::Hibernated { major, minor } => {
+                (u64::from(major) << 8) | u64::from(minor)
+            }
+            HibernateToken::Other(raw) => raw,
+        }
+    }
+}
+
+impl From<u64> for HibernateToken {
+    fn from(raw: u64) -> Self {
+        match raw {
+            0 => Self::NotHibernated,
+            1..=0xFFFF => Self::Hibernated {
+                major: (raw >> 8) as u8,
+                minor: raw as u8,
+            },
+            raw => Self::Other(raw),
+        }
+    }
+}
+
+impl fmt::Display for HibernateToken {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NotHibernated => f.write_str("not-hibernated"),
+            Self::Hibernated { major, minor } => write!(f, "{major}.{minor}"),
+            Self::Other(raw) => write!(f, "{raw:#x}"),
+        }
+    }
 }
 
 /// Hibernation state the halt task needs to persist the token across a power
@@ -34,23 +75,23 @@ pub struct HaltState {
     /// VMGS client used to persist the hibernate token.
     pub vmgs_client: vmgs_broker::VmgsClient,
     /// Token to write on hibernate.
-    pub current_token: u64,
+    pub current_token: HibernateToken,
 }
 
 /// Best-effort write of an 8-byte hibernate token to the VMGS. Failures are
 /// logged but never block the power transition.
-pub async fn write_token(vmgs_client: &vmgs_broker::VmgsClient, token: u64) {
+pub async fn write_token(vmgs_client: &vmgs_broker::VmgsClient, token: HibernateToken) {
     if let Err(err) = vmgs_client
         .write_file(
             vmgs::FileId::HIBERNATION_TOKEN,
-            token.to_le_bytes().to_vec(),
+            u64::from(token).to_le_bytes().to_vec(),
         )
         .await
     {
         tracing::error!(
             CVM_ALLOWED,
             error = &err as &dyn std::error::Error,
-            token = format_args!("{token:#x}"),
+            %token,
             "failed to write hibernate token"
         );
     }
@@ -77,14 +118,14 @@ pub async fn delete_token(vmgs_client: &vmgs_broker::VmgsClient) {
 
 /// At boot, record which hibernate token (if any) the previous session left
 /// behind.
-pub async fn read_token(vmgs_client: &vmgs_broker::VmgsClient) -> Option<u64> {
+pub async fn read_token(vmgs_client: &vmgs_broker::VmgsClient) -> Option<HibernateToken> {
     match vmgs_client.read_file(vmgs::FileId::HIBERNATION_TOKEN).await {
         Ok(buf) => match <[u8; 8]>::try_from(buf.as_slice()) {
             Ok(bytes) => {
-                let token = u64::from_le_bytes(bytes);
+                let token = HibernateToken::from(u64::from_le_bytes(bytes));
                 tracing::info!(
                     CVM_ALLOWED,
-                    token = format_args!("{token:#x}"),
+                    %token,
                     "hibernation enabled: hibernation token found"
                 );
                 Some(token)
@@ -141,17 +182,79 @@ mod tests {
     #[async_test]
     async fn write_read_delete(driver: DefaultDriver) {
         let (client, _task) = new_client(&driver).await;
-        write_token(&client, token::DEFAULT).await;
-        assert_eq!(read_token(&client).await, Some(token::DEFAULT));
+        write_token(&client, HibernateToken::CURRENT).await;
+        assert_eq!(read_token(&client).await, Some(HibernateToken::CURRENT));
         delete_token(&client).await;
         assert_eq!(read_token(&client).await, None);
     }
 
     #[async_test]
-    async fn read_none_value(driver: DefaultDriver) {
+    async fn write_not_hibernated(driver: DefaultDriver) {
         let (client, _task) = new_client(&driver).await;
-        write_token(&client, token::NONE).await;
-        assert_eq!(read_token(&client).await, Some(token::NONE));
+        write_token(&client, HibernateToken::NotHibernated).await;
+        assert_eq!(
+            read_token(&client).await,
+            Some(HibernateToken::NotHibernated)
+        );
+    }
+
+    #[test]
+    fn constants_encode_as_expected() {
+        assert_eq!(u64::from(HibernateToken::NotHibernated), 0);
+        assert_eq!(u64::from(HibernateToken::CURRENT), 0x0109);
+        assert_eq!(u64::from(HibernateToken::UNKNOWN), 0x0100);
+    }
+
+    #[test]
+    fn classification_boundaries() {
+        // 0 is the not-hibernated marker.
+        assert_eq!(HibernateToken::from(0), HibernateToken::NotHibernated);
+        // 1..=0xFFFF decode as firmware versions.
+        assert_eq!(
+            HibernateToken::from(1),
+            HibernateToken::Hibernated { major: 0, minor: 1 }
+        );
+        assert_eq!(
+            HibernateToken::from(0xFFFF),
+            HibernateToken::Hibernated {
+                major: 0xFF,
+                minor: 0xFF
+            }
+        );
+        // The first value past the version range falls through to Other.
+        assert_eq!(
+            HibernateToken::from(0x1_0000),
+            HibernateToken::Other(0x1_0000)
+        );
+        assert_eq!(
+            HibernateToken::from(u64::MAX),
+            HibernateToken::Other(u64::MAX)
+        );
+    }
+
+    #[test]
+    fn all_versions_round_trip() {
+        // Exhaustively cover the entire firmware-version range.
+        for raw in 1..=0xFFFFu64 {
+            let token = HibernateToken::from(raw);
+            assert!(matches!(token, HibernateToken::Hibernated { .. }));
+            assert_eq!(u64::from(token), raw);
+        }
+    }
+
+    #[test]
+    fn other_values_round_trip() {
+        // Spot-check a spread of values above the version range, including the
+        // boundary, powers of two, and the maximum.
+        let mut cases = vec![0x1_0000u64, 0x1_0001, u64::MAX, u64::MAX - 1];
+        for shift in 16..64 {
+            cases.push(1u64 << shift);
+        }
+        for raw in cases {
+            let token = HibernateToken::from(raw);
+            assert_eq!(token, HibernateToken::Other(raw));
+            assert_eq!(u64::from(token), raw);
+        }
     }
 
     #[async_test]

--- a/openhcl/underhill_core/src/hibernate.rs
+++ b/openhcl/underhill_core/src/hibernate.rs
@@ -17,8 +17,10 @@ pub mod token {
     /// Written when the firmware version is unknown (e.g. after servicing).
     pub const HIBERNATED_UNKNOWN: u64 = 0x0100;
     /// Written on hibernate under firmware version 1.7.
+    #[expect(dead_code, reason = "reserved firmware version, not yet written")]
     pub const HIBERNATED_1_7: u64 = (1 << 8) | 7;
     /// Written on hibernate under firmware version 1.8.
+    #[expect(dead_code, reason = "reserved firmware version, not yet written")]
     pub const HIBERNATED_1_8: u64 = (1 << 8) | 8;
     /// Written on hibernate under firmware version 1.9.
     pub const HIBERNATED_1_9: u64 = (1 << 8) | 9;
@@ -48,7 +50,7 @@ pub async fn write_token(vmgs_client: &vmgs_broker::VmgsClient, token: u64) {
         tracing::error!(
             CVM_ALLOWED,
             error = &err as &dyn std::error::Error,
-            token,
+            token = format_args!("{token:#x}"),
             "failed to write hibernate token"
         );
     }
@@ -77,9 +79,9 @@ pub async fn delete_token(vmgs_client: &vmgs_broker::VmgsClient) {
 /// behind.
 pub async fn read_token(vmgs_client: &vmgs_broker::VmgsClient) -> Option<u64> {
     match vmgs_client.read_file(vmgs::FileId::HIBERNATION_TOKEN).await {
-        Ok(buf) => match buf.first_chunk::<8>() {
-            Some(bytes) => {
-                let token = u64::from_le_bytes(*bytes);
+        Ok(buf) => match <[u8; 8]>::try_from(buf.as_slice()) {
+            Ok(bytes) => {
+                let token = u64::from_le_bytes(bytes);
                 tracing::info!(
                     CVM_ALLOWED,
                     token = format_args!("{token:#x}"),
@@ -87,7 +89,7 @@ pub async fn read_token(vmgs_client: &vmgs_broker::VmgsClient) -> Option<u64> {
                 );
                 Some(token)
             }
-            None => {
+            Err(_) => {
                 tracing::warn!(
                     CVM_ALLOWED,
                     "hibernation enabled: corrupt hibernation token found"
@@ -155,9 +157,20 @@ mod tests {
     #[async_test]
     async fn read_corrupt_is_none(driver: DefaultDriver) {
         let (client, _task) = new_client(&driver).await;
-        // A token that is not exactly 8 bytes is treated as corrupt.
+        // A token shorter than 8 bytes is treated as corrupt.
         client
             .write_file(vmgs::FileId::HIBERNATION_TOKEN, vec![1, 2, 3])
+            .await
+            .unwrap();
+        assert_eq!(read_token(&client).await, None);
+    }
+
+    #[async_test]
+    async fn read_oversized_is_none(driver: DefaultDriver) {
+        let (client, _task) = new_client(&driver).await;
+        // A token longer than 8 bytes is also treated as corrupt.
+        client
+            .write_file(vmgs::FileId::HIBERNATION_TOKEN, vec![0; 16])
             .await
             .unwrap();
         assert_eq!(read_token(&client).await, None);

--- a/openhcl/underhill_core/src/lib.rs
+++ b/openhcl/underhill_core/src/lib.rs
@@ -12,6 +12,7 @@ mod diag;
 mod dispatch;
 mod emuplat;
 mod get_tracing;
+mod hibernate;
 mod inspect_internal;
 mod inspect_proc;
 mod livedump;

--- a/openhcl/underhill_core/src/servicing.rs
+++ b/openhcl/underhill_core/src/servicing.rs
@@ -53,6 +53,17 @@ mod state {
         pub nvme_state: crate::nvme_manager::save_restore::NvmeManagerSavedState,
     }
 
+    /// Servicing state for hibernation.
+    #[derive(Protobuf)]
+    #[mesh(package = "underhill")]
+    pub struct HibernateSavedState {
+        /// The hibernate token pinned for this VM, carried across servicing so
+        /// it is not re-read from VMGS (where it was already consumed) on
+        /// restore.
+        #[mesh(1)]
+        pub token: u64,
+    }
+
     /// Servicing state needed to create the LoadedVm object.
     #[derive(Protobuf)]
     #[mesh(package = "underhill")]
@@ -82,6 +93,9 @@ mod state {
         /// Intercept the host-provided shutdown IC device.
         #[mesh(7)]
         pub overlay_shutdown_device: bool,
+        /// Hibernation servicing state.
+        #[mesh(8)]
+        pub hibernate: Option<HibernateSavedState>,
         /// NVMe saved state.
         #[mesh(10000)]
         pub nvme_state: Option<NvmeSavedState>,
@@ -209,6 +223,7 @@ pub mod transposed {
             disk_get_vmgs::save_restore::SavedBlockStorageMetadata,
         )>,
         pub overlay_shutdown_device: Option<bool>,
+        pub hibernate: Option<Option<HibernateSavedState>>,
         pub nvme_state: Option<Option<NvmeSavedState>>,
         pub dma_manager_state: Option<Option<OpenhclDmaManagerState>>,
         pub vmbus_client: Option<Option<vmbus_client::SavedState>>,
@@ -242,6 +257,7 @@ pub mod transposed {
                     flush_logs_result,
                     vmgs,
                     overlay_shutdown_device,
+                    hibernate,
                     nvme_state,
                     mana_state,
                     dma_manager_state,
@@ -260,6 +276,7 @@ pub mod transposed {
                     flush_logs_result: Some(flush_logs_result),
                     vmgs,
                     overlay_shutdown_device: Some(overlay_shutdown_device),
+                    hibernate: Some(hibernate),
                     nvme_state: Some(nvme_state),
                     mana_state,
                     dma_manager_state: Some(dma_manager_state),

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -4039,7 +4039,7 @@ async fn halt_task(
                     get_client.send_reset()
                 }
                 HaltRequest::Hibernate => {
-                    // Write the hibernate token before signaling the host, mirroring legacy HCL.
+                    // Write the hibernate token before signaling the host.
                     if let Some(hibernate_halt) = &hibernate_halt {
                         hibernate::write_token(
                             &hibernate_halt.vmgs_client,

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -3670,7 +3670,7 @@ async fn new_underhill_vm(
     // cycle. On a servicing restore the VMGS token was already consumed at the
     // original cold boot, so recover it from saved state; otherwise read (and
     // consume) it from VMGS.
-    let current_hibernate_token: Option<u64> = if !dps.general.hibernation_enabled {
+    let current_hibernate_token = if !dps.general.hibernation_enabled {
         None
     } else if is_restoring {
         // Older saved state may not carry hibernation state; treat as unknown.
@@ -3678,17 +3678,19 @@ async fn new_underhill_vm(
             servicing_state
                 .hibernate
                 .flatten()
-                .map_or(hibernate::token::HIBERNATED_UNKNOWN, |h| h.token),
+                .map_or(hibernate::HibernateToken::UNKNOWN, |h| h.token.into()),
         )
     } else if let Some(vmgs_client) = vmgs_client.as_ref() {
-        if let Some(read) = hibernate::read_token(vmgs_client).await {
-            // A non-NONE token that differs from the current version is a resume
-            // under different firmware; warn but don't honor it yet.
-            if read != hibernate::token::NONE && read != hibernate::token::DEFAULT {
+        if let Some(token @ hibernate::HibernateToken::Hibernated { .. }) =
+            hibernate::read_token(vmgs_client).await
+        {
+            // A resume under a different firmware version; warn but don't honor
+            // it yet.
+            if token != hibernate::HibernateToken::CURRENT {
                 tracing::warn!(
                     CVM_ALLOWED,
-                    token = format_args!("{read:#x}"),
-                    default = format_args!("{:#x}", hibernate::token::DEFAULT),
+                    resume = %token,
+                    current = %hibernate::HibernateToken::CURRENT,
                     "hibernation resume token does not match the current firmware version"
                 );
             }
@@ -3696,7 +3698,7 @@ async fn new_underhill_vm(
         // Consume any token, valid or corrupt, so it is not re-read next boot.
         hibernate::delete_token(vmgs_client).await;
         // No overload support yet; always use the current firmware version.
-        Some(hibernate::token::DEFAULT)
+        Some(hibernate::HibernateToken::CURRENT)
     } else {
         None
     };
@@ -4026,16 +4028,22 @@ async fn halt_task(
                 HaltRequest::PowerOff => {
                     // Record the powered-off state so a later boot is not a resume.
                     if let Some(hibernate_halt) = &hibernate_halt {
-                        hibernate::write_token(&hibernate_halt.vmgs_client, hibernate::token::NONE)
-                            .await;
+                        hibernate::write_token(
+                            &hibernate_halt.vmgs_client,
+                            hibernate::HibernateToken::NotHibernated,
+                        )
+                        .await;
                     }
                     get_client.send_power_off()
                 }
                 HaltRequest::Reset => {
                     // Record the powered-off state so a later boot is not a resume.
                     if let Some(hibernate_halt) = &hibernate_halt {
-                        hibernate::write_token(&hibernate_halt.vmgs_client, hibernate::token::NONE)
-                            .await;
+                        hibernate::write_token(
+                            &hibernate_halt.vmgs_client,
+                            hibernate::HibernateToken::NotHibernated,
+                        )
+                        .await;
                     }
                     get_client.send_reset()
                 }

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -3692,8 +3692,9 @@ async fn new_underhill_vm(
                     "hibernation resume token does not match the current firmware version"
                 );
             }
-            hibernate::delete_token(vmgs_client).await;
         }
+        // Consume any token, valid or corrupt, so it is not re-read next boot.
+        hibernate::delete_token(vmgs_client).await;
         // No overload support yet; always use the current firmware version.
         Some(hibernate::token::DEFAULT)
     } else {

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -3678,19 +3678,19 @@ async fn new_underhill_vm(
             servicing_state
                 .hibernate
                 .flatten()
-                .map_or(hibernate::HibernateToken::UNKNOWN, |h| h.token.into()),
+                .map_or(hibernate::Token::UNKNOWN, |h| h.token.into()),
         )
     } else if let Some(vmgs_client) = vmgs_client.as_ref() {
-        if let Some(token @ hibernate::HibernateToken::Hibernated { .. }) =
+        if let Some(token @ hibernate::Token::Hibernated { .. }) =
             hibernate::read_token(vmgs_client).await
         {
             // A resume under a different firmware version; warn but don't honor
             // it yet.
-            if token != hibernate::HibernateToken::CURRENT {
+            if token != hibernate::Token::CURRENT {
                 tracing::warn!(
                     CVM_ALLOWED,
                     resume = %token,
-                    current = %hibernate::HibernateToken::CURRENT,
+                    current = %hibernate::Token::CURRENT,
                     "hibernation resume token does not match the current firmware version"
                 );
             }
@@ -3698,8 +3698,14 @@ async fn new_underhill_vm(
         // Consume any token, valid or corrupt, so it is not re-read next boot.
         hibernate::delete_token(vmgs_client).await;
         // No overload support yet; always use the current firmware version.
-        Some(hibernate::HibernateToken::CURRENT)
+        Some(hibernate::Token::CURRENT)
     } else {
+        // Hibernation was requested but there is no VMGS to persist the token,
+        // so it cannot survive a power transition.
+        tracing::warn!(
+            CVM_ALLOWED,
+            "hibernation enabled but no VMGS is available; hibernate token will not be persisted"
+        );
         None
     };
 
@@ -4030,7 +4036,7 @@ async fn halt_task(
                     if let Some(hibernate_halt) = &hibernate_halt {
                         hibernate::write_token(
                             &hibernate_halt.vmgs_client,
-                            hibernate::HibernateToken::NotHibernated,
+                            hibernate::Token::NotHibernated,
                         )
                         .await;
                     }
@@ -4041,7 +4047,7 @@ async fn halt_task(
                     if let Some(hibernate_halt) = &hibernate_halt {
                         hibernate::write_token(
                             &hibernate_halt.vmgs_client,
-                            hibernate::HibernateToken::NotHibernated,
+                            hibernate::Token::NotHibernated,
                         )
                         .await;
                     }

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -38,6 +38,7 @@ use crate::emuplat::tpm::resources::GetTpmLoggerHandle;
 use crate::emuplat::tpm::resources::GetTpmRequestAkCertHelperHandle;
 use crate::emuplat::vga_proxy::UhRegisterHostIoFastPath;
 use crate::emuplat::watchdog::UnderhillWatchdogPlatform;
+use crate::hibernate;
 use crate::loader::LoadKind;
 use crate::loader::vtl0_config::MeasuredVtl0Info;
 use crate::loader::vtl2_config::RuntimeParameters;
@@ -3665,6 +3666,50 @@ async fn new_underhill_vm(
             .await
             .context("failed to relay initial vpci channels")?;
     }
+    // The hibernate token pins the firmware version across a hibernate/resume
+    // cycle. On a servicing restore the VMGS token was already consumed at the
+    // original cold boot, so recover it from saved state; otherwise read (and
+    // consume) it from VMGS.
+    let current_hibernate_token: Option<u64> = if !dps.general.hibernation_enabled {
+        None
+    } else if is_restoring {
+        // Older saved state may not carry hibernation state; treat as unknown.
+        Some(
+            servicing_state
+                .hibernate
+                .flatten()
+                .map_or(hibernate::token::HIBERNATED_UNKNOWN, |h| h.token),
+        )
+    } else if let Some(vmgs_client) = vmgs_client.as_ref() {
+        if let Some(read) = hibernate::read_token(vmgs_client).await {
+            // A non-NONE token that differs from the current version is a resume
+            // under different firmware; warn but don't honor it yet.
+            if read != hibernate::token::NONE && read != hibernate::token::DEFAULT {
+                tracing::warn!(
+                    CVM_ALLOWED,
+                    token = format_args!("{read:#x}"),
+                    default = format_args!("{:#x}", hibernate::token::DEFAULT),
+                    "hibernation resume token does not match the current firmware version"
+                );
+            }
+            hibernate::delete_token(vmgs_client).await;
+        }
+        // No overload support yet; always use the current firmware version.
+        Some(hibernate::token::DEFAULT)
+    } else {
+        None
+    };
+
+    // A Some token means hibernation is enabled and populated; pair it with a
+    // VMGS client to drive token persistence at halt time.
+    let hibernate_halt =
+        current_hibernate_token
+            .zip(vmgs_client.clone())
+            .map(|(current_token, vmgs_client)| hibernate::HaltState {
+                vmgs_client,
+                current_token,
+            });
+
     let (halt_notify_send, halt_notify_recv) = mesh::channel();
     let halt_task = tp.spawn(
         "halt",
@@ -3673,6 +3718,7 @@ async fn new_underhill_vm(
             fatal_error_recv,
             control_send.clone(),
             get_client.clone(),
+            hibernate_halt,
             env_cfg.halt_on_guest_halt,
         ),
     );
@@ -3732,6 +3778,7 @@ async fn new_underhill_vm(
         partition_unit,
         memory: gm,
         firmware_type,
+        hibernate_token: current_hibernate_token,
         isolation,
         chipset_devices: devices,
         _vmtime: vmtime,
@@ -3924,6 +3971,7 @@ async fn halt_task(
     mut _fatal_error_recv: mesh::Receiver<Box<dyn std::error::Error + Send + Sync>>,
     control_send: Arc<Mutex<Option<mesh::Sender<ControlRequest>>>>,
     get_client: GuestEmulationTransportClient,
+    hibernate_halt: Option<hibernate::HaltState>,
     halt_on_guest_halt: bool,
 ) {
     #[derive(Debug)]
@@ -3974,9 +4022,33 @@ async fn halt_task(
 
             // Now we can notify the host about the halt.
             match halt_request {
-                HaltRequest::PowerOff => get_client.send_power_off(),
-                HaltRequest::Reset => get_client.send_reset(),
-                HaltRequest::Hibernate => get_client.send_hibernate(),
+                HaltRequest::PowerOff => {
+                    // Record the powered-off state so a later boot is not a resume.
+                    if let Some(hibernate_halt) = &hibernate_halt {
+                        hibernate::write_token(&hibernate_halt.vmgs_client, hibernate::token::NONE)
+                            .await;
+                    }
+                    get_client.send_power_off()
+                }
+                HaltRequest::Reset => {
+                    // Record the powered-off state so a later boot is not a resume.
+                    if let Some(hibernate_halt) = &hibernate_halt {
+                        hibernate::write_token(&hibernate_halt.vmgs_client, hibernate::token::NONE)
+                            .await;
+                    }
+                    get_client.send_reset()
+                }
+                HaltRequest::Hibernate => {
+                    // Write the hibernate token before signaling the host, mirroring legacy HCL.
+                    if let Some(hibernate_halt) = &hibernate_halt {
+                        hibernate::write_token(
+                            &hibernate_halt.vmgs_client,
+                            hibernate_halt.current_token,
+                        )
+                        .await;
+                    }
+                    get_client.send_hibernate()
+                }
                 HaltRequest::TripleFault { vp, regs } => {
                     get_client.triple_fault(vp, TripleFaultType::UNRECOVERABLE_EXCEPTION, regs)
                 }

--- a/vm/vmgs/vmgs_broker/src/broker.rs
+++ b/vm/vmgs/vmgs_broker/src/broker.rs
@@ -11,10 +11,13 @@ use vmgs::Vmgs;
 use vmgs::VmgsFileInfo;
 use vmgs_format::FileId;
 
+/// An error returned by a VMGS broker operation.
 #[derive(Protobuf, Error, Debug)]
 pub enum VmgsBrokerError {
+    /// The requested file has no allocated bytes (i.e. does not exist).
     #[error("no allocated bytes for file id being read")]
     FileInfoNotAllocated,
+    /// Another VMGS error.
     #[error(transparent)]
     Other(RemoteError),
 }

--- a/vm/vmgs/vmgs_broker/src/broker.rs
+++ b/vm/vmgs/vmgs_broker/src/broker.rs
@@ -52,6 +52,7 @@ pub enum VmgsBrokerRpc {
     #[cfg(feature = "encryption")]
     WriteFileEncrypted(Rpc<(BrokerFileId, Vec<u8>), Result<(), VmgsBrokerError>>),
     Save(Rpc<(), vmgs::save_restore::state::SavedVmgsState>),
+    DeleteFile(Rpc<BrokerFileId, Result<(), VmgsBrokerError>>),
 }
 
 pub struct VmgsBrokerTask {
@@ -109,6 +110,15 @@ impl VmgsBrokerTask {
                 .await
             }
             VmgsBrokerRpc::Save(rpc) => rpc.handle_sync(|()| self.vmgs.save()),
+            VmgsBrokerRpc::DeleteFile(rpc) => {
+                rpc.handle(async |file_id| {
+                    self.vmgs
+                        .delete_file(file_id.into())
+                        .await
+                        .map_err(Into::into)
+                })
+                .await
+            }
         }
     }
 }

--- a/vm/vmgs/vmgs_broker/src/client.rs
+++ b/vm/vmgs/vmgs_broker/src/client.rs
@@ -87,6 +87,16 @@ impl VmgsClient {
         Ok(())
     }
 
+    /// Deletes the specified `file_id`.
+    #[instrument(skip_all, fields(file_id))]
+    pub async fn delete_file(&self, file_id: FileId) -> Result<(), VmgsClientError> {
+        self.control
+            .call_failable(VmgsBrokerRpc::DeleteFile, file_id.into())
+            .await?;
+
+        Ok(())
+    }
+
     /// If VMGS has been configured with encryption, encrypt + write `buf` to
     /// the specified `file_id`. Otherwise, perform a regular plaintext write
     /// instead.

--- a/vm/vmgs/vmgs_broker/src/client.rs
+++ b/vm/vmgs/vmgs_broker/src/client.rs
@@ -53,7 +53,7 @@ pub struct VmgsClient {
 
 impl VmgsClient {
     /// Get allocated and valid bytes from File Control Block for file_id.
-    #[instrument(skip_all, fields(file_id))]
+    #[instrument(skip_all, fields(file_id = %file_id))]
     pub async fn get_file_info(&self, file_id: FileId) -> Result<VmgsFileInfo, VmgsClientError> {
         let res = self
             .control
@@ -64,7 +64,7 @@ impl VmgsClient {
     }
 
     /// Reads the specified `file_id`.
-    #[instrument(skip_all, fields(file_id))]
+    #[instrument(skip_all, fields(file_id = %file_id))]
     pub async fn read_file(&self, file_id: FileId) -> Result<Vec<u8>, VmgsClientError> {
         let res = self
             .control
@@ -78,7 +78,7 @@ impl VmgsClient {
     ///
     /// NOTE: It is an error to overwrite a previously encrypted FileId with
     /// plaintext data.
-    #[instrument(skip_all, fields(file_id))]
+    #[instrument(skip_all, fields(file_id = %file_id))]
     pub async fn write_file(&self, file_id: FileId, buf: Vec<u8>) -> Result<(), VmgsClientError> {
         self.control
             .call_failable(VmgsBrokerRpc::WriteFile, (file_id.into(), buf))
@@ -88,7 +88,7 @@ impl VmgsClient {
     }
 
     /// Deletes the specified `file_id`.
-    #[instrument(skip_all, fields(file_id))]
+    #[instrument(skip_all, fields(file_id = %file_id))]
     pub async fn delete_file(&self, file_id: FileId) -> Result<(), VmgsClientError> {
         self.control
             .call_failable(VmgsBrokerRpc::DeleteFile, file_id.into())
@@ -101,7 +101,7 @@ impl VmgsClient {
     /// the specified `file_id`. Otherwise, perform a regular plaintext write
     /// instead.
     #[cfg(feature = "encryption")]
-    #[instrument(skip_all, fields(file_id))]
+    #[instrument(skip_all, fields(file_id = %file_id))]
     pub async fn write_file_encrypted(
         &self,
         file_id: FileId,

--- a/vm/vmgs/vmgs_broker/src/lib.rs
+++ b/vm/vmgs/vmgs_broker/src/lib.rs
@@ -10,6 +10,7 @@ mod client;
 pub mod non_volatile_store;
 pub mod resolver;
 
+pub use broker::VmgsBrokerError;
 pub use client::VmgsClient;
 pub use client::VmgsClientError;
 

--- a/vm/vmgs/vmgs_format/src/lib.rs
+++ b/vm/vmgs/vmgs_format/src/lib.rs
@@ -53,7 +53,7 @@ open_enum! {
         GUEST_WATCHDOG = 10,
         HW_KEY_PROTECTOR = 11,
         GUEST_SECRET_KEY = 13,
-        HIBERNATION_FIRMWARE = 14,
+        HIBERNATION_TOKEN = 14,
         PLATFORM_SEED = 15,
         PROVENANCE_DOC = 16,
         TPM_NVRAM_BACKUP = 17,

--- a/vm/vmgs/vmgstool/src/main.rs
+++ b/vm/vmgs/vmgstool/src/main.rs
@@ -369,7 +369,7 @@ fn parse_file_id(file_id: &str) -> Result<FileId, std::num::ParseIntError> {
         "GUEST_WATCHDOG" => FileId::GUEST_WATCHDOG,
         "HW_KEY_PROTECTOR" => FileId::HW_KEY_PROTECTOR,
         "GUEST_SECRET_KEY" => FileId::GUEST_SECRET_KEY,
-        "HIBERNATION_FIRMWARE" => FileId::HIBERNATION_FIRMWARE,
+        "HIBERNATION_TOKEN" => FileId::HIBERNATION_TOKEN,
         "PLATFORM_SEED" => FileId::PLATFORM_SEED,
         "PROVENANCE_DOC" => FileId::PROVENANCE_DOC,
         "TPM_NVRAM_BACKUP" => FileId::TPM_NVRAM_BACKUP,


### PR DESCRIPTION
### Summary

Adds a self-contained OpenHCL `hibernate` module that manages an 8-byte "hibernate token" stored in the VMGS `HIBERNATION_TOKEN` file, mirroring the legacy HCL `HclPowerServices` / `DevicePlatform::WriteUefiConfigBlob` behavior. This is the first of two PRs split out from the larger hibernation-firmware work; it covers only the **token** lifecycle (writing, clearing, telemetry, and servicing persistence). Firmware-image snapshot/restore is a follow-up.

### Motivation

Hibernation-enabled guests need a durable marker recording their power state and the firmware version they hibernated under, so the paravisor can detect resume-vs-cold-boot and (in a later change) enforce firmware-version consistency across a hibernate/resume cycle.

### Testing

- Unit tests in `hibernate.rs` cover the token round-trip against an in-memory VMGS: absent read, write→read→delete, the `NONE` value, and a corrupt (non-8-byte) token.

> Note: `underhill_core` is `#![cfg(target_os = "linux")]`, so it compiles and tests only on a Linux build (CI / WSL). `vmgs_format`, `vmgs_broker`, and formatting were validated locally.