### PR TITLE
ci: fix panic reading rust-step side effects in source release job

### DIFF
--- a/flowey/flowey_lib_common/src/publish_gh_release.rs
+++ b/flowey/flowey_lib_common/src/publish_gh_release.rs
@@ -60,6 +60,10 @@ pub struct GhReleaseParams<C = VarNotClaimed> {
     /// What to do when a release already exists for this tag.
     pub on_existing: OnExistingRelease,
     /// Side effects that must complete before the release is published.
+    ///
+    /// These are only claimed, never read: claiming is what orders the publish
+    /// step after them, and side effects handed back by a rust step are never
+    /// written to the var db, so reading one would panic at runtime.
     pub prerequisites: Vec<ReadVar<SideEffect, C>>,
 
     pub done: WriteVar<SideEffect, C>,
@@ -138,13 +142,9 @@ impl FlowNode for Node {
                         draft,
                         verify_tag,
                         on_existing,
-                        prerequisites,
+                        prerequisites: _,
                         done: _,
                     } = req;
-
-                    for prerequisite in prerequisites {
-                        rt.read(prerequisite);
-                    }
 
                     let repo = format!("{repo_owner}/{repo_name}");
                     let target = rt.read(target);

--- a/flowey/flowey_lib_hvlite/src/_jobs/publish_openvmm_gh_release.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/publish_openvmm_gh_release.rs
@@ -113,12 +113,14 @@ impl SimpleFlowNode for Node {
         // the release to a different commit. Reruns reuse it only when it still
         // names the exact archived revision.
         let tag_is_pinned = ctx.emit_rust_step("pin source release tag", |ctx| {
-            let no_existing_release = no_existing_release.claim(ctx);
+            // Claiming without reading is what orders this step after the
+            // check. The side effect a rust step hands back is never written to
+            // the var db, so reading it at runtime would panic.
+            no_existing_release.claim(ctx);
             let gh_cli = gh_cli.claim(ctx);
             let tag = tag.clone().claim(ctx);
             let target = target.clone().claim(ctx);
             move |rt| {
-                rt.read(no_existing_release);
                 let gh_cli = rt.read(gh_cli);
                 let tag = rt.read(tag);
                 let target = rt.read(target);


### PR DESCRIPTION
The first real dispatch of the OpenVMM source release workflow ([run 31733701937](https://github.com/microsoft/openvmm/actions/runs/31733701937)) aborted in the `pin source release tag` step:

``
thread 'main' panicked at flowey/flowey_core/src/node.rs:1800:32:
db is missing var auto_se:flowey_lib_hvlite::_jobs::publish_openvmm_gh_release:13
``

## Root cause

The `SideEffect` that `ctx.emit_rust_step` hands back is created via `new_prefixed_var("auto_se")` and claimed for write on behalf of the step, but nothing ever writes it to the runtime var db. It is the *claim* in a downstream step that creates the dependency edge in the DAG; the value is never meant to be read. Calling `rt.read()` on one therefore panics in `RuntimeVarDb::get_var`.

The established idiom elsewhere in the tree (e.g. `download_openvmm_vmm_tests_artifacts`) is to claim the side effect and never read it.

## Fix

* `publish_openvmm_gh_release`: claim `no_existing_release` without reading it.
* `publish_gh_release`: drop the equivalent `rt.read(prerequisite)` loop. `prerequisites` is already claimed in `GhReleaseParams::claim`, so ordering is unaffected. This path had never executed — the only prior caller passes `Vec::new()` — and would have hit the identical panic one step later, since `tag_is_pinned` is also a rust-step side effect.

Comments added at both sites so this doesn't get reintroduced.

## Validation

`cargo clippy -p flowey_lib_hvlite -p flowey_lib_common --all-targets` and `cargo xtask fmt` both clean; no generated workflow YAML changes.
