### PR TITLE
[release/1.8.2607] Revert "petri: Capture hyper-v analytic and operational logs too"

### DIFF
--- a/petri/src/vm/hyperv/powershell.rs
+++ b/petri/src/vm/hyperv/powershell.rs
@@ -1631,11 +1631,6 @@ pub async fn run_get_winevent(
 
 const HYPERV_WORKER_TABLE: &str = "Microsoft-Windows-Hyper-V-Worker-Admin";
 const HYPERV_VMMS_TABLE: &str = "Microsoft-Windows-Hyper-V-VMMS-Admin";
-const HYPERV_WORKER_OPERATIONAL_TABLE: &str = "Microsoft-Windows-Hyper-V-Worker-Operational";
-const HYPERV_VMMS_OPERATIONAL_TABLE: &str = "Microsoft-Windows-Hyper-V-VMMS-Operational";
-const HYPERV_WORKER_ANALYTIC_TABLE: &str = "Microsoft-Windows-Hyper-V-Worker-Analytic";
-const HYPERV_WORKER_VDEV_ANALYTIC_TABLE: &str = "Microsoft-Windows-Hyper-V-Worker-VDev-Analytic";
-const HYPERV_VMMS_ANALYTIC_TABLE: &str = "Microsoft-Windows-Hyper-V-VMMS-Analytic";
 
 /// Providers that report a process fault to Windows Error Reporting and the
 /// Azure Watson agent.
@@ -1739,39 +1734,19 @@ define_winevents!(
 );
 
 /// Get Hyper-V event logs for a VM
-pub async fn hyperv_event_logs(vmid: Option<&Guid>, start_time: &Timestamp) -> Vec<WinEvent> {
+pub async fn hyperv_event_logs(
+    vmid: Option<&Guid>,
+    start_time: &Timestamp,
+) -> anyhow::Result<Vec<WinEvent>> {
     let vmid = vmid.map(|id| id.to_string());
-    // All the logs are fetched in a single query. `Get-WinEvent` reports a log
-    // that is missing or disabled as a non-terminating error and still returns
-    // the events from the remaining logs.
-    let mut events = match run_get_winevent(
-        &[
-            HYPERV_WORKER_TABLE,
-            HYPERV_VMMS_TABLE,
-            HYPERV_WORKER_OPERATIONAL_TABLE,
-            HYPERV_VMMS_OPERATIONAL_TABLE,
-            HYPERV_WORKER_ANALYTIC_TABLE,
-            HYPERV_WORKER_VDEV_ANALYTIC_TABLE,
-            HYPERV_VMMS_ANALYTIC_TABLE,
-        ],
+    run_get_winevent(
+        &[HYPERV_WORKER_TABLE, HYPERV_VMMS_TABLE],
         &[],
         Some(start_time),
         vmid.as_deref(),
         &[],
     )
     .await
-    {
-        Ok(events) => events,
-        Err(err) => {
-            tracing::warn!(
-                error = err.as_ref() as &dyn std::error::Error,
-                "failed to read hyper-v event logs"
-            );
-            Vec::new()
-        }
-    };
-    events.sort_by_key(|e| e.time_created);
-    events
 }
 
 /// Get the Windows Error Reporting / Azure Watson events logged since

--- a/petri/src/vm/hyperv/vm.rs
+++ b/petri/src/vm/hyperv/vm.rs
@@ -136,7 +136,7 @@ impl HyperVVM {
     /// Get Hyper-V logs and write them to the log file
     pub async fn flush_logs(&mut self) -> anyhow::Result<()> {
         let start_time = self.last_log_flushed.as_ref().unwrap_or(&self.create_time);
-        for event in powershell::hyperv_event_logs(Some(&self.vmid), start_time).await {
+        for event in powershell::hyperv_event_logs(Some(&self.vmid), start_time).await? {
             self.log_winevent(&event);
             if self.last_log_flushed.is_none_or(|t| t < event.time_created) {
                 // add 1ms to avoid duplicate log entries


### PR DESCRIPTION
Reverts #4228 on `release/1.8.2607` (commit `75506a3bed3c60b1ef64869272ae3f170e00520e`).

#4228 can cause PCAT VMM test failures on the TDX runners.

The actual fix for the underlying issue is #4231 ("petri: Push boot event timeout handling into backends"), but taking that full fix back to `release/1.8.2607` is a larger and riskier change than this release branch warrants — it additionally requires backporting #3916 ("membacking: support Windows large-page guest RAM backing") as a prerequisite, since #4231 does not cherry-pick cleanly without it.

Reverting #4228 is the cleaner option for this release branch. The revert applied cleanly with no conflicts and no manual edits.

---
_This pull request was created by an AI agent (GitHub Copilot) on behalf of @smalis-msft._