### PR TITLE
[release/1.8.2607] crypto: ECDSA cleanup

### DIFF
--- a/support/crypto/src/ecdsa/mod.rs
+++ b/support/crypto/src/ecdsa/mod.rs
@@ -57,7 +57,7 @@ impl EcdsaKeyPair {
     /// Hash `data` with `hash_algorithm` and sign the resulting digest.
     /// Returns the signature as `r || s` in big-endian, each component
     /// `curve.key_size()` bytes.
-    pub fn sign(&self, hash_algorithm: HashAlgorithm, data: &[u8]) -> Result<Vec<u8>, EcdsaError> {
+    pub fn sign(&self, data: &[u8], hash_algorithm: HashAlgorithm) -> Result<Vec<u8>, EcdsaError> {
         let hash = hash_algorithm.hash(data);
         self.0.sign_prehash(&hash)
     }
@@ -73,8 +73,8 @@ impl EcdsaPublicKey {
     /// by [`EcdsaPublicKey::public_key_bytes`]). This is for verifying against
     /// an externally-supplied public key (e.g. one extracted from an X.509
     /// certificate) where no private key is held.
-    pub fn new(curve: EcdsaCurve, public_key: &[u8]) -> Result<Self, EcdsaError> {
-        sys::EcdsaPublicKeyInner::new(curve, public_key).map(Self)
+    pub fn from_public_key_bytes(curve: EcdsaCurve, public_key: &[u8]) -> Result<Self, EcdsaError> {
+        sys::EcdsaPublicKeyInner::from_public_key_bytes(curve, public_key).map(Self)
     }
 
     /// Construct an ECDSA public key from a DER-encoded `SubjectPublicKeyInfo`
@@ -84,18 +84,18 @@ impl EcdsaPublicKey {
         sys::EcdsaPublicKeyInner::from_public_key_der(spki_der).map(Self)
     }
 
-    /// Hash `data` with `hash_algorithm` and verify `signature` against this
+    /// Hash `message` with `hash_algorithm` and verify `signature` against this
     /// public key. The signature must be `r || s` in big-endian,
     /// each component `curve.key_size()` bytes (i.e. the format produced by
     /// [`EcdsaKeyPair::sign`]). Returns `Ok(true)` if the signature is valid,
     /// `Ok(false)` if it is invalid, or an error for other failures.
     pub fn verify(
         &self,
-        hash_algorithm: HashAlgorithm,
-        data: &[u8],
+        message: &[u8],
         signature: &[u8],
+        hash_algorithm: HashAlgorithm,
     ) -> Result<bool, EcdsaError> {
-        let hash = hash_algorithm.hash(data);
+        let hash = hash_algorithm.hash(message);
         self.0.verify_prehash(&hash, signature)
     }
 
@@ -132,7 +132,7 @@ mod tests {
     #[test]
     fn sign_p384_produces_correct_size() {
         let key = EcdsaKeyPair::generate(EcdsaCurve::P384).unwrap();
-        let sig = key.sign(HashAlgorithm::Sha384, b"message to sign").unwrap();
+        let sig = key.sign(b"message to sign", HashAlgorithm::Sha384).unwrap();
         // P-384 signature is r || s, each 48 bytes.
         assert_eq!(sig.len(), 96);
     }
@@ -140,8 +140,8 @@ mod tests {
     #[test]
     fn sign_p384_is_non_deterministic() {
         let key = EcdsaKeyPair::generate(EcdsaCurve::P384).unwrap();
-        let sig1 = key.sign(HashAlgorithm::Sha384, b"message to sign").unwrap();
-        let sig2 = key.sign(HashAlgorithm::Sha384, b"message to sign").unwrap();
+        let sig1 = key.sign(b"message to sign", HashAlgorithm::Sha384).unwrap();
+        let sig2 = key.sign(b"message to sign", HashAlgorithm::Sha384).unwrap();
         // ECDSA uses a random nonce, so two signatures of the same message
         // should differ (with overwhelming probability).
         assert_ne!(sig1, sig2);
@@ -171,7 +171,7 @@ mod tests {
     #[test]
     fn signature_components_are_valid() {
         let key = EcdsaKeyPair::generate(EcdsaCurve::P384).unwrap();
-        let sig = key.sign(HashAlgorithm::Sha384, b"data to sign").unwrap();
+        let sig = key.sign(b"data to sign", HashAlgorithm::Sha384).unwrap();
 
         let r = &sig[..48];
         let s = &sig[48..];
@@ -203,19 +203,19 @@ mod tests {
         let public_key: &EcdsaPublicKey = &key;
         let message = b"roundtrip test message";
 
-        let signature = key.sign(HashAlgorithm::Sha384, message).unwrap();
+        let signature = key.sign(message, HashAlgorithm::Sha384).unwrap();
 
         // A valid signature over the original message verifies.
         assert!(
             public_key
-                .verify(HashAlgorithm::Sha384, message, &signature)
+                .verify(message, &signature, HashAlgorithm::Sha384)
                 .unwrap()
         );
 
         // A signature checked against a different message does not verify.
         assert!(
             !public_key
-                .verify(HashAlgorithm::Sha384, b"tampered message", &signature)
+                .verify(b"tampered message", &signature, HashAlgorithm::Sha384)
                 .unwrap()
         );
 
@@ -224,51 +224,53 @@ mod tests {
         *bad_signature.last_mut().unwrap() ^= 0x01;
         assert!(
             !public_key
-                .verify(HashAlgorithm::Sha384, message, &bad_signature)
+                .verify(message, &bad_signature, HashAlgorithm::Sha384)
                 .unwrap()
         );
     }
 
     /// Round-trip through a public key reconstructed from raw `Qx || Qy` bytes
-    /// via [`EcdsaPublicKey::new`]: a signature made with a key pair verifies
-    /// under its exported-and-reimported public key, and is rejected under a
-    /// different key or a tampered message.
+    /// via [`EcdsaPublicKey::from_public_key_bytes`]: a signature made with a
+    /// key pair verifies under its exported-and-reimported public key, and is
+    /// rejected under a different key or a tampered message.
     #[test]
     fn roundtrip_public_key_from_bytes() {
         let key = EcdsaKeyPair::generate(EcdsaCurve::P384).unwrap();
         let message = b"reimport test message";
-        let signature = key.sign(HashAlgorithm::Sha384, message).unwrap();
+        let signature = key.sign(message, HashAlgorithm::Sha384).unwrap();
 
         let pk_bytes = key.public_key_bytes().unwrap();
-        let public_key = EcdsaPublicKey::new(EcdsaCurve::P384, &pk_bytes).unwrap();
+        let public_key =
+            EcdsaPublicKey::from_public_key_bytes(EcdsaCurve::P384, &pk_bytes).unwrap();
 
         // The reimported public key verifies the signature.
         assert!(
             public_key
-                .verify(HashAlgorithm::Sha384, message, &signature)
+                .verify(message, &signature, HashAlgorithm::Sha384)
                 .unwrap()
         );
 
         // A tampered message does not verify.
         assert!(
             !public_key
-                .verify(HashAlgorithm::Sha384, b"other message", &signature)
+                .verify(b"other message", &signature, HashAlgorithm::Sha384)
                 .unwrap()
         );
 
         // A signature made by a different key does not verify.
         let other = EcdsaKeyPair::generate(EcdsaCurve::P384).unwrap();
-        let other_sig = other.sign(HashAlgorithm::Sha384, message).unwrap();
+        let other_sig = other.sign(message, HashAlgorithm::Sha384).unwrap();
         assert!(
             !public_key
-                .verify(HashAlgorithm::Sha384, message, &other_sig)
+                .verify(message, &other_sig, HashAlgorithm::Sha384)
                 .unwrap()
         );
     }
 
     /// A public key whose raw encoding is not exactly `Qx || Qy`
-    /// (`2 * key_size` bytes) is rejected by [`EcdsaPublicKey::new`], rather
-    /// than being silently accepted as a non-canonical encoding.
+    /// (`2 * key_size` bytes) is rejected by
+    /// [`EcdsaPublicKey::from_public_key_bytes`], rather than being silently
+    /// accepted as a non-canonical encoding.
     #[test]
     fn public_key_from_bytes_rejects_wrong_length() {
         let key = EcdsaKeyPair::generate(EcdsaCurve::P384).unwrap();
@@ -276,10 +278,10 @@ mod tests {
         assert_eq!(pk_bytes.len(), 96);
 
         // Too short (a truncated coordinate) and too long must both fail.
-        assert!(EcdsaPublicKey::new(EcdsaCurve::P384, &pk_bytes[..90]).is_err());
+        assert!(EcdsaPublicKey::from_public_key_bytes(EcdsaCurve::P384, &pk_bytes[..90]).is_err());
         let mut too_long = pk_bytes.clone();
         too_long.push(0);
-        assert!(EcdsaPublicKey::new(EcdsaCurve::P384, &too_long).is_err());
+        assert!(EcdsaPublicKey::from_public_key_bytes(EcdsaCurve::P384, &too_long).is_err());
     }
 
     /// A key exported as `Qx || Qy`, wrapped into a DER `SubjectPublicKeyInfo`,
@@ -291,7 +293,7 @@ mod tests {
 
         let key = EcdsaKeyPair::generate(EcdsaCurve::P384).unwrap();
         let message = b"spki round-trip message";
-        let signature = key.sign(HashAlgorithm::Sha384, message).unwrap();
+        let signature = key.sign(message, HashAlgorithm::Sha384).unwrap();
         let pk = key.public_key_bytes().unwrap();
 
         // Wrap `Qx || Qy` into an uncompressed point and a P-384 SPKI.
@@ -310,13 +312,13 @@ mod tests {
         let public_key = EcdsaPublicKey::from_public_key_der(&spki_der).unwrap();
         assert!(
             public_key
-                .verify(HashAlgorithm::Sha384, message, &signature)
+                .verify(message, &signature, HashAlgorithm::Sha384)
                 .unwrap()
         );
         // A tampered message must not verify.
         assert!(
             !public_key
-                .verify(HashAlgorithm::Sha384, b"tampered", &signature)
+                .verify(b"tampered", &signature, HashAlgorithm::Sha384)
                 .unwrap()
         );
     }

--- a/support/crypto/src/ecdsa/ossl.rs
+++ b/support/crypto/src/ecdsa/ossl.rs
@@ -6,8 +6,8 @@
 use super::EcdsaCurve;
 use super::EcdsaError;
 
-fn err(e: openssl::error::ErrorStack, op: &'static str) -> EcdsaError {
-    EcdsaError(crate::BackendError(e, op))
+fn err(err: openssl::error::ErrorStack, op: &'static str) -> EcdsaError {
+    EcdsaError(crate::BackendError(err, op))
 }
 
 #[repr(C)] // Needed for the transmute in as_pub.
@@ -55,7 +55,9 @@ impl EcdsaKeyPairInner {
     }
 
     pub(crate) fn as_pub(&self) -> &EcdsaPublicKeyInner {
-        // SAFETY: PKey<Private> can be safely treated as PKey<Public> for read-only operations.
+        // SAFETY: both types are `repr(C)` with the same field layout, and
+        // PKey<Private> can be safely treated as PKey<Public> for read-only
+        // operations.
         unsafe { std::mem::transmute::<&EcdsaKeyPairInner, &EcdsaPublicKeyInner>(self) }
     }
 }
@@ -67,7 +69,7 @@ pub struct EcdsaPublicKeyInner {
 }
 
 impl EcdsaPublicKeyInner {
-    pub fn new(curve: EcdsaCurve, public_key: &[u8]) -> Result<Self, EcdsaError> {
+    pub fn from_public_key_bytes(curve: EcdsaCurve, public_key: &[u8]) -> Result<Self, EcdsaError> {
         let nid = match curve {
             EcdsaCurve::P384 => openssl::nid::Nid::SECP384R1,
         };

--- a/support/crypto/src/ecdsa/symcrypt.rs
+++ b/support/crypto/src/ecdsa/symcrypt.rs
@@ -6,33 +6,34 @@
 use super::EcdsaCurve;
 use super::EcdsaError;
 use der::Decode;
+use symcrypt::ecc::CurveType;
+use symcrypt::ecc::EcKey;
+use symcrypt::ecc::EcKeyUsage;
+use symcrypt::errors::SymCryptError;
 
-fn err(e: symcrypt::errors::SymCryptError, op: &'static str) -> EcdsaError {
-    EcdsaError(crate::BackendError::SymCrypt(e, op))
+fn err(err: SymCryptError, op: &'static str) -> EcdsaError {
+    EcdsaError(crate::BackendError::SymCrypt(err, op))
 }
 
-fn der_err(e: der::Error, op: &'static str) -> EcdsaError {
-    EcdsaError(crate::BackendError::Der(e, op))
+fn der_err(err: der::Error, op: &'static str) -> EcdsaError {
+    EcdsaError(crate::BackendError::Der(err, op))
 }
 
 #[repr(transparent)] // Needed for the transmute in as_pub.
-pub struct EcdsaKeyPairInner {
-    key: symcrypt::ecc::EcKey,
-}
+pub struct EcdsaKeyPairInner(EcKey);
 
 impl EcdsaKeyPairInner {
     pub fn generate(curve: EcdsaCurve) -> Result<Self, EcdsaError> {
         let curve_type = match curve {
-            EcdsaCurve::P384 => symcrypt::ecc::CurveType::NistP384,
+            EcdsaCurve::P384 => CurveType::NistP384,
         };
-        let key =
-            symcrypt::ecc::EcKey::generate_key_pair(curve_type, symcrypt::ecc::EcKeyUsage::EcDsa)
-                .map_err(|e| err(e, "generating ECDSA key pair"))?;
-        Ok(Self { key })
+        let key = EcKey::generate_key_pair(curve_type, EcKeyUsage::EcDsa)
+            .map_err(|e| err(e, "generating ECDSA key pair"))?;
+        Ok(Self(key))
     }
 
     pub fn sign_prehash(&self, hash: &[u8]) -> Result<Vec<u8>, EcdsaError> {
-        self.key.ecdsa_sign(hash).map_err(|e| err(e, "ECDSA sign"))
+        self.0.ecdsa_sign(hash).map_err(|e| err(e, "ECDSA sign"))
     }
 
     pub(crate) fn as_pub(&self) -> &EcdsaPublicKeyInner {
@@ -42,26 +43,20 @@ impl EcdsaKeyPairInner {
 }
 
 #[repr(transparent)] // Needed for the transmute in as_pub.
-pub struct EcdsaPublicKeyInner {
-    key: symcrypt::ecc::EcKey,
-}
+pub struct EcdsaPublicKeyInner(EcKey);
 
 impl EcdsaPublicKeyInner {
-    pub fn new(curve: EcdsaCurve, public_key: &[u8]) -> Result<Self, EcdsaError> {
+    pub fn from_public_key_bytes(curve: EcdsaCurve, public_key: &[u8]) -> Result<Self, EcdsaError> {
         let curve_type = match curve {
-            EcdsaCurve::P384 => symcrypt::ecc::CurveType::NistP384,
+            EcdsaCurve::P384 => CurveType::NistP384,
         };
         // SymCrypt's `set_public_key` validates that `public_key` is exactly the
         // expected `Qx || Qy` length for the curve (rejecting both short and
         // long inputs with `InvalidArgument`), so no separate length check is
         // needed here.
-        let key = symcrypt::ecc::EcKey::set_public_key(
-            curve_type,
-            public_key,
-            symcrypt::ecc::EcKeyUsage::EcDsa,
-        )
-        .map_err(|e| err(e, "importing public key"))?;
-        Ok(Self { key })
+        let key = EcKey::set_public_key(curve_type, public_key, EcKeyUsage::EcDsa)
+            .map_err(|e| err(e, "importing public key"))?;
+        Ok(Self(key))
     }
 
     pub fn from_public_key_der(spki_der: &[u8]) -> Result<Self, EcdsaError> {
@@ -79,7 +74,7 @@ impl EcdsaPublicKeyInner {
             .parameters
             .ok_or_else(|| {
                 err(
-                    symcrypt::errors::SymCryptError::InvalidArgument,
+                    SymCryptError::InvalidArgument,
                     "missing EC curve parameters",
                 )
             })?
@@ -89,7 +84,7 @@ impl EcdsaPublicKeyInner {
             EcdsaCurve::P384
         } else {
             return Err(err(
-                symcrypt::errors::SymCryptError::InvalidArgument,
+                SymCryptError::InvalidArgument,
                 "unsupported or unrecognized EC curve",
             ));
         };
@@ -99,30 +94,29 @@ impl EcdsaPublicKeyInner {
         let point = spki.subject_public_key.raw_bytes();
         if point.len() != 1 + 2 * curve.key_size() || point[0] != 0x04 {
             return Err(err(
-                symcrypt::errors::SymCryptError::InvalidArgument,
+                SymCryptError::InvalidArgument,
                 "public key is not an uncompressed EC point (0x04 || Qx || Qy)",
             ));
         }
-        Self::new(curve, &point[1..])
+        Self::from_public_key_bytes(curve, &point[1..])
     }
 
     pub fn verify_prehash(&self, hash: &[u8], signature: &[u8]) -> Result<bool, EcdsaError> {
-        match self.key.ecdsa_verify(signature, hash) {
+        match self.0.ecdsa_verify(signature, hash) {
             Ok(()) => Ok(true),
             // `SignatureVerificationFailure` is the expected error for a
             // signature that does not match. `InvalidArgument` occurs when the
             // signature is malformed (e.g. wrong length, or a component that is
             // out of range), which likewise means "does not verify".
-            Err(
-                symcrypt::errors::SymCryptError::SignatureVerificationFailure
-                | symcrypt::errors::SymCryptError::InvalidArgument,
-            ) => Ok(false),
+            Err(SymCryptError::SignatureVerificationFailure | SymCryptError::InvalidArgument) => {
+                Ok(false)
+            }
             Err(e) => Err(err(e, "ECDSA verify")),
         }
     }
 
     pub fn public_key_bytes(&self) -> Result<Vec<u8>, EcdsaError> {
-        self.key
+        self.0
             .export_public_key()
             .map_err(|e| err(e, "exporting public key"))
     }

--- a/support/crypto/src/ecdsa/win.rs
+++ b/support/crypto/src/ecdsa/win.rs
@@ -8,8 +8,34 @@ use super::EcdsaError;
 use crate::win::AlgHandle;
 use crate::win::KeyHandle;
 use std::sync::LazyLock;
+use windows::Win32::Foundation::E_INVALIDARG;
+use windows::Win32::Foundation::E_UNEXPECTED;
 use windows::Win32::Foundation::STATUS_INVALID_SIGNATURE;
-use windows::Win32::Security::Cryptography::*;
+use windows::Win32::Security::Cryptography::BCRYPT_ALG_HANDLE;
+use windows::Win32::Security::Cryptography::BCRYPT_ECCKEY_BLOB;
+use windows::Win32::Security::Cryptography::BCRYPT_ECCPUBLIC_BLOB;
+use windows::Win32::Security::Cryptography::BCRYPT_ECDSA_P384_ALGORITHM;
+use windows::Win32::Security::Cryptography::BCRYPT_ECDSA_PUBLIC_P384_MAGIC;
+use windows::Win32::Security::Cryptography::BCRYPT_FLAGS;
+use windows::Win32::Security::Cryptography::BCRYPT_HANDLE;
+use windows::Win32::Security::Cryptography::BCRYPT_KEY_HANDLE;
+use windows::Win32::Security::Cryptography::BCRYPT_KEY_LENGTH;
+use windows::Win32::Security::Cryptography::BCRYPT_OPEN_ALGORITHM_PROVIDER_FLAGS;
+use windows::Win32::Security::Cryptography::BCryptExportKey;
+use windows::Win32::Security::Cryptography::BCryptFinalizeKeyPair;
+use windows::Win32::Security::Cryptography::BCryptGenerateKeyPair;
+use windows::Win32::Security::Cryptography::BCryptGetProperty;
+use windows::Win32::Security::Cryptography::BCryptImportKeyPair;
+use windows::Win32::Security::Cryptography::BCryptOpenAlgorithmProvider;
+use windows::Win32::Security::Cryptography::BCryptSignHash;
+use windows::Win32::Security::Cryptography::BCryptVerifySignature;
+use windows::Win32::Security::Cryptography::CERT_PUBLIC_KEY_INFO;
+use windows::Win32::Security::Cryptography::CRYPT_IMPORT_PUBLIC_KEY_FLAGS;
+use windows::Win32::Security::Cryptography::CRYPT_INTEGER_BLOB;
+use windows::Win32::Security::Cryptography::CryptImportPublicKeyInfoEx2;
+use windows::Win32::Security::Cryptography::X509_ASN_ENCODING;
+use windows::Win32::Security::Cryptography::X509_PUBLIC_KEY_INFO;
+use windows::Win32::Security::Cryptography::szOID_ECC_PUBLIC_KEY;
 
 static ECDSA_P384: LazyLock<Result<AlgHandle, EcdsaError>> = LazyLock::new(|| {
     let mut handle = BCRYPT_ALG_HANDLE::default();
@@ -28,8 +54,8 @@ static ECDSA_P384: LazyLock<Result<AlgHandle, EcdsaError>> = LazyLock::new(|| {
     .map_err(|e| err(e, "BCryptOpenAlgorithmProvider"))
 });
 
-fn err(e: windows_result::Error, op: &'static str) -> EcdsaError {
-    EcdsaError(crate::BackendError(e, op))
+fn err(err: windows_result::Error, op: &'static str) -> EcdsaError {
+    EcdsaError(crate::BackendError(err, op))
 }
 
 fn alg_handle(curve: EcdsaCurve) -> Result<&'static AlgHandle, EcdsaError> {
@@ -118,8 +144,6 @@ impl EcdsaKeyPairInner {
     }
 }
 
-/// In-memory `BCRYPT_ECCKEY_BLOB` for an ECDSA P-384 public key: the
-/// `{ dwMagic, cbKey }` header followed by the `Qx || Qy` affine coordinates.
 #[repr(C)] // Needed for the transmute in as_pub.
 pub struct EcdsaPublicKeyInner {
     handle: KeyHandle,
@@ -127,7 +151,7 @@ pub struct EcdsaPublicKeyInner {
 }
 
 impl EcdsaPublicKeyInner {
-    pub fn new(curve: EcdsaCurve, public_key: &[u8]) -> Result<Self, EcdsaError> {
+    pub fn from_public_key_bytes(curve: EcdsaCurve, public_key: &[u8]) -> Result<Self, EcdsaError> {
         let alg = alg_handle(curve)?;
         let key_size = curve.key_size();
 
@@ -139,8 +163,8 @@ impl EcdsaPublicKeyInner {
         // encodings identically.
         if public_key.len() != key_size * 2 {
             return Err(err(
-                windows::core::Error::new(
-                    windows::Win32::Foundation::E_INVALIDARG,
+                windows_result::Error::new(
+                    E_INVALIDARG,
                     "ECDSA public key is not the expected length (Qx || Qy)",
                 ),
                 "validating ECDSA public key length",
@@ -202,10 +226,7 @@ impl EcdsaPublicKeyInner {
         let is_ec = !oid.is_null() && unsafe { oid.as_bytes() == szOID_ECC_PUBLIC_KEY.as_bytes() };
         if !is_ec {
             return Err(err(
-                windows::core::Error::new(
-                    windows::Win32::Foundation::E_INVALIDARG,
-                    "public key is not an ECDSA key",
-                ),
+                windows_result::Error::new(E_INVALIDARG, "public key is not an ECDSA key"),
                 "validating public key algorithm",
             ));
         }
@@ -232,8 +253,8 @@ impl EcdsaPublicKeyInner {
             384 => EcdsaCurve::P384,
             _ => {
                 return Err(err(
-                    windows::core::Error::new(
-                        windows::Win32::Foundation::E_INVALIDARG,
+                    windows_result::Error::new(
+                        E_INVALIDARG,
                         "unsupported or unrecognized EC curve",
                     ),
                     "determining public key curve",
@@ -300,10 +321,7 @@ impl EcdsaPublicKeyInner {
 
         if (blob_len as usize) < header_size + key_size * 2 {
             return Err(err(
-                windows::core::Error::new(
-                    windows::Win32::Foundation::E_UNEXPECTED,
-                    "public key blob too small",
-                ),
+                windows_result::Error::new(E_UNEXPECTED, "public key blob too small"),
                 "validating public key blob size",
             ));
         }

--- a/support/crypto/src/x509/symcrypt_rust.rs
+++ b/support/crypto/src/x509/symcrypt_rust.rs
@@ -85,8 +85,11 @@ impl X509CertificateInner {
             let qxqy = point.strip_prefix(&[0x04u8]).ok_or_else(|| {
                 der_err(der::ErrorKind::Failed.into(), "parsing EC public key point")
             })?;
-            let key = crate::ecdsa::EcdsaPublicKey::new(crate::ecdsa::EcdsaCurve::P384, qxqy)
-                .map_err(|crate::ecdsa::EcdsaError(e)| X509Error(e))?;
+            let key = crate::ecdsa::EcdsaPublicKey::from_public_key_bytes(
+                crate::ecdsa::EcdsaCurve::P384,
+                qxqy,
+            )
+            .map_err(|crate::ecdsa::EcdsaError(e)| X509Error(e))?;
             return Ok(X509PublicKey::Ecdsa(key));
         }
 

--- a/vm/loader/igvmfilegen/src/snp_id_block.rs
+++ b/vm/loader/igvmfilegen/src/snp_id_block.rs
@@ -363,7 +363,7 @@ fn signature_and_verify(
 
     // Verify (public key, r||s) over the SHA-384 of the signed content.
     let valid = public_key
-        .verify(crypto::HashAlgorithm::Sha384, signed_bytes, &sig)
+        .verify(signed_bytes, &sig, crypto::HashAlgorithm::Sha384)
         .context("verifying SNP ID block signature")?;
     anyhow::ensure!(
         valid,
@@ -471,7 +471,7 @@ fn sign_id_block_with_temp_key(
     // Sign the ID block bytes; `EcdsaKeyPair::sign` hashes them with SHA-384
     // internally. Returns r || s in big-endian, each 48 bytes for P-384.
     let signature = key
-        .sign(crypto::HashAlgorithm::Sha384, id_block.as_bytes())
+        .sign(id_block.as_bytes(), crypto::HashAlgorithm::Sha384)
         .context("signing SNP ID block")?;
 
     anyhow::ensure!(
@@ -572,7 +572,7 @@ mod tests {
 
         let key = EcdsaKeyPair::generate(EcdsaCurve::P384).unwrap();
         let raw_sig = key
-            .sign(crypto::HashAlgorithm::Sha384, signing_payload)
+            .sign(signing_payload, crypto::HashAlgorithm::Sha384)
             .unwrap();
         (ecdsa_raw_to_der(&raw_sig), spki_der(&key))
     }
@@ -692,7 +692,7 @@ mod tests {
         fn try_sign(&self, msg: &[u8]) -> Result<EcdsaDerSignature, signature::Error> {
             let raw = self
                 .key
-                .sign(crypto::HashAlgorithm::Sha384, msg)
+                .sign(msg, crypto::HashAlgorithm::Sha384)
                 .map_err(|_| signature::Error::new())?;
             Ok(EcdsaDerSignature(ecdsa_raw_to_der(&raw)))
         }
@@ -1024,7 +1024,7 @@ mod tests {
         // P-384 certificate, using the same key for both.
         let key = EcdsaKeyPair::generate(EcdsaCurve::P384).unwrap();
         let sig_der = ecdsa_raw_to_der(
-            &key.sign(crypto::HashAlgorithm::Sha384, &signing_payload)
+            &key.sign(&signing_payload, crypto::HashAlgorithm::Sha384)
                 .unwrap(),
         );
         let cert_der = self_signed_p384_cert_der(&key);


### PR DESCRIPTION
Backport of #4108 to `release/1.8.2607`.

Cherry-picked commit `e15f6a589c573bfdcadc5f76afabc7e7afb42266`. The cherry-pick applied cleanly with no conflicts and no manual edits.

This is a prerequisite for backporting #4217 ("crypto: Error message cleanup"), which conflicts on `release/1.8.2607` without this refactor.

---
_This pull request was created by an AI agent (GitHub Copilot) on behalf of @smalis-msft._