### PR TITLE
openvmm: add cli to place PCIe ECAM below 4 GiB

### DIFF
--- a/Guide/src/reference/architecture/openvmm/memory-layout.md
+++ b/Guide/src/reference/architecture/openvmm/memory-layout.md
@@ -122,13 +122,16 @@ issues requests in this order:
    RC in the segment), which is then subdivided into per-RC sub-ranges.
    The block size is derived from the segment's combined bus window as
    `(max_bus - min_bus + 1) * 1 MB` (32 devices × 8 functions × 4 KiB per
-   config space). ECAM is placed above 4 GiB so the low MMIO window stays
-   free for devices that require 32-bit addressing. Every ECAM range must
-   start at or above a fixed `256 MiB` minimum: the ACPI MCFG table reports
-   the bus-0 base as `ecam_start - start_bus * 1 MiB`, and since `start_bus`
-   is a `u8` up to 255 MiB of headroom may be required. A resolved ECAM
-   below this minimum fails VM construction rather than producing an
-   unrepresentable MCFG entry.
+   config space). ECAM is placed above 4 GiB by default so the low MMIO
+   window stays free for devices that require 32-bit addressing. The
+   `--pcie-ecam-below-4gb` compatibility option instead places each
+   segment's ECAM in 32-bit MMIO for direct-boot kernels that cannot
+   discover high ECAM. Every ECAM range must start at or above a fixed
+   `256 MiB` minimum: the ACPI MCFG table reports the bus-0 base as
+   `ecam_start - start_bus * 1 MiB`, and since `start_bus` is a `u8` up to
+   255 MiB of headroom may be required. A resolved ECAM below this minimum
+   fails VM construction rather than producing an unrepresentable MCFG
+   entry.
 5. **PCIe per-root-complex ranges**, one set per root complex:
     - **Low MMIO** (`Mmio32`), 2 MB aligned. A caller can pin this to a
       fixed range instead of supplying a size, for assigned-device, IOMMU,

--- a/Guide/src/reference/openvmm/management/cli.md
+++ b/Guide/src/reference/openvmm/management/cli.md
@@ -318,6 +318,13 @@ complex name:
   this via the ACPI `_PXM` object. When omitted, no `_PXM` is emitted
   and the guest uses its default allocation policy.
 
+By default, PCIe ECAM is placed above 4 GiB to preserve low MMIO space for
+device BARs. Use `--pcie-ecam-below-4gb` to place every PCI segment's ECAM in
+32-bit MMIO instead. This compatibility workaround is intended for direct-boot
+guest kernels that cannot discover high ECAM without firmware interfaces
+available during a conventional boot. The flag defaults to off and requires
+`--pcie-root-complex`.
+
 ### Root port and switch options
 
 `--pcie-root-port` accepts optional comma-separated options after the port

--- a/openvmm/openvmm_core/src/worker/dispatch.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch.rs
@@ -189,6 +189,7 @@ impl Manifest {
             floppy_disks: config.floppy_disks,
             ide_disks: config.ide_disks,
             pcie_root_complexes: config.pcie_root_complexes,
+            pcie_ecam_below_4gb: config.pcie_ecam_below_4gb,
             pcie_devices: config.pcie_devices,
             pcie_switches: config.pcie_switches,
             pcie_generic_initiators: config.pcie_generic_initiators,
@@ -232,6 +233,7 @@ pub struct Manifest {
     floppy_disks: Vec<FloppyDiskConfig>,
     ide_disks: Vec<IdeDeviceConfig>,
     pcie_root_complexes: Vec<PcieRootComplexConfig>,
+    pcie_ecam_below_4gb: bool,
     pcie_devices: Vec<PcieDeviceConfig>,
     pcie_switches: Vec<PcieSwitchConfig>,
     pcie_generic_initiators: Vec<openvmm_defs::config::PcieGenericInitiatorConfig>,
@@ -1129,6 +1131,7 @@ impl InitializedVm {
             layout: cfg.layout.clone(),
             pcie_root_complexes: &cfg.pcie_root_complexes,
             virtio_mmio_count,
+            pcie_ecam_below_4gb: cfg.pcie_ecam_below_4gb,
             vtl2_layout,
             ram_start_address,
             vtl2_framebuffer_size,
@@ -3943,6 +3946,7 @@ impl LoadedVm {
             floppy_disks: vec![],            // TODO
             ide_disks: vec![],               // TODO
             pcie_root_complexes: vec![],     // TODO
+            pcie_ecam_below_4gb: false,      // TODO
             pcie_devices: vec![],            // TODO
             pcie_switches: vec![],           // TODO
             pcie_generic_initiators: vec![], // TODO

--- a/openvmm/openvmm_core/src/worker/memory_layout.rs
+++ b/openvmm/openvmm_core/src/worker/memory_layout.rs
@@ -127,6 +127,8 @@ pub(super) struct MemoryLayoutInput<'a> {
     /// Number of virtio-mmio device slots to allocate in 32-bit MMIO space.
     /// A single contiguous region of `count * 4 KiB` is allocated.
     pub virtio_mmio_count: usize,
+    /// Place PCIe ECAM below 4 GiB for x86 guests that cannot use high ECAM.
+    pub pcie_ecam_below_4gb: bool,
     /// Optional IGVM VTL2 private-memory request. This is allocated after all
     /// VTL0-visible RAM and MMIO and is carried separately from ordinary RAM.
     pub vtl2_layout: Option<Vtl2MemoryLayoutRequest>,
@@ -232,8 +234,15 @@ pub(super) fn resolve_memory_layout(
         }
     }
 
-    // ECAM: dynamically allocated above 4GB, keeping the low MMIO window free
-    // for devices that require 32-bit addressing.
+    // ECAM normally lives above 4GB, keeping low MMIO free for device BARs.
+    // Some direct-boot kernels cannot discover high ECAM without the firmware
+    // interfaces used during a conventional boot, so allow callers to request
+    // 32-bit placement as a compatibility workaround.
+    let ecam_placement = if input.pcie_ecam_below_4gb {
+        Placement::Mmio32
+    } else {
+        Placement::Mmio64
+    };
     for se in &mut segment_ecams {
         let bus_count = u64::from(se.max_bus - se.min_bus) + 1;
         builder.request(
@@ -241,7 +250,7 @@ pub(super) fn resolve_memory_layout(
             &mut se.range,
             bus_count * PCIE_ECAM_BYTES_PER_BUS,
             PCIE_ECAM_BYTES_PER_BUS,
-            Placement::Mmio64,
+            ecam_placement,
         );
     }
 
@@ -635,6 +644,7 @@ mod tests {
             layout: DEFAULT_LAYOUT,
             pcie_root_complexes: &[],
             virtio_mmio_count: 0,
+            pcie_ecam_below_4gb: false,
             vtl2_layout,
             ram_start_address: 0,
             vtl2_framebuffer_size: 0,
@@ -764,6 +774,20 @@ mod tests {
             actual.memory_layout.probe_address(ranges.high_mmio.start()),
             Some(AddressType::PciMmio)
         );
+    }
+
+    #[test]
+    fn pcie_ecam_can_be_placed_below_4gb() {
+        let root_complexes = [pcie_root_complex(
+            PcieMmioRangeConfig::Dynamic { size: 64 * MB },
+            PcieMmioRangeConfig::Dynamic { size: GB },
+        )];
+        let mut config = input(&[512 * MB], None);
+        config.pcie_root_complexes = &root_complexes;
+        config.pcie_ecam_below_4gb = true;
+
+        let actual = resolve_memory_layout(config).unwrap();
+        assert!(actual.pcie_root_complex_ranges[0].ecam_range.end() <= 4 * GB);
     }
 
     #[test]

--- a/openvmm/openvmm_defs/src/config.rs
+++ b/openvmm/openvmm_defs/src/config.rs
@@ -27,6 +27,7 @@ pub struct Config {
     pub floppy_disks: Vec<floppy_resources::FloppyDiskConfig>,
     pub ide_disks: Vec<ide_resources::IdeDeviceConfig>,
     pub pcie_root_complexes: Vec<PcieRootComplexConfig>,
+    pub pcie_ecam_below_4gb: bool,
     pub pcie_devices: Vec<PcieDeviceConfig>,
     pub pcie_switches: Vec<PcieSwitchConfig>,
     pub pcie_generic_initiators: Vec<PcieGenericInitiatorConfig>,

--- a/openvmm/openvmm_entry/src/cli_args.rs
+++ b/openvmm/openvmm_entry/src/cli_args.rs
@@ -1165,6 +1165,10 @@ Options:
     #[clap(long, conflicts_with("pcat"))]
     pub pcie_root_complex: Vec<PcieRootComplexCli>,
 
+    /// Place PCIe ECAM below 4 GiB for guest kernels that cannot discover high ECAM
+    #[clap(long, requires("pcie_root_complex"), conflicts_with("pcat"))]
+    pub pcie_ecam_below_4gb: bool,
+
     /// Attach a PCI Express root port to the VM
     #[clap(long_help = r#"
 Attach root ports to root complexes.

--- a/openvmm/openvmm_entry/src/lib.rs
+++ b/openvmm/openvmm_entry/src/lib.rs
@@ -1899,6 +1899,7 @@ async fn vm_config_from_command_line(
         load_mode,
         floppy_disks,
         pcie_root_complexes,
+        pcie_ecam_below_4gb: opt.pcie_ecam_below_4gb,
         #[cfg(target_os = "linux")]
         pcie_devices: {
             let mut devs = pcie_devices;

--- a/openvmm/openvmm_entry/src/ttrpc/mod.rs
+++ b/openvmm/openvmm_entry/src/ttrpc/mod.rs
@@ -891,6 +891,7 @@ impl VmService {
             ide_disks: vec![],
             floppy_disks: vec![],
             pcie_root_complexes: pcie.root_complexes,
+            pcie_ecam_below_4gb: false,
             pcie_devices: pcie.devices,
             pcie_switches: pcie.switches,
             pcie_generic_initiators: pcie.generic_initiators,

--- a/petri/src/vm/openvmm/construct.rs
+++ b/petri/src/vm/openvmm/construct.rs
@@ -686,6 +686,7 @@ impl PetriVmConfigOpenVmm {
             floppy_disks: vec![],
             ide_disks,
             pcie_root_complexes: vec![],
+            pcie_ecam_below_4gb: false,
             pcie_devices,
             pcie_switches: vec![],
             pcie_generic_initiators: vec![],


### PR DESCRIPTION
Add --pcie-ecam-below-4gb as an explicit compatibility option for direct-boot kernels (such as booting SNP) that are not compatible with above 4GB ECAM ranges unless additional firmware tables are provided to the guest, like SMBIOS. Some configurations like SNP do not currently have a way for the kernel to discover these tables if not booting through EFI. 

Keep high ECAM as the default as we want this to be the default behavior. 

This could be possibly removed in the future if we have a kernel fix for this, and we no longer need to support such kernels. 