### PR TITLE
nix: update mu_msvm nix hashes for reproducible builds (#3983)

### DIFF
--- a/Guide/src/dev_guide/dev_tools/flowey/nix.md
+++ b/Guide/src/dev_guide/dev_tools/flowey/nix.md
@@ -30,6 +30,35 @@ error: Cannot build '/nix/store/spg5vbm6mzmsxpg5v2ibg97qrz8khc70-openhcl-kernel-
 
 Given this error, you would update the corresponding hash to `sha256-An1N76i1MPb+rrQ1nBpoiuxnNeD0E+VuwqXdkPzaZn0=` in the `openhcl_kernel.nix` file.
 
+### Updating `mu_msvm` UEFI (`nix/uefi_mu_msvm.nix`)
+
+When bumping `mu_msvm`, update both the Nix fetch and the Flowey version
+constant in the same PR.
+
+1. Update `nix/uefi_mu_msvm.nix`:
+    - Set `version` to the new release.
+    - Ensure the `fetchzip` URL uses that version.
+    - Set both architecture hashes to empty strings.
+2. Update `flowey/flowey_lib_hvlite/src/_jobs/cfg_versions.rs`:
+    - Bump `MU_MSVM` to the same version.
+3. From the repo root, run `sudo nix-shell` (or `nix-shell` if sudo is not
+  required in your environment).
+4. Copy the first `got:` hash from the mismatch error into the matching entry
+  in `nix/uefi_mu_msvm.nix`.
+5. Run `sudo nix-shell` again to fetch the other architecture and copy its
+  `got:` hash.
+6. Re-run `sudo nix-shell` a final time to verify both hashes are correct.
+
+Expected mismatch output:
+
+```bash
+error: hash mismatch in fixed-output derivation '/nix/store/...-source.drv':
+      specified: sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
+        got:    sha256-<new hash from downloaded artifact>
+```
+
+Use the `got:` value in the `.nix` file.
+
 ## Updating the Rust Version
 
 The Nix shell derives its Rust toolchain version from `rust-version` in the root `Cargo.toml` and resolves it against a pinned [rust-overlay](https://github.com/oxalica/rust-overlay) commit in `shell.nix`. When `rust-version` is bumped in `Cargo.toml`, the pinned rust-overlay may not yet include the new version, causing an error like:

--- a/nix/uefi_mu_msvm.nix
+++ b/nix/uefi_mu_msvm.nix
@@ -8,13 +8,13 @@ let
          else if system == "aarch64-linux" then "AARCH64-CLANGPDB"
          else "X64-VS2022";
   hash = {
-    "AARCH64-CLANGPDB" = "sha256-HI2tT8sry3avIafZT1aMzP0821fiFKQc9CE7o5hl6Nw=";
-    "X64-VS2022" = "sha256-V44ql2wTDhE0GcrzRztJhgrE6inuhY19YvO79m286nU=";
+    "AARCH64-CLANGPDB" = "sha256-3UjCLzbldssvanro50hZoTQ4zrs+RzHKfnwdJMTcgQk=";
+    "X64-VS2022" = "sha256-7g0tD6S1911TpnLs5Annj6XMJavGDx0/qJhD2978ODE=";
   }.${archToolchain};
 
 in stdenv.mkDerivation rec {
   pname = "uefi-mu-msvm-${archToolchain}";
-  version = "26.0.13";
+  version = "26.0.19";
 
   src = fetchzip {
     url =


### PR DESCRIPTION
Clean cherry pick of PR #3983

This is a follow up to (https://github.com/microsoft/openvmm/pull/3977). We need to also update the nix hashes whenever we bump mu_msvm. This PR also updates the guide so that AI agents can follow along as well.
