### PR TITLE
snp: perf improvements

### DIFF
--- a/flowey/flowey_lib_hvlite/src/_jobs/cfg_versions.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/cfg_versions.rs
@@ -29,7 +29,7 @@ pub const NEXTEST: &str = "0.9.133";
 pub const NODEJS: &str = "24.x";
 // None disables hcl-dev builds and tests; Some(version) enables them.
 pub const OPENHCL_KERNEL_DEV_VERSION: Option<&str> = None;
-pub const OPENHCL_KERNEL_STABLE_VERSION: &str = "6.18.37.2";
+pub const OPENHCL_KERNEL_STABLE_VERSION: &str = "6.18.37.3";
 pub const OPENVMM_DEPS: &str = "0.3.0-116";
 pub const PROTOC: &str = "27.1";
 

--- a/nix/openhcl_kernel.nix
+++ b/nix/openhcl_kernel.nix
@@ -1,7 +1,7 @@
 { system, stdenv, fetchzip, targetArch ? null, is_dev ? false, is_cvm ? false }:
 
 let
-  version = if is_dev then "6.18.37.3" else "6.18.37.2";
+  version = if is_dev then "deprecated" else "6.18.37.3";
   # Allow explicit override of architecture, otherwise derive from host system
   # Note: targetArch uses "x86_64"/"aarch64", but URLs use "x64"/"arm64"
   arch = if targetArch == "x86_64" then "x64"
@@ -18,24 +18,15 @@ let
   hashes = {
     hcl-main = {
       std = {
-        x64 = "sha256-iVHDpscZEt46fRER0jTWocNM2YRPsuPCujroOQ/AXl4=";
-        arm64 = "sha256-XM7kW14T9vBldWD+HsqnVCJrhoDU7EfkphhRorksGRs=";
+        x64 = "sha256-4SwccsD57lf0GmDp0sVNDegG3g/FCqW+pjnjOPNClwo=";
+        arm64 = "sha256-j5cKHKsTH3tD6X+uvl42gr7jJ+q1sYTWQFGiA8CjbNE=";
       };
       cvm = {
-        x64 = "sha256-6PyO+uyJZdkCp/nyh/mk4cCmeQtejQp+pI0x5o7oMK0=";
+        x64 = "sha256-4GbgaaOvVdL/sEo2cTMFgzQ1P8MRHCeb4ZidHfs4rfU=";
         arm64 = throw "openhcl-kernel: cvm arm64 variant not available";
       };
     };
-    hcl-dev = {
-      std = {
-        x64 = "sha256-/0TSC9eNltwvUU7aLUtEktLKNXJFVTrzKpMq/0MY8RI=";
-        arm64 = "sha256-6sfXBLk6CmQvbh35HoVH6hdff9Ov7k4rAtT/NrHonvA=";
-      };
-      cvm = {
-        x64 = "sha256-6PyO+uyJZdkCp/nyh/mk4cCmeQtejQp+pI0x5o7oMK0=";
-        arm64 = throw "openhcl-kernel: dev cvm arm64 variant not available";
-      };
-    };
+    hcl-dev = throw "openhcl-kernel: dev kernel has been deprecated";
   };
   hash = hashes.${branch}.${build_type}.${arch};
 

--- a/openhcl/hcl/src/ioctl.rs
+++ b/openhcl/hcl/src/ioctl.rs
@@ -1502,10 +1502,11 @@ impl HclVp {
         // This is only used on CVMs. Skip it otherwise, since run page accesses
         // will fault on VPs that are still in the sidecar kernel.
         if isolation_type.is_hardware_isolated() {
-            // SAFETY: `proxy_irr_blocked` is not accessed by any other VPs/kernel at this point (`HclVp` creation)
-            // so we know we have exclusive access.
-            let proxy_irr_blocked = unsafe { &mut (*run.as_ptr()).proxy_irr_blocked };
-            proxy_irr_blocked.fill(!0);
+            // SAFETY: The run page is not accessed by any other VPs/kernel at this point
+            // (`HclVp` creation), so we know we have exclusive access.
+            unsafe {
+                (*run.as_ptr()).proxy_irr_blocked.fill(!0);
+            }
         }
 
         let backing = match isolation_type {
@@ -1532,6 +1533,15 @@ impl HclVp {
                 },
             },
             IsolationType::Snp => {
+                // SAFETY: The run page is not accessed by any other VPs/kernel at this point
+                // (`HclVp` creation), so we know we have exclusive access.
+                unsafe {
+                    let context: &mut protocol::snp_vp_context =
+                        &mut *(&raw mut (*run.as_ptr()).context).cast();
+                    context
+                        .vmsa_tweak_bitmap
+                        .copy_from_slice(&hcl.snp_register_bitmap);
+                }
                 let vmsa_vtl0 = MappedPage::new(fd, HCL_VMSA_PAGE_OFFSET | vp as i64)
                     .map_err(|e| Error::MmapVp(e, Some(Vtl::Vtl0)))?;
                 let vmsa_vtl1 = MappedPage::new(fd, HCL_VMSA_GUEST_VSM_PAGE_OFFSET | vp as i64)

--- a/openhcl/hcl/src/ioctl/snp.rs
+++ b/openhcl/hcl/src/ioctl/snp.rs
@@ -24,6 +24,8 @@ use memory_range::MemoryRange;
 use sidecar_client::SidecarVp;
 use std::cell::UnsafeCell;
 use std::os::fd::AsRawFd;
+use std::sync::atomic::AtomicU32;
+use std::sync::atomic::Ordering;
 use thiserror::Error;
 use x86defs::snp::SevAvicPage;
 use x86defs::snp::SevRmpAdjust;
@@ -33,6 +35,16 @@ use x86defs::snp::SevVmsa;
 pub struct Snp<'a> {
     vmsa: VtlArray<&'a UnsafeCell<SevVmsa>, 2>,
     avic_pages: VtlArray<&'a UnsafeCell<SevAvicPage>, 2>,
+}
+
+/// A synthetic timer count write handled by the kernel.
+pub struct SnpStimer0Update {
+    /// The new synthetic timer count.
+    pub count: u64,
+    /// The reference time when the count was programmed.
+    pub programmed_ref_time: u64,
+    /// Whether the kernel timer expired before returning to user mode.
+    pub expired: bool,
 }
 
 /// Error returned by failing SNP operations.
@@ -214,6 +226,59 @@ impl<'a> super::private::BackingPrivate<'a> for Snp<'a> {
 }
 
 impl<'a> ProcessorRunner<'a, Snp<'a>> {
+    fn snp_context_ptr(&self) -> *mut crate::protocol::snp_vp_context {
+        // This is an SNP partition, so the architecture context union is
+        // interpreted as an SNP context.
+        // SAFETY: `self.run` points to a mapped run page for this VP.
+        unsafe { (&raw mut (*self.run.get()).context).cast() }
+    }
+
+    /// Publishes the current STIMER0 configuration to the kernel.
+    pub fn set_stimer0_config(&mut self, config: Option<u64>) {
+        // SAFETY: The kernel does not access these fields while the run ioctl
+        // is not active. The flags remain atomic for the timer callback.
+        unsafe {
+            let context = self.snp_context_ptr();
+            let flags = &*((&raw mut (*context).stimer0_flags).cast::<AtomicU32>());
+            if let Some(config) = config {
+                (&raw mut (*context).stimer0_config).write(config);
+                flags.fetch_or(
+                    crate::protocol::MSHV_VTL_SNP_STIMER0_CONFIG_VALID,
+                    Ordering::Release,
+                );
+            } else {
+                flags.fetch_and(
+                    !crate::protocol::MSHV_VTL_SNP_STIMER0_CONFIG_VALID,
+                    Ordering::Release,
+                );
+            }
+        }
+    }
+
+    /// Takes a synthetic timer count write handled by the kernel.
+    pub fn take_stimer0_update(&mut self) -> Option<SnpStimer0Update> {
+        // SAFETY: The kernel cancels its timer before returning from the run
+        // ioctl and publishes state before setting KERNEL_UPDATE.
+        unsafe {
+            let context = self.snp_context_ptr();
+            let flags = &*((&raw mut (*context).stimer0_flags).cast::<AtomicU32>());
+            let value = flags.fetch_and(
+                !(crate::protocol::MSHV_VTL_SNP_STIMER0_KERNEL_UPDATE
+                    | crate::protocol::MSHV_VTL_SNP_STIMER0_EXPIRED),
+                Ordering::AcqRel,
+            );
+            if value & crate::protocol::MSHV_VTL_SNP_STIMER0_KERNEL_UPDATE == 0 {
+                return None;
+            }
+
+            Some(SnpStimer0Update {
+                count: (&raw const (*context).stimer0_count).read(),
+                programmed_ref_time: (&raw const (*context).stimer0_programmed_ref_time).read(),
+                expired: value & crate::protocol::MSHV_VTL_SNP_STIMER0_EXPIRED != 0,
+            })
+        }
+    }
+
     /// Gets a reference to the VMSA and backing state of a VTL
     pub fn vmsa(&self, vtl: GuestVtl) -> VmsaWrapper<'_, &SevVmsa> {
         // SAFETY: the VMSA will not be concurrently accessed by the processor

--- a/openhcl/hcl/src/protocol.rs
+++ b/openhcl/hcl/src/protocol.rs
@@ -293,6 +293,24 @@ pub struct tdx_vp_context {
 const _: () = assert!(core::mem::offset_of!(tdx_vp_context, gpr_list) + 272 == 512);
 const _: () = assert!(size_of::<tdx_vp_context>() == 1024);
 
+#[repr(C)]
+pub struct snp_vp_context {
+    pub vmsa_tweak_bitmap: [u8; 64],
+    pub stimer0_config: u64,
+    pub stimer0_count: u64,
+    pub stimer0_programmed_ref_time: u64,
+    pub stimer0_flags: u32,
+    pub reserved: [u8; 932],
+}
+
+const _: () = assert!(size_of::<snp_vp_context>() == 1024);
+const _: () = assert!(core::mem::offset_of!(snp_vp_context, stimer0_config) == 64);
+const _: () = assert!(core::mem::offset_of!(snp_vp_context, stimer0_flags) == 88);
+
+pub const MSHV_VTL_SNP_STIMER0_CONFIG_VALID: u32 = 1 << 0;
+pub const MSHV_VTL_SNP_STIMER0_KERNEL_UPDATE: u32 = 1 << 1;
+pub const MSHV_VTL_SNP_STIMER0_EXPIRED: u32 = 1 << 2;
+
 #[bitfield(u64)]
 #[derive(IntoBytes, Immutable, KnownLayout, FromBytes)]
 pub struct hcl_kick_cpus_flags {

--- a/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
@@ -3189,8 +3189,12 @@ pub(super) trait HardwareIsolatedGuestTimer<T: HardwareIsolatedBacking>:
     /// Clear any pending deadline.
     fn clear_deadline(&self, vp: &mut UhProcessor<'_, T>);
 
-    /// Synchronize armed deadline state for hardware virtualized timers.
-    fn sync_deadline_state(&self, vp: &mut UhProcessor<'_, T>);
+    /// Publish timer state before running a lower VTL.
+    fn begin_vtl_transition(&self, vp: &mut UhProcessor<'_, T>, vtl: GuestVtl);
+
+    /// Synchronize timer state after returning from a lower VTL. Implementations
+    /// must not assume that backend-private register readback has completed.
+    fn end_vtl_transition(&self, vp: &mut UhProcessor<'_, T>, vtl: GuestVtl);
 }
 
 /// Interface for managing lower VTL timer deadlines via [`VmTime`].
@@ -3234,9 +3238,9 @@ impl<T: HardwareIsolatedBacking> HardwareIsolatedGuestTimer<T> for VmTimeGuestTi
         vp.vmtime.cancel_timeout();
     }
 
-    fn sync_deadline_state(&self, _vp: &mut UhProcessor<'_, T>) {
-        // No-op for software timers
-    }
+    fn begin_vtl_transition(&self, _vp: &mut UhProcessor<'_, T>, _vtl: GuestVtl) {}
+
+    fn end_vtl_transition(&self, _vp: &mut UhProcessor<'_, T>, _vtl: GuestVtl) {}
 }
 
 #[cfg(test)]

--- a/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/snp/mod.rs
@@ -200,6 +200,62 @@ impl SnpSynicTimerDeadline {
     }
 }
 
+struct SnpKernelGuestTimer {
+    fallback: hardware_cvm::VmTimeGuestTimer,
+}
+
+impl SnpKernelGuestTimer {
+    fn timeout(&self, vmtime: &VmTimeAccess, ref_time_now: u64, ref_time_next: u64) -> VmTime {
+        self.fallback.timeout(vmtime, ref_time_now, ref_time_next)
+    }
+}
+
+impl HardwareIsolatedGuestTimer<SnpBacked> for SnpKernelGuestTimer {
+    fn is_hardware_virtualized(&self) -> bool {
+        false
+    }
+
+    fn update_deadline(
+        &self,
+        vp: &mut UhProcessor<'_, SnpBacked>,
+        ref_time_now: u64,
+        ref_time_next: u64,
+    ) {
+        self.fallback
+            .update_deadline(vp, ref_time_now, ref_time_next);
+    }
+
+    fn clear_deadline(&self, vp: &mut UhProcessor<'_, SnpBacked>) {
+        self.fallback.clear_deadline(vp);
+    }
+
+    fn begin_vtl_transition(&self, vp: &mut UhProcessor<'_, SnpBacked>, vtl: GuestVtl) {
+        vp.runner.set_stimer0_config(
+            (vtl == GuestVtl::Vtl0)
+                .then(|| vp.backing.cvm.hv[GuestVtl::Vtl0].synic.stimer_config(0)),
+        );
+    }
+
+    fn end_vtl_transition(&self, vp: &mut UhProcessor<'_, SnpBacked>, _vtl: GuestVtl) {
+        if let Some(update) = vp.runner.take_stimer0_update() {
+            assert_eq!(_vtl, GuestVtl::Vtl0);
+            tracing::trace!(
+                count = update.count,
+                programmed_ref_time = update.programmed_ref_time,
+                expired = update.expired,
+                "synchronizing kernel STIMER0 update"
+            );
+            // Kernel expiry only wakes VTL2. Reconstructing the original due
+            // time lets the normal SynIC scan perform the sole delivery.
+            vp.backing.cvm.hv[GuestVtl::Vtl0].synic.set_stimer_count_at(
+                0,
+                update.count,
+                update.programmed_ref_time,
+            );
+        }
+    }
+}
+
 enum UhDirectOverlay {
     Sipp,
     Sifp,
@@ -504,7 +560,7 @@ pub struct SnpBackedShared {
     sev_status: SevStatusMsr,
     /// Accessor for managing lower VTL timer deadlines.
     #[inspect(skip)]
-    guest_timer: hardware_cvm::VmTimeGuestTimer,
+    guest_timer: SnpKernelGuestTimer,
     secure_avic: bool,
     /// Whether virtual NMI (V_NMI) is supported by the host CPU.
     pub(crate) vnmi: bool,
@@ -553,7 +609,9 @@ impl SnpBackedShared {
         tracing::info!(CVM_ALLOWED, ?secure_avic, "Secure AVIC status");
 
         // Configure timer interface for lower VTLs.
-        let guest_timer = hardware_cvm::VmTimeGuestTimer;
+        let guest_timer = SnpKernelGuestTimer {
+            fallback: hardware_cvm::VmTimeGuestTimer,
+        };
 
         Ok(Self {
             sev_status,
@@ -1609,12 +1667,18 @@ impl UhProcessor<'_, SnpBacked> {
         // Set the lazy EOI bit just before running.
         let lazy_eoi = self.sync_lazy_eoi(next_vtl);
 
+        self.shared.guest_timer.begin_vtl_transition(self, next_vtl);
+
         let mut has_intercept = self
             .runner
             .run()
             .map_err(|e| dev.fatal_error(SnpRunVpError::RunVpError(e).into()))?;
 
         let entered_from_vtl = next_vtl;
+
+        self.shared
+            .guest_timer
+            .end_vtl_transition(self, entered_from_vtl);
 
         // Kernel offload may have set or cleared the halt/idle states while
         // handling VTL0 exits internally. Keep the userspace activity state in

--- a/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/tdx/mod.rs
@@ -478,8 +478,9 @@ impl hardware_cvm::HardwareIsolatedGuestTimer<TdxBacked> for TdxTscDeadlineServi
         state.update_deadline = 0;
     }
 
-    /// Synchronize armed deadline state in the processor context.
-    fn sync_deadline_state(&self, vp: &mut UhProcessor<'_, TdxBacked>) {
+    fn begin_vtl_transition(&self, _vp: &mut UhProcessor<'_, TdxBacked>, _vtl: GuestVtl) {}
+
+    fn end_vtl_transition(&self, vp: &mut UhProcessor<'_, TdxBacked>, _vtl: GuestVtl) {
         let vp_state = vp
             .backing
             .tsc_deadline_state
@@ -1733,6 +1734,8 @@ impl UhProcessor<'_, TdxBacked> {
 
         *self.runner.offload_flags_mut() = offload_flags;
 
+        self.shared.guest_timer.begin_vtl_transition(self, next_vtl);
+
         self.runner
             .write_private_regs(&self.backing.vtls[next_vtl].private_regs);
 
@@ -1750,8 +1753,9 @@ impl UhProcessor<'_, TdxBacked> {
         self.runner
             .read_private_regs(&mut self.backing.vtls[entered_from_vtl].private_regs);
 
-        // Synchronize timer deadline state
-        self.shared.guest_timer.sync_deadline_state(self);
+        self.shared
+            .guest_timer
+            .end_vtl_transition(self, entered_from_vtl);
 
         // Kernel offload may have set or cleared the halt/idle states
         if offload_enabled && kernel_known_state {

--- a/vm/hv1/hv1_emulator/src/synic.rs
+++ b/vm/hv1/hv1_emulator/src/synic.rs
@@ -135,6 +135,31 @@ fn sint_interrupt(request: &mut dyn RequestInterrupt, sint: hvdef::HvSynicSint) 
 }
 
 impl Timer {
+    fn set_count(&mut self, v: u64) {
+        self.count = v;
+        if self.config.auto_enable() && self.count != 0 {
+            self.config.set_enabled(true);
+        }
+        self.reevaluate = true;
+    }
+
+    fn set_count_at(&mut self, v: u64, ref_time: u64) {
+        self.count = v;
+        if self.config.auto_enable() && self.count != 0 {
+            self.config.set_enabled(true);
+        }
+        self.reevaluate = false;
+        self.due_time = if self.config.enabled() && self.count != 0 {
+            Some(if self.config.periodic() {
+                ref_time.wrapping_add(self.count)
+            } else {
+                self.count
+            })
+        } else {
+            None
+        };
+    }
+
     fn evaluate(
         &mut self,
         timer_index: u32,
@@ -405,12 +430,12 @@ impl ProcessorSynic {
 
     /// Sets the specified synthetic timer count register.
     pub fn set_stimer_count(&mut self, n: usize, v: u64) {
-        self.timers[n].count = v;
-        if self.timers[n].config.auto_enable() && self.timers[n].count != 0 {
-            self.timers[n].config.set_enabled(true);
-        }
+        self.timers[n].set_count(v);
+    }
 
-        self.timers[n].reevaluate = true;
+    /// Sets a synthetic timer count written at the given reference time.
+    pub fn set_stimer_count_at(&mut self, n: usize, v: u64, ref_time: u64) {
+        self.timers[n].set_count_at(v, ref_time);
     }
 
     /// Requests a notification when any of the requested sints has a free
@@ -717,5 +742,61 @@ impl SintState {
         }
         self.ready_sints |= 1 << sint;
         true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn restored_periodic_timer_preserves_program_time() {
+        let mut timer = Timer {
+            config: HvSynicStimerConfig::new()
+                .with_periodic(true)
+                .with_auto_enable(true),
+            ..Default::default()
+        };
+
+        timer.set_count_at(100, 1000);
+
+        assert!(timer.config.enabled());
+        assert_eq!(timer.due_time, Some(1100));
+        assert!(!timer.reevaluate);
+    }
+
+    #[test]
+    fn restored_oneshot_timer_preserves_absolute_deadline() {
+        let mut timer = Timer {
+            config: HvSynicStimerConfig::new().with_auto_enable(true),
+            ..Default::default()
+        };
+
+        timer.set_count_at(2000, 1000);
+
+        assert!(timer.config.enabled());
+        assert_eq!(timer.due_time, Some(2000));
+        assert!(!timer.reevaluate);
+    }
+
+    #[test]
+    fn restored_expired_timer_is_evaluated() {
+        let mut timer = Timer {
+            config: HvSynicStimerConfig::new()
+                .with_auto_enable(true)
+                .with_direct_mode(true)
+                .with_apic_vector(0x40),
+            ..Default::default()
+        };
+        let mut sints = SintState::default();
+        let mut requested = None;
+        let mut interrupt = |vector, auto_eoi| requested = Some((vector, auto_eoi));
+
+        timer.set_count_at(1000, 900);
+        timer.evaluate(0, &mut sints, 1001, &mut interrupt);
+
+        assert_eq!(requested, Some((0x40, false)));
+        assert!(!timer.config.enabled());
+        assert_eq!(timer.due_time, None);
     }
 }

--- a/vm/loader/manifests/openhcl-x64-cvm-dev.json
+++ b/vm/loader/manifests/openhcl-x64-cvm-dev.json
@@ -16,7 +16,7 @@
             "image": {
                 "openhcl": {
                     "command_line": "OPENHCL_CONFIDENTIAL_DEBUG=1",
-                    "memory_page_count": 163840,
+                    "memory_page_count": 262144,
                     "memory_page_base": 32768,
                     "uefi": true
                 }


### PR DESCRIPTION
Don't advertise cluster IPI, so the guest uses hardware assisted writes

Share VMSA translation key with kernel to allow fast-path register read/write

Allow kernel to handle some stimer0 requests using state handoff

Updated linux kernel to 6.18.37.3 with matching support

---------

Clean CP of #4224