### PR TITLE
vmm_tests: test failure buckets and repetitions

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -80,8 +80,9 @@ fail-fast = false
 [profile.ci]
 # Set the default timeout to 1 second, with tests terminated after 10 seconds
 slow-timeout = { period = "1s", terminate-after = 10 }
-# Print out output for failing tests at the end of the run.
-failure-output = "final"
+# Don't pollute the output with logs. Summaries are printed with flowey
+# and full logs can be downloaded via artifact or viewed on the results website
+failure-output = "never"
 # Do not cancel the test run on the first failure.
 fail-fast = false
 

--- a/.github/workflows/openvmm-ci.yaml
+++ b/.github/workflows/openvmm-ci.yaml
@@ -1608,7 +1608,9 @@ jobs:
       name: 'publish test results: x64-windows-unit-tests-base (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey.exe e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: |-
+        flowey.exe e 13 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey.exe e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: run 'x64-windows-unit-tests-crypto-native' nextest tests
       run: |-
@@ -1628,7 +1630,9 @@ jobs:
       name: 'publish test results: x64-windows-unit-tests-crypto-native (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey.exe e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      run: |-
+        flowey.exe e 13 flowey_lib_hvlite::run_cargo_nextest_run 2
+        flowey.exe e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
     - name: run 'x64-windows-unit-tests-crypto-rust' nextest tests
       run: |-
@@ -1908,7 +1912,7 @@ jobs:
       run: |-
         flowey e 14 flowey_lib_common::install_cargo_nextest 0
         flowey e 14 flowey_lib_hvlite::init_cross_build 1
-        flowey e 14 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey e 14 flowey_lib_hvlite::run_cargo_nextest_run 4
       shell: bash
     - name: generate nextest command
       run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 3
@@ -1931,7 +1935,9 @@ jobs:
       name: 'publish test results: x64-linux-unit-tests-crypto-rust (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      run: |-
+        flowey e 14 flowey_lib_hvlite::run_cargo_nextest_run 3
+        flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 2
       shell: bash
     - name: run 'x64-linux-unit-tests-crypto-openssl' nextest tests
       run: |-
@@ -1951,7 +1957,9 @@ jobs:
       name: 'publish test results: x64-linux-unit-tests-crypto-openssl (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: |-
+        flowey e 14 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: run 'x64-linux-unit-tests-crypto-all' nextest tests
       run: |-
@@ -1983,7 +1991,9 @@ jobs:
         flowey e 14 flowey_lib_hvlite::build_xtask 2
       shell: bash
     - name: determine unit test exclusions
-      run: flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 0
+      run: |-
+        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 0
+        flowey e 14 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
       run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 4
@@ -2006,7 +2016,9 @@ jobs:
       name: 'publish test results: x64-linux-unit-tests-base (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      run: |-
+        flowey e 14 flowey_lib_hvlite::run_cargo_nextest_run 2
+        flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
     - name: run 'x64-linux-unit-tests-crypto-native' nextest tests
       run: |-
@@ -2276,7 +2288,7 @@ jobs:
       run: |-
         flowey e 15 flowey_lib_common::install_cargo_nextest 0
         flowey e 15 flowey_lib_hvlite::init_cross_build 3
-        flowey e 15 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey e 15 flowey_lib_hvlite::run_cargo_nextest_run 4
       shell: bash
     - name: generate nextest command
       run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 3
@@ -2299,7 +2311,9 @@ jobs:
       name: 'publish test results: x64-linux-musl-unit-tests-crypto-rust (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      run: |-
+        flowey e 15 flowey_lib_hvlite::run_cargo_nextest_run 3
+        flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 2
       shell: bash
     - name: run 'x64-linux-musl-unit-tests-crypto-openssl' nextest tests
       run: |-
@@ -2319,7 +2333,9 @@ jobs:
       name: 'publish test results: x64-linux-musl-unit-tests-crypto-openssl (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 4
+      run: |-
+        flowey e 15 flowey_lib_hvlite::run_cargo_nextest_run 5
+        flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 4
       shell: bash
     - name: run 'x64-linux-musl-unit-tests-crypto-symcrypt' nextest tests
       run: |-
@@ -2339,7 +2355,9 @@ jobs:
       name: 'publish test results: x64-linux-musl-unit-tests-crypto-symcrypt (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: |-
+        flowey e 15 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: run 'x64-linux-musl-unit-tests-crypto-all' nextest tests
       run: |-
@@ -2371,7 +2389,9 @@ jobs:
         flowey e 15 flowey_lib_hvlite::build_xtask 1
       shell: bash
     - name: determine unit test exclusions
-      run: flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 0
+      run: |-
+        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 0
+        flowey e 15 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
       run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 5
@@ -2394,7 +2414,9 @@ jobs:
       name: 'publish test results: x64-linux-musl-unit-tests-base (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      run: |-
+        flowey e 15 flowey_lib_hvlite::run_cargo_nextest_run 2
+        flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
     - name: run 'x64-linux-musl-unit-tests-crypto-native' nextest tests
       run: |-
@@ -2666,7 +2688,9 @@ jobs:
       name: 'publish test results: aarch64-windows-unit-tests-base (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey.exe e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: |-
+        flowey.exe e 16 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey.exe e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: run 'aarch64-windows-unit-tests-crypto-native' nextest tests
       run: |-
@@ -2686,7 +2710,9 @@ jobs:
       name: 'publish test results: aarch64-windows-unit-tests-crypto-native (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey.exe e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      run: |-
+        flowey.exe e 16 flowey_lib_hvlite::run_cargo_nextest_run 2
+        flowey.exe e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
     - name: run 'aarch64-windows-unit-tests-crypto-rust' nextest tests
       run: |-
@@ -2942,7 +2968,7 @@ jobs:
       run: |-
         flowey e 17 flowey_lib_common::install_cargo_nextest 0
         flowey e 17 flowey_lib_hvlite::init_cross_build 1
-        flowey e 17 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey e 17 flowey_lib_hvlite::run_cargo_nextest_run 4
       shell: bash
     - name: generate nextest command
       run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 3
@@ -2965,7 +2991,9 @@ jobs:
       name: 'publish test results: aarch64-linux-unit-tests-crypto-rust (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      run: |-
+        flowey e 17 flowey_lib_hvlite::run_cargo_nextest_run 3
+        flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 2
       shell: bash
     - name: run 'aarch64-linux-unit-tests-crypto-openssl' nextest tests
       run: |-
@@ -2985,7 +3013,9 @@ jobs:
       name: 'publish test results: aarch64-linux-unit-tests-crypto-openssl (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: |-
+        flowey e 17 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: run 'aarch64-linux-unit-tests-crypto-all' nextest tests
       run: |-
@@ -3017,7 +3047,9 @@ jobs:
         flowey e 17 flowey_lib_hvlite::build_xtask 1
       shell: bash
     - name: determine unit test exclusions
-      run: flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 0
+      run: |-
+        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 0
+        flowey e 17 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
       run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 4
@@ -3040,7 +3072,9 @@ jobs:
       name: 'publish test results: aarch64-linux-unit-tests-base (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      run: |-
+        flowey e 17 flowey_lib_hvlite::run_cargo_nextest_run 2
+        flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
     - name: run 'aarch64-linux-unit-tests-crypto-native' nextest tests
       run: |-
@@ -3310,7 +3344,7 @@ jobs:
       run: |-
         flowey e 18 flowey_lib_common::install_cargo_nextest 0
         flowey e 18 flowey_lib_hvlite::init_cross_build 3
-        flowey e 18 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey e 18 flowey_lib_hvlite::run_cargo_nextest_run 4
       shell: bash
     - name: generate nextest command
       run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 3
@@ -3333,7 +3367,9 @@ jobs:
       name: 'publish test results: aarch64-linux-musl-unit-tests-crypto-rust (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      run: |-
+        flowey e 18 flowey_lib_hvlite::run_cargo_nextest_run 3
+        flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 2
       shell: bash
     - name: run 'aarch64-linux-musl-unit-tests-crypto-openssl' nextest tests
       run: |-
@@ -3353,7 +3389,9 @@ jobs:
       name: 'publish test results: aarch64-linux-musl-unit-tests-crypto-openssl (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 4
+      run: |-
+        flowey e 18 flowey_lib_hvlite::run_cargo_nextest_run 5
+        flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 4
       shell: bash
     - name: run 'aarch64-linux-musl-unit-tests-crypto-symcrypt' nextest tests
       run: |-
@@ -3373,7 +3411,9 @@ jobs:
       name: 'publish test results: aarch64-linux-musl-unit-tests-crypto-symcrypt (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: |-
+        flowey e 18 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: run 'aarch64-linux-musl-unit-tests-crypto-all' nextest tests
       run: |-
@@ -3405,7 +3445,9 @@ jobs:
         flowey e 18 flowey_lib_hvlite::build_xtask 1
       shell: bash
     - name: determine unit test exclusions
-      run: flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 0
+      run: |-
+        flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 0
+        flowey e 18 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
       run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 5
@@ -3428,7 +3470,9 @@ jobs:
       name: 'publish test results: aarch64-linux-musl-unit-tests-base (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      run: |-
+        flowey e 18 flowey_lib_hvlite::run_cargo_nextest_run 2
+        flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
     - name: run 'aarch64-linux-musl-unit-tests-crypto-native' nextest tests
       run: |-
@@ -3570,7 +3614,7 @@ jobs:
       run: |-
         flowey.exe e 19 flowey_lib_common::system_info 0
         flowey.exe e 19 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey.exe e 19 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
         flowey.exe e 19 flowey_core::pipeline::artifact::resolve 8
         flowey.exe e 19 flowey_core::pipeline::artifact::resolve 9
         flowey.exe e 19 flowey_core::pipeline::artifact::resolve 12
@@ -3677,39 +3721,41 @@ jobs:
     - name: setting up vmm_tests env
       run: |-
         flowey.exe e 19 flowey_lib_hvlite::init_vmm_tests_env 0
-        flowey.exe e 19 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey.exe e 19 flowey_lib_hvlite::run_cargo_nextest_run 0
         flowey.exe e 19 flowey_core::pipeline::artifact::resolve 16
         flowey.exe e 19 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: generate nextest command
-      run: flowey.exe e 19 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-      shell: bash
-    - name: install vmm tests deps (windows)
-      run: flowey.exe e 19 flowey_lib_hvlite::install_vmm_tests_deps 0
-      shell: bash
-    - name: starting test_igvm_agent_rpc_server
       run: |-
-        flowey.exe e 19 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+        flowey.exe e 19 flowey_lib_common::gen_cargo_nextest_run_cmd 0
         flowey.exe e 19 flowey_core::pipeline::artifact::resolve 10
       shell: bash
     - name: running vmm_test prep_steps
       run: flowey.exe e 19 flowey_lib_hvlite::run_prep_steps 0
       shell: bash
+    - name: starting test_igvm_agent_rpc_server
+      run: flowey.exe e 19 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+      shell: bash
+    - name: install vmm tests deps (windows)
+      run: flowey.exe e 19 flowey_lib_hvlite::install_vmm_tests_deps 0
+      shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
         flowey.exe e 19 flowey_lib_common::run_cargo_nextest_run 0
         flowey.exe e 19 flowey_lib_common::run_cargo_nextest_run 1
-        flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
-      shell: bash
-    - name: summarize failing vmm tests
-      run: |-
-        flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
-        flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
       shell: bash
     - name: stopping test_igvm_agent_rpc_server
       run: |-
         flowey.exe e 19 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
+        flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+      shell: bash
+    - name: rename and create new log dir
+      run: flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+      shell: bash
+    - name: summarize failing vmm tests
+      run: |-
         flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 5
+        flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 6
         flowey.exe e 19 flowey_lib_common::publish_test_results 0
         flowey.exe e 19 flowey_lib_common::publish_test_results 1
         flowey.exe v 19 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
@@ -3737,7 +3783,7 @@ jobs:
       name: 'publish test results: x64-windows-intel-vmm-tests (logs)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 6
+      run: flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 7
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
       run: flowey.exe e 19 flowey_lib_common::cache 3
@@ -3991,8 +4037,59 @@ jobs:
         echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmgstool-dev" | flowey.exe v 20 'artifact_use_from_x64-windows-vmgstool-dev' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 20 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
       shell: bash
-    - name: create gh-release-download cache dir
+    - name: create cargo-nextest cache dir
       run: |-
+        flowey.exe e 20 flowey_lib_common::download_cargo_nextest 0
+        flowey.exe e 20 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 20 flowey_lib_common::download_cargo_nextest 2
+        flowey.exe e 20 flowey_lib_common::download_cargo_nextest 3
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey.exe e 20 flowey_lib_common::cache 0
+        flowey.exe v 20 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 20 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25
+      with:
+        key: ${{ env.floweyvar4 }}
+        path: ${{ env.floweyvar5 }}
+      name: 'Restore cache: cargo-nextest'
+    - name: downloading cargo-nextest
+      run: |-
+        flowey.exe v 20 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey.exe e 20 flowey_lib_common::cache 2
+        flowey.exe e 20 flowey_lib_common::download_cargo_nextest 4
+      shell: bash
+    - name: check if openvmm needs to be cloned
+      run: |-
+        flowey.exe e 20 flowey_lib_common::git_checkout 0
+        flowey.exe v 20 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar3
+        flowey.exe v 20 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__git_checkout__1
+      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
+      with:
+        fetch-depth: '1'
+        path: repo0
+        persist-credentials: ${{ env.floweyvar3 }}
+      name: checkout repo openvmm
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report cloned repo directories
+      run: |-
+        flowey.exe v 20 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
+        ${{ github.workspace }}
+        EOF
+        flowey.exe e 20 flowey_lib_common::git_checkout 3
+      shell: bash
+    - name: print system info
+      run: |-
+        flowey.exe e 20 flowey_lib_common::system_info 0
+        flowey.exe e 20 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey.exe e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
         flowey.exe e 20 flowey_core::pipeline::artifact::resolve 13
         flowey.exe e 20 flowey_core::pipeline::artifact::resolve 3
         flowey.exe e 20 flowey_core::pipeline::artifact::resolve 11
@@ -4012,7 +4109,9 @@ jobs:
         ${{ runner.temp }}
         EOF
         flowey.exe e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
-        flowey.exe e 20 flowey_lib_common::download_gh_release 0
+      shell: bash
+    - name: create gh-release-download cache dir
+      run: flowey.exe e 20 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
@@ -4095,89 +4194,38 @@ jobs:
       run: flowey.exe e 20 flowey_lib_hvlite::resolve_openvmm_test_virtio_win 0
       shell: bash
     - name: setting up vmm_tests env
-      run: flowey.exe e 20 flowey_lib_hvlite::init_vmm_tests_env 0
-      shell: bash
-    - name: create cargo-nextest cache dir
       run: |-
-        flowey.exe e 20 flowey_lib_common::download_cargo_nextest 0
-        flowey.exe e 20 flowey_lib_common::download_cargo_nextest 1
-        flowey.exe e 20 flowey_lib_common::download_cargo_nextest 2
-        flowey.exe e 20 flowey_lib_common::download_cargo_nextest 3
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey.exe e 20 flowey_lib_common::cache 0
-        flowey.exe v 20 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 20 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
-      shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25
-      with:
-        key: ${{ env.floweyvar4 }}
-        path: ${{ env.floweyvar5 }}
-      name: 'Restore cache: cargo-nextest'
-    - name: downloading cargo-nextest
-      run: |-
-        flowey.exe v 20 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey.exe e 20 flowey_lib_common::cache 2
-        flowey.exe e 20 flowey_lib_common::download_cargo_nextest 4
-      shell: bash
-    - name: check if openvmm needs to be cloned
-      run: |-
-        flowey.exe e 20 flowey_lib_common::git_checkout 0
-        flowey.exe v 20 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar3
-        flowey.exe v 20 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__git_checkout__1
-      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
-      with:
-        fetch-depth: '1'
-        path: repo0
-        persist-credentials: ${{ env.floweyvar3 }}
-      name: checkout repo openvmm
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report cloned repo directories
-      run: |-
-        flowey.exe v 20 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
-        ${{ github.workspace }}
-        EOF
-        flowey.exe e 20 flowey_lib_common::git_checkout 3
-      shell: bash
-    - name: print system info
-      run: |-
-        flowey.exe e 20 flowey_lib_common::system_info 0
-        flowey.exe e 20 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey.exe e 20 flowey_lib_hvlite::init_vmm_tests_env 0
         flowey.exe e 20 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey.exe e 20 flowey_lib_hvlite::run_cargo_nextest_run 1
         flowey.exe e 20 flowey_core::pipeline::artifact::resolve 16
         flowey.exe e 20 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: generate nextest command
       run: flowey.exe e 20 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
-    - name: install vmm tests deps (windows)
-      run: flowey.exe e 20 flowey_lib_hvlite::install_vmm_tests_deps 0
-      shell: bash
     - name: starting test_igvm_agent_rpc_server
       run: flowey.exe e 20 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+      shell: bash
+    - name: install vmm tests deps (windows)
+      run: flowey.exe e 20 flowey_lib_hvlite::install_vmm_tests_deps 0
       shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
         flowey.exe e 20 flowey_lib_common::run_cargo_nextest_run 0
         flowey.exe e 20 flowey_lib_common::run_cargo_nextest_run 1
-        flowey.exe e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
-      shell: bash
-    - name: summarize failing vmm tests
-      run: |-
-        flowey.exe e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
-        flowey.exe e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
       shell: bash
     - name: stopping test_igvm_agent_rpc_server
       run: |-
         flowey.exe e 20 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
+        flowey.exe e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+      shell: bash
+    - name: rename and create new log dir
+      run: flowey.exe e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+      shell: bash
+    - name: summarize failing vmm tests
+      run: |-
         flowey.exe e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 5
+        flowey.exe e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 6
         flowey.exe e 20 flowey_lib_common::publish_test_results 0
         flowey.exe e 20 flowey_lib_common::publish_test_results 1
         flowey.exe v 20 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
@@ -4205,7 +4253,7 @@ jobs:
       name: 'publish test results: x64-windows-intel-mi-secure-vmm-tests (logs)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: flowey.exe e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 6
+      run: flowey.exe e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 7
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
       run: flowey.exe e 20 flowey_lib_common::cache 3
@@ -4326,7 +4374,7 @@ jobs:
       run: |-
         flowey.exe e 21 flowey_lib_common::system_info 0
         flowey.exe e 21 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey.exe e 21 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
         flowey.exe e 21 flowey_core::pipeline::artifact::resolve 8
         flowey.exe e 21 flowey_core::pipeline::artifact::resolve 9
         flowey.exe e 21 flowey_core::pipeline::artifact::resolve 12
@@ -4433,39 +4481,41 @@ jobs:
     - name: setting up vmm_tests env
       run: |-
         flowey.exe e 21 flowey_lib_hvlite::init_vmm_tests_env 0
-        flowey.exe e 21 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey.exe e 21 flowey_lib_hvlite::run_cargo_nextest_run 0
         flowey.exe e 21 flowey_core::pipeline::artifact::resolve 16
         flowey.exe e 21 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: generate nextest command
-      run: flowey.exe e 21 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-      shell: bash
-    - name: install vmm tests deps (windows)
-      run: flowey.exe e 21 flowey_lib_hvlite::install_vmm_tests_deps 0
-      shell: bash
-    - name: starting test_igvm_agent_rpc_server
       run: |-
-        flowey.exe e 21 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+        flowey.exe e 21 flowey_lib_common::gen_cargo_nextest_run_cmd 0
         flowey.exe e 21 flowey_core::pipeline::artifact::resolve 10
       shell: bash
     - name: running vmm_test prep_steps
       run: flowey.exe e 21 flowey_lib_hvlite::run_prep_steps 0
       shell: bash
+    - name: starting test_igvm_agent_rpc_server
+      run: flowey.exe e 21 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+      shell: bash
+    - name: install vmm tests deps (windows)
+      run: flowey.exe e 21 flowey_lib_hvlite::install_vmm_tests_deps 0
+      shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
         flowey.exe e 21 flowey_lib_common::run_cargo_nextest_run 0
         flowey.exe e 21 flowey_lib_common::run_cargo_nextest_run 1
-        flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
-      shell: bash
-    - name: summarize failing vmm tests
-      run: |-
-        flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
-        flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
       shell: bash
     - name: stopping test_igvm_agent_rpc_server
       run: |-
         flowey.exe e 21 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
+        flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+      shell: bash
+    - name: rename and create new log dir
+      run: flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+      shell: bash
+    - name: summarize failing vmm tests
+      run: |-
         flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 5
+        flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 6
         flowey.exe e 21 flowey_lib_common::publish_test_results 0
         flowey.exe e 21 flowey_lib_common::publish_test_results 1
         flowey.exe v 21 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
@@ -4493,7 +4543,7 @@ jobs:
       name: 'publish test results: x64-windows-intel-tdx-vmm-tests (logs)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 6
+      run: flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 7
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
       run: flowey.exe e 21 flowey_lib_common::cache 3
@@ -4613,7 +4663,7 @@ jobs:
       run: |-
         flowey.exe e 22 flowey_lib_common::system_info 0
         flowey.exe e 22 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey.exe e 22 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
         flowey.exe e 22 flowey_core::pipeline::artifact::resolve 8
         flowey.exe e 22 flowey_core::pipeline::artifact::resolve 9
         flowey.exe e 22 flowey_core::pipeline::artifact::resolve 12
@@ -4720,39 +4770,41 @@ jobs:
     - name: setting up vmm_tests env
       run: |-
         flowey.exe e 22 flowey_lib_hvlite::init_vmm_tests_env 0
-        flowey.exe e 22 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey.exe e 22 flowey_lib_hvlite::run_cargo_nextest_run 0
         flowey.exe e 22 flowey_core::pipeline::artifact::resolve 16
         flowey.exe e 22 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: generate nextest command
-      run: flowey.exe e 22 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-      shell: bash
-    - name: install vmm tests deps (windows)
-      run: flowey.exe e 22 flowey_lib_hvlite::install_vmm_tests_deps 0
-      shell: bash
-    - name: starting test_igvm_agent_rpc_server
       run: |-
-        flowey.exe e 22 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+        flowey.exe e 22 flowey_lib_common::gen_cargo_nextest_run_cmd 0
         flowey.exe e 22 flowey_core::pipeline::artifact::resolve 10
       shell: bash
     - name: running vmm_test prep_steps
       run: flowey.exe e 22 flowey_lib_hvlite::run_prep_steps 0
       shell: bash
+    - name: starting test_igvm_agent_rpc_server
+      run: flowey.exe e 22 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+      shell: bash
+    - name: install vmm tests deps (windows)
+      run: flowey.exe e 22 flowey_lib_hvlite::install_vmm_tests_deps 0
+      shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
         flowey.exe e 22 flowey_lib_common::run_cargo_nextest_run 0
         flowey.exe e 22 flowey_lib_common::run_cargo_nextest_run 1
-        flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
-      shell: bash
-    - name: summarize failing vmm tests
-      run: |-
-        flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
-        flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
       shell: bash
     - name: stopping test_igvm_agent_rpc_server
       run: |-
         flowey.exe e 22 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
+        flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+      shell: bash
+    - name: rename and create new log dir
+      run: flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+      shell: bash
+    - name: summarize failing vmm tests
+      run: |-
         flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 5
+        flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 6
         flowey.exe e 22 flowey_lib_common::publish_test_results 0
         flowey.exe e 22 flowey_lib_common::publish_test_results 1
         flowey.exe v 22 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
@@ -4780,7 +4832,7 @@ jobs:
       name: 'publish test results: x64-windows-amd-vmm-tests (logs)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 6
+      run: flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 7
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
       run: flowey.exe e 22 flowey_lib_common::cache 3
@@ -4901,7 +4953,7 @@ jobs:
       run: |-
         flowey.exe e 23 flowey_lib_common::system_info 0
         flowey.exe e 23 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey.exe e 23 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
         flowey.exe e 23 flowey_core::pipeline::artifact::resolve 8
         flowey.exe e 23 flowey_core::pipeline::artifact::resolve 9
         flowey.exe e 23 flowey_core::pipeline::artifact::resolve 12
@@ -5008,39 +5060,41 @@ jobs:
     - name: setting up vmm_tests env
       run: |-
         flowey.exe e 23 flowey_lib_hvlite::init_vmm_tests_env 0
-        flowey.exe e 23 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey.exe e 23 flowey_lib_hvlite::run_cargo_nextest_run 0
         flowey.exe e 23 flowey_core::pipeline::artifact::resolve 16
         flowey.exe e 23 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: generate nextest command
-      run: flowey.exe e 23 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-      shell: bash
-    - name: install vmm tests deps (windows)
-      run: flowey.exe e 23 flowey_lib_hvlite::install_vmm_tests_deps 0
-      shell: bash
-    - name: starting test_igvm_agent_rpc_server
       run: |-
-        flowey.exe e 23 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+        flowey.exe e 23 flowey_lib_common::gen_cargo_nextest_run_cmd 0
         flowey.exe e 23 flowey_core::pipeline::artifact::resolve 10
       shell: bash
     - name: running vmm_test prep_steps
       run: flowey.exe e 23 flowey_lib_hvlite::run_prep_steps 0
       shell: bash
+    - name: starting test_igvm_agent_rpc_server
+      run: flowey.exe e 23 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+      shell: bash
+    - name: install vmm tests deps (windows)
+      run: flowey.exe e 23 flowey_lib_hvlite::install_vmm_tests_deps 0
+      shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
         flowey.exe e 23 flowey_lib_common::run_cargo_nextest_run 0
         flowey.exe e 23 flowey_lib_common::run_cargo_nextest_run 1
-        flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
-      shell: bash
-    - name: summarize failing vmm tests
-      run: |-
-        flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
-        flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
       shell: bash
     - name: stopping test_igvm_agent_rpc_server
       run: |-
         flowey.exe e 23 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
+        flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+      shell: bash
+    - name: rename and create new log dir
+      run: flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+      shell: bash
+    - name: summarize failing vmm tests
+      run: |-
         flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 5
+        flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 6
         flowey.exe e 23 flowey_lib_common::publish_test_results 0
         flowey.exe e 23 flowey_lib_common::publish_test_results 1
         flowey.exe v 23 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
@@ -5068,7 +5122,7 @@ jobs:
       name: 'publish test results: x64-windows-amd-snp-vmm-tests (logs)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 6
+      run: flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 7
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
       run: flowey.exe e 23 flowey_lib_common::cache 3
@@ -5127,8 +5181,59 @@ jobs:
         echo "$AgentTempDirNormal/used_artifacts/x64-tmks" | flowey v 24 'artifact_use_from_x64-tmks' --is-raw-string update
         echo "$AgentTempDirNormal/used_artifacts/x64-windows-pipette" | flowey v 24 'artifact_use_from_x64-windows-pipette' --is-raw-string update
       shell: bash
-    - name: checking if packages need to be installed
+    - name: create cargo-nextest cache dir
       run: |-
+        flowey e 24 flowey_lib_common::download_cargo_nextest 0
+        flowey e 24 flowey_lib_common::download_cargo_nextest 1
+        flowey e 24 flowey_lib_common::download_cargo_nextest 2
+        flowey e 24 flowey_lib_common::download_cargo_nextest 3
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 24 flowey_lib_common::cache 0
+        flowey v 24 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
+        flowey v 24 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25
+      with:
+        key: ${{ env.floweyvar4 }}
+        path: ${{ env.floweyvar5 }}
+      name: 'Restore cache: cargo-nextest'
+    - name: downloading cargo-nextest
+      run: |-
+        flowey v 24 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey e 24 flowey_lib_common::cache 2
+        flowey e 24 flowey_lib_common::download_cargo_nextest 4
+      shell: bash
+    - name: check if openvmm needs to be cloned
+      run: |-
+        flowey e 24 flowey_lib_common::git_checkout 0
+        flowey v 24 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar3
+        flowey v 24 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__git_checkout__1
+      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
+      with:
+        fetch-depth: '1'
+        path: repo0
+        persist-credentials: ${{ env.floweyvar3 }}
+      name: checkout repo openvmm
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report cloned repo directories
+      run: |-
+        flowey v 24 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
+        ${{ github.workspace }}
+        EOF
+        flowey e 24 flowey_lib_common::git_checkout 3
+      shell: bash
+    - name: print system info
+      run: |-
+        flowey e 24 flowey_lib_common::system_info 0
+        flowey e 24 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
         flowey e 24 flowey_core::pipeline::artifact::resolve 8
         flowey e 24 flowey_core::pipeline::artifact::resolve 2
         flowey e 24 flowey_core::pipeline::artifact::resolve 3
@@ -5140,7 +5245,9 @@ jobs:
         ${{ runner.temp }}
         EOF
         flowey e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
-        flowey e 24 flowey_lib_common::install_dist_pkg 0
+      shell: bash
+    - name: checking if packages need to be installed
+      run: flowey e 24 flowey_lib_common::install_dist_pkg 0
       shell: bash
     - name: installing packages
       run: flowey e 24 flowey_lib_common::install_dist_pkg 1
@@ -5229,96 +5336,36 @@ jobs:
       run: flowey e 24 flowey_lib_hvlite::resolve_openvmm_test_virtio_win 0
       shell: bash
     - name: setting up vmm_tests env
-      run: flowey e 24 flowey_lib_hvlite::init_vmm_tests_env 0
-      shell: bash
-    - name: ensure hypervisor device is accessible
-      run: flowey e 24 flowey_lib_hvlite::test_nextest_vmm_tests_archive 1
-      shell: bash
-    - name: ensure 2 MiB hugetlb pages are available
-      run: flowey e 24 flowey_lib_hvlite::test_nextest_vmm_tests_archive 2
-      shell: bash
-    - name: prepare vhost-vsock
-      run: flowey e 24 flowey_lib_hvlite::test_nextest_vmm_tests_archive 3
-      shell: bash
-    - name: create cargo-nextest cache dir
       run: |-
-        flowey e 24 flowey_lib_common::download_cargo_nextest 0
-        flowey e 24 flowey_lib_common::download_cargo_nextest 1
-        flowey e 24 flowey_lib_common::download_cargo_nextest 2
-        flowey e 24 flowey_lib_common::download_cargo_nextest 3
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 24 flowey_lib_common::cache 0
-        flowey v 24 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
-        flowey v 24 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
-      shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25
-      with:
-        key: ${{ env.floweyvar4 }}
-        path: ${{ env.floweyvar5 }}
-      name: 'Restore cache: cargo-nextest'
-    - name: downloading cargo-nextest
-      run: |-
-        flowey v 24 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey e 24 flowey_lib_common::cache 2
-        flowey e 24 flowey_lib_common::download_cargo_nextest 4
-      shell: bash
-    - name: check if openvmm needs to be cloned
-      run: |-
-        flowey e 24 flowey_lib_common::git_checkout 0
-        flowey v 24 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar3
-        flowey v 24 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__git_checkout__1
-      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
-      with:
-        fetch-depth: '1'
-        path: repo0
-        persist-credentials: ${{ env.floweyvar3 }}
-      name: checkout repo openvmm
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report cloned repo directories
-      run: |-
-        flowey v 24 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
-        ${{ github.workspace }}
-        EOF
-        flowey e 24 flowey_lib_common::git_checkout 3
-      shell: bash
-    - name: print system info
-      run: |-
-        flowey e 24 flowey_lib_common::system_info 0
-        flowey e 24 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 24 flowey_lib_hvlite::init_vmm_tests_env 0
         flowey e 24 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey e 24 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
-        flowey e 24 flowey_lib_hvlite::run_cargo_nextest_run 1
         flowey e 24 flowey_core::pipeline::artifact::resolve 6
-        flowey e 24 flowey_lib_hvlite::test_nextest_vmm_tests_archive 4
+        flowey e 24 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 24 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-      shell: bash
-    - name: install vmm tests deps (linux)
       run: |-
-        flowey e 24 flowey_lib_hvlite::install_vmm_tests_deps 0
+        flowey e 24 flowey_lib_common::gen_cargo_nextest_run_cmd 0
         flowey e 24 flowey_core::pipeline::artifact::resolve 5
       shell: bash
     - name: running vmm_test prep_steps
       run: flowey e 24 flowey_lib_hvlite::run_prep_steps 0
       shell: bash
+    - name: install vmm tests deps (linux)
+      run: flowey e 24 flowey_lib_hvlite::install_vmm_tests_deps 0
+      shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
         flowey e 24 flowey_lib_common::run_cargo_nextest_run 0
         flowey e 24 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+        flowey e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+      shell: bash
+    - name: rename and create new log dir
+      run: flowey e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
       shell: bash
     - name: summarize failing vmm tests
       run: |-
-        flowey e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
-        flowey e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+        flowey e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 5
+        flowey e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 6
         flowey e 24 flowey_lib_common::publish_test_results 0
         flowey e 24 flowey_lib_common::publish_test_results 1
         flowey v 24 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
@@ -5346,7 +5393,7 @@ jobs:
       name: 'publish test results: x64-linux-amd-kvm-vmm-tests (logs)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: flowey e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 5
+      run: flowey e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 7
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
       run: flowey e 24 flowey_lib_common::cache 3
@@ -5453,8 +5500,59 @@ jobs:
         echo "$AgentTempDirNormal/used_artifacts/x64-tmks" | flowey v 25 'artifact_use_from_x64-tmks' --is-raw-string update
         echo "$AgentTempDirNormal/used_artifacts/x64-windows-pipette" | flowey v 25 'artifact_use_from_x64-windows-pipette' --is-raw-string update
       shell: bash
-    - name: checking if packages need to be installed
+    - name: create cargo-nextest cache dir
       run: |-
+        flowey e 25 flowey_lib_common::download_cargo_nextest 0
+        flowey e 25 flowey_lib_common::download_cargo_nextest 1
+        flowey e 25 flowey_lib_common::download_cargo_nextest 2
+        flowey e 25 flowey_lib_common::download_cargo_nextest 3
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 25 flowey_lib_common::cache 0
+        flowey v 25 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
+        flowey v 25 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25
+      with:
+        key: ${{ env.floweyvar4 }}
+        path: ${{ env.floweyvar5 }}
+      name: 'Restore cache: cargo-nextest'
+    - name: downloading cargo-nextest
+      run: |-
+        flowey v 25 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey e 25 flowey_lib_common::cache 2
+        flowey e 25 flowey_lib_common::download_cargo_nextest 4
+      shell: bash
+    - name: check if openvmm needs to be cloned
+      run: |-
+        flowey e 25 flowey_lib_common::git_checkout 0
+        flowey v 25 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar3
+        flowey v 25 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__git_checkout__1
+      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
+      with:
+        fetch-depth: '1'
+        path: repo0
+        persist-credentials: ${{ env.floweyvar3 }}
+      name: checkout repo openvmm
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report cloned repo directories
+      run: |-
+        flowey v 25 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
+        ${{ github.workspace }}
+        EOF
+        flowey e 25 flowey_lib_common::git_checkout 3
+      shell: bash
+    - name: print system info
+      run: |-
+        flowey e 25 flowey_lib_common::system_info 0
+        flowey e 25 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
         flowey e 25 flowey_core::pipeline::artifact::resolve 8
         flowey e 25 flowey_core::pipeline::artifact::resolve 4
         flowey e 25 flowey_core::pipeline::artifact::resolve 1
@@ -5466,7 +5564,9 @@ jobs:
         ${{ runner.temp }}
         EOF
         flowey e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
-        flowey e 25 flowey_lib_common::install_dist_pkg 0
+      shell: bash
+    - name: checking if packages need to be installed
+      run: flowey e 25 flowey_lib_common::install_dist_pkg 0
       shell: bash
     - name: installing packages
       run: flowey e 25 flowey_lib_common::install_dist_pkg 1
@@ -5555,92 +5655,36 @@ jobs:
       run: flowey e 25 flowey_lib_hvlite::resolve_openvmm_test_virtio_win 0
       shell: bash
     - name: setting up vmm_tests env
-      run: flowey e 25 flowey_lib_hvlite::init_vmm_tests_env 0
-      shell: bash
-    - name: ensure hypervisor device is accessible
-      run: flowey e 25 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
-      shell: bash
-    - name: prepare vhost-vsock
-      run: flowey e 25 flowey_lib_hvlite::test_nextest_vmm_tests_archive 1
-      shell: bash
-    - name: create cargo-nextest cache dir
       run: |-
-        flowey e 25 flowey_lib_common::download_cargo_nextest 0
-        flowey e 25 flowey_lib_common::download_cargo_nextest 1
-        flowey e 25 flowey_lib_common::download_cargo_nextest 2
-        flowey e 25 flowey_lib_common::download_cargo_nextest 3
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 25 flowey_lib_common::cache 0
-        flowey v 25 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
-        flowey v 25 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
-      shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25
-      with:
-        key: ${{ env.floweyvar4 }}
-        path: ${{ env.floweyvar5 }}
-      name: 'Restore cache: cargo-nextest'
-    - name: downloading cargo-nextest
-      run: |-
-        flowey v 25 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey e 25 flowey_lib_common::cache 2
-        flowey e 25 flowey_lib_common::download_cargo_nextest 4
-      shell: bash
-    - name: check if openvmm needs to be cloned
-      run: |-
-        flowey e 25 flowey_lib_common::git_checkout 0
-        flowey v 25 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar3
-        flowey v 25 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__git_checkout__1
-      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
-      with:
-        fetch-depth: '1'
-        path: repo0
-        persist-credentials: ${{ env.floweyvar3 }}
-      name: checkout repo openvmm
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report cloned repo directories
-      run: |-
-        flowey v 25 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
-        ${{ github.workspace }}
-        EOF
-        flowey e 25 flowey_lib_common::git_checkout 3
-      shell: bash
-    - name: print system info
-      run: |-
-        flowey e 25 flowey_lib_common::system_info 0
-        flowey e 25 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 25 flowey_lib_hvlite::init_vmm_tests_env 0
         flowey e 25 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey e 25 flowey_lib_hvlite::run_cargo_nextest_run 1
         flowey e 25 flowey_core::pipeline::artifact::resolve 5
-        flowey e 25 flowey_lib_hvlite::test_nextest_vmm_tests_archive 2
+        flowey e 25 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 25 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-      shell: bash
-    - name: install vmm tests deps (linux)
       run: |-
-        flowey e 25 flowey_lib_hvlite::install_vmm_tests_deps 0
+        flowey e 25 flowey_lib_common::gen_cargo_nextest_run_cmd 0
         flowey e 25 flowey_core::pipeline::artifact::resolve 6
       shell: bash
     - name: running vmm_test prep_steps
       run: flowey e 25 flowey_lib_hvlite::run_prep_steps 0
       shell: bash
+    - name: install vmm tests deps (linux)
+      run: flowey e 25 flowey_lib_hvlite::install_vmm_tests_deps 0
+      shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
         flowey e 25 flowey_lib_common::run_cargo_nextest_run 0
         flowey e 25 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+        flowey e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+      shell: bash
+    - name: rename and create new log dir
+      run: flowey e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
       shell: bash
     - name: summarize failing vmm tests
       run: |-
-        flowey e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
-        flowey e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+        flowey e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 5
+        flowey e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 6
         flowey e 25 flowey_lib_common::publish_test_results 0
         flowey e 25 flowey_lib_common::publish_test_results 1
         flowey v 25 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
@@ -5668,7 +5712,7 @@ jobs:
       name: 'publish test results: x64-linux-intel-mshv-vmm-tests (logs)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: flowey e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 5
+      run: flowey e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 7
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
       run: flowey e 25 flowey_lib_common::cache 3
@@ -5779,8 +5823,59 @@ jobs:
         echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmgstool-dev" | flowey.exe v 26 'artifact_use_from_aarch64-windows-vmgstool-dev' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmm-tests-archive" | flowey.exe v 26 'artifact_use_from_aarch64-windows-vmm-tests-archive' --is-raw-string update
       shell: bash
-    - name: create gh-release-download cache dir
+    - name: create cargo-nextest cache dir
       run: |-
+        flowey.exe e 26 flowey_lib_common::download_cargo_nextest 0
+        flowey.exe e 26 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 26 flowey_lib_common::download_cargo_nextest 2
+        flowey.exe e 26 flowey_lib_common::download_cargo_nextest 3
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey.exe e 26 flowey_lib_common::cache 0
+        flowey.exe v 26 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 26 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25
+      with:
+        key: ${{ env.floweyvar4 }}
+        path: ${{ env.floweyvar5 }}
+      name: 'Restore cache: cargo-nextest'
+    - name: downloading cargo-nextest
+      run: |-
+        flowey.exe v 26 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey.exe e 26 flowey_lib_common::cache 2
+        flowey.exe e 26 flowey_lib_common::download_cargo_nextest 4
+      shell: bash
+    - name: check if openvmm needs to be cloned
+      run: |-
+        flowey.exe e 26 flowey_lib_common::git_checkout 0
+        flowey.exe v 26 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar3
+        flowey.exe v 26 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__git_checkout__1
+      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
+      with:
+        fetch-depth: '1'
+        path: repo0
+        persist-credentials: ${{ env.floweyvar3 }}
+      name: checkout repo openvmm
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report cloned repo directories
+      run: |-
+        flowey.exe v 26 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
+        ${{ github.workspace }}
+        EOF
+        flowey.exe e 26 flowey_lib_common::git_checkout 3
+      shell: bash
+    - name: print system info
+      run: |-
+        flowey.exe e 26 flowey_lib_common::system_info 0
+        flowey.exe e 26 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey.exe e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
         flowey.exe e 26 flowey_core::pipeline::artifact::resolve 5
         flowey.exe e 26 flowey_core::pipeline::artifact::resolve 6
         flowey.exe e 26 flowey_core::pipeline::artifact::resolve 7
@@ -5795,7 +5890,9 @@ jobs:
         ${{ runner.temp }}
         EOF
         flowey.exe e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
-        flowey.exe e 26 flowey_lib_common::download_gh_release 0
+      shell: bash
+    - name: create gh-release-download cache dir
+      run: flowey.exe e 26 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
@@ -5878,89 +5975,38 @@ jobs:
       run: flowey.exe e 26 flowey_lib_hvlite::resolve_openvmm_test_virtio_win 0
       shell: bash
     - name: setting up vmm_tests env
-      run: flowey.exe e 26 flowey_lib_hvlite::init_vmm_tests_env 0
-      shell: bash
-    - name: create cargo-nextest cache dir
       run: |-
-        flowey.exe e 26 flowey_lib_common::download_cargo_nextest 0
-        flowey.exe e 26 flowey_lib_common::download_cargo_nextest 1
-        flowey.exe e 26 flowey_lib_common::download_cargo_nextest 2
-        flowey.exe e 26 flowey_lib_common::download_cargo_nextest 3
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey.exe e 26 flowey_lib_common::cache 0
-        flowey.exe v 26 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 26 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
-      shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25
-      with:
-        key: ${{ env.floweyvar4 }}
-        path: ${{ env.floweyvar5 }}
-      name: 'Restore cache: cargo-nextest'
-    - name: downloading cargo-nextest
-      run: |-
-        flowey.exe v 26 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey.exe e 26 flowey_lib_common::cache 2
-        flowey.exe e 26 flowey_lib_common::download_cargo_nextest 4
-      shell: bash
-    - name: check if openvmm needs to be cloned
-      run: |-
-        flowey.exe e 26 flowey_lib_common::git_checkout 0
-        flowey.exe v 26 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar3
-        flowey.exe v 26 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__git_checkout__1
-      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
-      with:
-        fetch-depth: '1'
-        path: repo0
-        persist-credentials: ${{ env.floweyvar3 }}
-      name: checkout repo openvmm
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report cloned repo directories
-      run: |-
-        flowey.exe v 26 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
-        ${{ github.workspace }}
-        EOF
-        flowey.exe e 26 flowey_lib_common::git_checkout 3
-      shell: bash
-    - name: print system info
-      run: |-
-        flowey.exe e 26 flowey_lib_common::system_info 0
-        flowey.exe e 26 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey.exe e 26 flowey_lib_hvlite::init_vmm_tests_env 0
         flowey.exe e 26 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey.exe e 26 flowey_lib_hvlite::run_cargo_nextest_run 1
         flowey.exe e 26 flowey_core::pipeline::artifact::resolve 10
         flowey.exe e 26 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: generate nextest command
       run: flowey.exe e 26 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
-    - name: install vmm tests deps (windows)
-      run: flowey.exe e 26 flowey_lib_hvlite::install_vmm_tests_deps 0
-      shell: bash
     - name: starting test_igvm_agent_rpc_server
       run: flowey.exe e 26 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+      shell: bash
+    - name: install vmm tests deps (windows)
+      run: flowey.exe e 26 flowey_lib_hvlite::install_vmm_tests_deps 0
       shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
         flowey.exe e 26 flowey_lib_common::run_cargo_nextest_run 0
         flowey.exe e 26 flowey_lib_common::run_cargo_nextest_run 1
-        flowey.exe e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
-      shell: bash
-    - name: summarize failing vmm tests
-      run: |-
-        flowey.exe e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
-        flowey.exe e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
       shell: bash
     - name: stopping test_igvm_agent_rpc_server
       run: |-
         flowey.exe e 26 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
+        flowey.exe e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+      shell: bash
+    - name: rename and create new log dir
+      run: flowey.exe e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+      shell: bash
+    - name: summarize failing vmm tests
+      run: |-
         flowey.exe e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 5
+        flowey.exe e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 6
         flowey.exe e 26 flowey_lib_common::publish_test_results 0
         flowey.exe e 26 flowey_lib_common::publish_test_results 1
         flowey.exe v 26 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
@@ -5988,7 +6034,7 @@ jobs:
       name: 'publish test results: aarch64-windows-vmm-tests (logs)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: flowey.exe e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 6
+      run: flowey.exe e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 7
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
       run: flowey.exe e 26 flowey_lib_common::cache 3
@@ -6044,9 +6090,6 @@ jobs:
         echo "$AgentTempDirNormal/used_artifacts/aarch64-tmks" | flowey v 27 'artifact_use_from_aarch64-tmks' --is-raw-string update
         echo "$AgentTempDirNormal/used_artifacts/x64-linux-incubator" | flowey v 27 'artifact_use_from_x64-linux-incubator' --is-raw-string update
       shell: bash
-    - name: ensure hypervisor device is accessible
-      run: flowey e 27 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
-      shell: bash
     - name: create cargo-nextest cache dir
       run: |-
         flowey e 27 flowey_lib_common::download_cargo_nextest 0
@@ -6099,7 +6142,7 @@ jobs:
       run: |-
         flowey e 27 flowey_lib_common::system_info 0
         flowey e 27 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+        flowey e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
       shell: bash
     - name: create gh-release-download cache dir
       run: flowey e 27 flowey_lib_common::download_gh_release 0
@@ -6124,12 +6167,18 @@ jobs:
         flowey e 27 flowey_lib_common::cache 10
         flowey e 27 flowey_lib_common::download_gh_release 1
       shell: bash
+    - name: unpack openvmm-test-linux archives
+      run: flowey e 27 flowey_lib_hvlite::resolve_openvmm_test_linux_kernel 0
+      shell: bash
+    - name: unpack openvmm-test-initrd archives
+      run: flowey e 27 flowey_lib_hvlite::resolve_openvmm_test_initrd 0
+      shell: bash
     - name: unpack QEMU archive
       run: |-
         flowey e 27 flowey_lib_hvlite::resolve_openvmm_qemu 0
         flowey e 27 flowey_core::pipeline::artifact::resolve 6
-        flowey e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
         flowey e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+        flowey e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
         flowey e 27 flowey_core::pipeline::artifact::resolve 4
         flowey e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 5
         flowey v 27 'flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:0:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source runner.temp <<EOF
@@ -6196,12 +6245,6 @@ jobs:
         flowey e 27 flowey_lib_common::download_gh_artifact 0
         flowey e 27 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
       shell: bash
-    - name: unpack openvmm-test-initrd archives
-      run: flowey e 27 flowey_lib_hvlite::resolve_openvmm_test_initrd 0
-      shell: bash
-    - name: unpack openvmm-test-linux archives
-      run: flowey e 27 flowey_lib_hvlite::resolve_openvmm_test_linux_kernel 0
-      shell: bash
     - name: unpack mu_msvm package (aarch64)
       run: flowey e 27 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
@@ -6214,16 +6257,14 @@ jobs:
     - name: compute incubator target runner env
       run: |-
         flowey e 27 flowey_lib_hvlite::write_incubator_target_runner 0
-        flowey e 27 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey e 27 flowey_lib_hvlite::test_nextest_vmm_tests_archive 1
+        flowey e 27 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey e 27 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: generate nextest command
       run: flowey e 27 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: install vmm tests deps (linux)
-      run: |-
-        flowey e 27 flowey_lib_hvlite::install_vmm_tests_deps 0
-        flowey e 27 flowey_lib_hvlite::run_cargo_nextest_run 0
+      run: flowey e 27 flowey_lib_hvlite::install_vmm_tests_deps 0
       shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
@@ -6231,10 +6272,13 @@ jobs:
         flowey e 27 flowey_lib_common::run_cargo_nextest_run 1
         flowey e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 6
       shell: bash
+    - name: rename and create new log dir
+      run: flowey e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 7
+      shell: bash
     - name: summarize failing vmm tests
       run: |-
-        flowey e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 7
         flowey e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 8
+        flowey e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 9
         flowey e 27 flowey_lib_common::publish_test_results 0
         flowey e 27 flowey_lib_common::publish_test_results 1
         flowey v 27 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
@@ -6262,7 +6306,7 @@ jobs:
       name: 'publish test results: aarch64-linux-tcg-vmm-tests (logs)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: flowey e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 9
+      run: flowey e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 10
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
       run: flowey e 27 flowey_lib_common::cache 3

--- a/.github/workflows/openvmm-ci.yaml
+++ b/.github/workflows/openvmm-ci.yaml
@@ -3730,14 +3730,16 @@ jobs:
         flowey.exe e 19 flowey_lib_common::gen_cargo_nextest_run_cmd 0
         flowey.exe e 19 flowey_core::pipeline::artifact::resolve 10
       shell: bash
+    - name: install vmm tests deps (windows)
+      run: |-
+        flowey.exe e 19 flowey_lib_hvlite::install_vmm_tests_deps 0
+        flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+      shell: bash
     - name: running vmm_test prep_steps
       run: flowey.exe e 19 flowey_lib_hvlite::run_prep_steps 0
       shell: bash
     - name: starting test_igvm_agent_rpc_server
       run: flowey.exe e 19 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
-      shell: bash
-    - name: install vmm tests deps (windows)
-      run: flowey.exe e 19 flowey_lib_hvlite::install_vmm_tests_deps 0
       shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
@@ -3747,15 +3749,15 @@ jobs:
     - name: stopping test_igvm_agent_rpc_server
       run: |-
         flowey.exe e 19 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
-        flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+        flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
       shell: bash
     - name: rename and create new log dir
-      run: flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+      run: flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 5
       shell: bash
     - name: summarize failing vmm tests
       run: |-
-        flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 5
         flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 6
+        flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 7
         flowey.exe e 19 flowey_lib_common::publish_test_results 0
         flowey.exe e 19 flowey_lib_common::publish_test_results 1
         flowey.exe v 19 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
@@ -3783,7 +3785,7 @@ jobs:
       name: 'publish test results: x64-windows-intel-vmm-tests (logs)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 7
+      run: flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 8
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
       run: flowey.exe e 19 flowey_lib_common::cache 3
@@ -4490,14 +4492,16 @@ jobs:
         flowey.exe e 21 flowey_lib_common::gen_cargo_nextest_run_cmd 0
         flowey.exe e 21 flowey_core::pipeline::artifact::resolve 10
       shell: bash
+    - name: install vmm tests deps (windows)
+      run: |-
+        flowey.exe e 21 flowey_lib_hvlite::install_vmm_tests_deps 0
+        flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+      shell: bash
     - name: running vmm_test prep_steps
       run: flowey.exe e 21 flowey_lib_hvlite::run_prep_steps 0
       shell: bash
     - name: starting test_igvm_agent_rpc_server
       run: flowey.exe e 21 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
-      shell: bash
-    - name: install vmm tests deps (windows)
-      run: flowey.exe e 21 flowey_lib_hvlite::install_vmm_tests_deps 0
       shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
@@ -4507,15 +4511,15 @@ jobs:
     - name: stopping test_igvm_agent_rpc_server
       run: |-
         flowey.exe e 21 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
-        flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+        flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
       shell: bash
     - name: rename and create new log dir
-      run: flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+      run: flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 5
       shell: bash
     - name: summarize failing vmm tests
       run: |-
-        flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 5
         flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 6
+        flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 7
         flowey.exe e 21 flowey_lib_common::publish_test_results 0
         flowey.exe e 21 flowey_lib_common::publish_test_results 1
         flowey.exe v 21 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
@@ -4543,7 +4547,7 @@ jobs:
       name: 'publish test results: x64-windows-intel-tdx-vmm-tests (logs)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 7
+      run: flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 8
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
       run: flowey.exe e 21 flowey_lib_common::cache 3
@@ -4779,14 +4783,16 @@ jobs:
         flowey.exe e 22 flowey_lib_common::gen_cargo_nextest_run_cmd 0
         flowey.exe e 22 flowey_core::pipeline::artifact::resolve 10
       shell: bash
+    - name: install vmm tests deps (windows)
+      run: |-
+        flowey.exe e 22 flowey_lib_hvlite::install_vmm_tests_deps 0
+        flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+      shell: bash
     - name: running vmm_test prep_steps
       run: flowey.exe e 22 flowey_lib_hvlite::run_prep_steps 0
       shell: bash
     - name: starting test_igvm_agent_rpc_server
       run: flowey.exe e 22 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
-      shell: bash
-    - name: install vmm tests deps (windows)
-      run: flowey.exe e 22 flowey_lib_hvlite::install_vmm_tests_deps 0
       shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
@@ -4796,15 +4802,15 @@ jobs:
     - name: stopping test_igvm_agent_rpc_server
       run: |-
         flowey.exe e 22 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
-        flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+        flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
       shell: bash
     - name: rename and create new log dir
-      run: flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+      run: flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 5
       shell: bash
     - name: summarize failing vmm tests
       run: |-
-        flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 5
         flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 6
+        flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 7
         flowey.exe e 22 flowey_lib_common::publish_test_results 0
         flowey.exe e 22 flowey_lib_common::publish_test_results 1
         flowey.exe v 22 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
@@ -4832,7 +4838,7 @@ jobs:
       name: 'publish test results: x64-windows-amd-vmm-tests (logs)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 7
+      run: flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 8
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
       run: flowey.exe e 22 flowey_lib_common::cache 3
@@ -5069,14 +5075,16 @@ jobs:
         flowey.exe e 23 flowey_lib_common::gen_cargo_nextest_run_cmd 0
         flowey.exe e 23 flowey_core::pipeline::artifact::resolve 10
       shell: bash
+    - name: install vmm tests deps (windows)
+      run: |-
+        flowey.exe e 23 flowey_lib_hvlite::install_vmm_tests_deps 0
+        flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+      shell: bash
     - name: running vmm_test prep_steps
       run: flowey.exe e 23 flowey_lib_hvlite::run_prep_steps 0
       shell: bash
     - name: starting test_igvm_agent_rpc_server
       run: flowey.exe e 23 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
-      shell: bash
-    - name: install vmm tests deps (windows)
-      run: flowey.exe e 23 flowey_lib_hvlite::install_vmm_tests_deps 0
       shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
@@ -5086,15 +5094,15 @@ jobs:
     - name: stopping test_igvm_agent_rpc_server
       run: |-
         flowey.exe e 23 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
-        flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+        flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
       shell: bash
     - name: rename and create new log dir
-      run: flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+      run: flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 5
       shell: bash
     - name: summarize failing vmm tests
       run: |-
-        flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 5
         flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 6
+        flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 7
         flowey.exe e 23 flowey_lib_common::publish_test_results 0
         flowey.exe e 23 flowey_lib_common::publish_test_results 1
         flowey.exe v 23 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
@@ -5122,7 +5130,7 @@ jobs:
       name: 'publish test results: x64-windows-amd-snp-vmm-tests (logs)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 7
+      run: flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 8
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
       run: flowey.exe e 23 flowey_lib_common::cache 3
@@ -5347,25 +5355,27 @@ jobs:
         flowey e 24 flowey_lib_common::gen_cargo_nextest_run_cmd 0
         flowey e 24 flowey_core::pipeline::artifact::resolve 5
       shell: bash
+    - name: install vmm tests deps (linux)
+      run: |-
+        flowey e 24 flowey_lib_hvlite::install_vmm_tests_deps 0
+        flowey e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+      shell: bash
     - name: running vmm_test prep_steps
       run: flowey e 24 flowey_lib_hvlite::run_prep_steps 0
-      shell: bash
-    - name: install vmm tests deps (linux)
-      run: flowey e 24 flowey_lib_hvlite::install_vmm_tests_deps 0
       shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
         flowey e 24 flowey_lib_common::run_cargo_nextest_run 0
         flowey e 24 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+        flowey e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
       shell: bash
     - name: rename and create new log dir
-      run: flowey e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+      run: flowey e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 5
       shell: bash
     - name: summarize failing vmm tests
       run: |-
-        flowey e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 5
         flowey e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 6
+        flowey e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 7
         flowey e 24 flowey_lib_common::publish_test_results 0
         flowey e 24 flowey_lib_common::publish_test_results 1
         flowey v 24 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
@@ -5393,7 +5403,7 @@ jobs:
       name: 'publish test results: x64-linux-amd-kvm-vmm-tests (logs)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: flowey e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 7
+      run: flowey e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 8
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
       run: flowey e 24 flowey_lib_common::cache 3
@@ -5666,25 +5676,27 @@ jobs:
         flowey e 25 flowey_lib_common::gen_cargo_nextest_run_cmd 0
         flowey e 25 flowey_core::pipeline::artifact::resolve 6
       shell: bash
+    - name: install vmm tests deps (linux)
+      run: |-
+        flowey e 25 flowey_lib_hvlite::install_vmm_tests_deps 0
+        flowey e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+      shell: bash
     - name: running vmm_test prep_steps
       run: flowey e 25 flowey_lib_hvlite::run_prep_steps 0
-      shell: bash
-    - name: install vmm tests deps (linux)
-      run: flowey e 25 flowey_lib_hvlite::install_vmm_tests_deps 0
       shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
         flowey e 25 flowey_lib_common::run_cargo_nextest_run 0
         flowey e 25 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+        flowey e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
       shell: bash
     - name: rename and create new log dir
-      run: flowey e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+      run: flowey e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 5
       shell: bash
     - name: summarize failing vmm tests
       run: |-
-        flowey e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 5
         flowey e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 6
+        flowey e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 7
         flowey e 25 flowey_lib_common::publish_test_results 0
         flowey e 25 flowey_lib_common::publish_test_results 1
         flowey v 25 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
@@ -5712,7 +5724,7 @@ jobs:
       name: 'publish test results: x64-linux-intel-mshv-vmm-tests (logs)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: flowey e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 7
+      run: flowey e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 8
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
       run: flowey e 25 flowey_lib_common::cache 3

--- a/.github/workflows/openvmm-pr-release.yaml
+++ b/.github/workflows/openvmm-pr-release.yaml
@@ -3500,14 +3500,16 @@ jobs:
         flowey.exe e 19 flowey_lib_common::gen_cargo_nextest_run_cmd 0
         flowey.exe e 19 flowey_core::pipeline::artifact::resolve 10
       shell: bash
+    - name: install vmm tests deps (windows)
+      run: |-
+        flowey.exe e 19 flowey_lib_hvlite::install_vmm_tests_deps 0
+        flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+      shell: bash
     - name: running vmm_test prep_steps
       run: flowey.exe e 19 flowey_lib_hvlite::run_prep_steps 0
       shell: bash
     - name: starting test_igvm_agent_rpc_server
       run: flowey.exe e 19 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
-      shell: bash
-    - name: install vmm tests deps (windows)
-      run: flowey.exe e 19 flowey_lib_hvlite::install_vmm_tests_deps 0
       shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
@@ -3517,15 +3519,15 @@ jobs:
     - name: stopping test_igvm_agent_rpc_server
       run: |-
         flowey.exe e 19 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
-        flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+        flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
       shell: bash
     - name: rename and create new log dir
-      run: flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+      run: flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 5
       shell: bash
     - name: summarize failing vmm tests
       run: |-
-        flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 5
         flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 6
+        flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 7
         flowey.exe e 19 flowey_lib_common::publish_test_results 0
         flowey.exe e 19 flowey_lib_common::publish_test_results 1
         flowey.exe v 19 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
@@ -3553,7 +3555,7 @@ jobs:
       name: 'publish test results: x64-windows-intel-vmm-tests (logs)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 7
+      run: flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 8
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
       run: flowey.exe e 19 flowey_lib_common::cache 3
@@ -4264,14 +4266,16 @@ jobs:
         flowey.exe e 21 flowey_lib_common::gen_cargo_nextest_run_cmd 0
         flowey.exe e 21 flowey_core::pipeline::artifact::resolve 10
       shell: bash
+    - name: install vmm tests deps (windows)
+      run: |-
+        flowey.exe e 21 flowey_lib_hvlite::install_vmm_tests_deps 0
+        flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+      shell: bash
     - name: running vmm_test prep_steps
       run: flowey.exe e 21 flowey_lib_hvlite::run_prep_steps 0
       shell: bash
     - name: starting test_igvm_agent_rpc_server
       run: flowey.exe e 21 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
-      shell: bash
-    - name: install vmm tests deps (windows)
-      run: flowey.exe e 21 flowey_lib_hvlite::install_vmm_tests_deps 0
       shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
@@ -4281,15 +4285,15 @@ jobs:
     - name: stopping test_igvm_agent_rpc_server
       run: |-
         flowey.exe e 21 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
-        flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+        flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
       shell: bash
     - name: rename and create new log dir
-      run: flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+      run: flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 5
       shell: bash
     - name: summarize failing vmm tests
       run: |-
-        flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 5
         flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 6
+        flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 7
         flowey.exe e 21 flowey_lib_common::publish_test_results 0
         flowey.exe e 21 flowey_lib_common::publish_test_results 1
         flowey.exe v 21 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
@@ -4317,7 +4321,7 @@ jobs:
       name: 'publish test results: x64-windows-intel-tdx-vmm-tests (logs)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 7
+      run: flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 8
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
       run: flowey.exe e 21 flowey_lib_common::cache 3
@@ -4554,14 +4558,16 @@ jobs:
         flowey.exe e 22 flowey_lib_common::gen_cargo_nextest_run_cmd 0
         flowey.exe e 22 flowey_core::pipeline::artifact::resolve 10
       shell: bash
+    - name: install vmm tests deps (windows)
+      run: |-
+        flowey.exe e 22 flowey_lib_hvlite::install_vmm_tests_deps 0
+        flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+      shell: bash
     - name: running vmm_test prep_steps
       run: flowey.exe e 22 flowey_lib_hvlite::run_prep_steps 0
       shell: bash
     - name: starting test_igvm_agent_rpc_server
       run: flowey.exe e 22 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
-      shell: bash
-    - name: install vmm tests deps (windows)
-      run: flowey.exe e 22 flowey_lib_hvlite::install_vmm_tests_deps 0
       shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
@@ -4571,15 +4577,15 @@ jobs:
     - name: stopping test_igvm_agent_rpc_server
       run: |-
         flowey.exe e 22 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
-        flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+        flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
       shell: bash
     - name: rename and create new log dir
-      run: flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+      run: flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 5
       shell: bash
     - name: summarize failing vmm tests
       run: |-
-        flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 5
         flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 6
+        flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 7
         flowey.exe e 22 flowey_lib_common::publish_test_results 0
         flowey.exe e 22 flowey_lib_common::publish_test_results 1
         flowey.exe v 22 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
@@ -4607,7 +4613,7 @@ jobs:
       name: 'publish test results: x64-windows-amd-vmm-tests (logs)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 7
+      run: flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 8
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
       run: flowey.exe e 22 flowey_lib_common::cache 3
@@ -4844,14 +4850,16 @@ jobs:
         flowey.exe e 23 flowey_lib_common::gen_cargo_nextest_run_cmd 0
         flowey.exe e 23 flowey_core::pipeline::artifact::resolve 10
       shell: bash
+    - name: install vmm tests deps (windows)
+      run: |-
+        flowey.exe e 23 flowey_lib_hvlite::install_vmm_tests_deps 0
+        flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+      shell: bash
     - name: running vmm_test prep_steps
       run: flowey.exe e 23 flowey_lib_hvlite::run_prep_steps 0
       shell: bash
     - name: starting test_igvm_agent_rpc_server
       run: flowey.exe e 23 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
-      shell: bash
-    - name: install vmm tests deps (windows)
-      run: flowey.exe e 23 flowey_lib_hvlite::install_vmm_tests_deps 0
       shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
@@ -4861,15 +4869,15 @@ jobs:
     - name: stopping test_igvm_agent_rpc_server
       run: |-
         flowey.exe e 23 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
-        flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+        flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
       shell: bash
     - name: rename and create new log dir
-      run: flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+      run: flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 5
       shell: bash
     - name: summarize failing vmm tests
       run: |-
-        flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 5
         flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 6
+        flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 7
         flowey.exe e 23 flowey_lib_common::publish_test_results 0
         flowey.exe e 23 flowey_lib_common::publish_test_results 1
         flowey.exe v 23 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
@@ -4897,7 +4905,7 @@ jobs:
       name: 'publish test results: x64-windows-amd-snp-vmm-tests (logs)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 7
+      run: flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 8
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
       run: flowey.exe e 23 flowey_lib_common::cache 3
@@ -5123,25 +5131,27 @@ jobs:
         flowey e 24 flowey_lib_common::gen_cargo_nextest_run_cmd 0
         flowey e 24 flowey_core::pipeline::artifact::resolve 5
       shell: bash
+    - name: install vmm tests deps (linux)
+      run: |-
+        flowey e 24 flowey_lib_hvlite::install_vmm_tests_deps 0
+        flowey e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+      shell: bash
     - name: running vmm_test prep_steps
       run: flowey e 24 flowey_lib_hvlite::run_prep_steps 0
-      shell: bash
-    - name: install vmm tests deps (linux)
-      run: flowey e 24 flowey_lib_hvlite::install_vmm_tests_deps 0
       shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
         flowey e 24 flowey_lib_common::run_cargo_nextest_run 0
         flowey e 24 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+        flowey e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
       shell: bash
     - name: rename and create new log dir
-      run: flowey e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+      run: flowey e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 5
       shell: bash
     - name: summarize failing vmm tests
       run: |-
-        flowey e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 5
         flowey e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 6
+        flowey e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 7
         flowey e 24 flowey_lib_common::publish_test_results 0
         flowey e 24 flowey_lib_common::publish_test_results 1
         flowey v 24 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
@@ -5169,7 +5179,7 @@ jobs:
       name: 'publish test results: x64-linux-amd-kvm-vmm-tests (logs)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: flowey e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 7
+      run: flowey e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 8
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
       run: flowey e 24 flowey_lib_common::cache 3
@@ -5443,25 +5453,27 @@ jobs:
         flowey e 25 flowey_lib_common::gen_cargo_nextest_run_cmd 0
         flowey e 25 flowey_core::pipeline::artifact::resolve 6
       shell: bash
+    - name: install vmm tests deps (linux)
+      run: |-
+        flowey e 25 flowey_lib_hvlite::install_vmm_tests_deps 0
+        flowey e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+      shell: bash
     - name: running vmm_test prep_steps
       run: flowey e 25 flowey_lib_hvlite::run_prep_steps 0
-      shell: bash
-    - name: install vmm tests deps (linux)
-      run: flowey e 25 flowey_lib_hvlite::install_vmm_tests_deps 0
       shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
         flowey e 25 flowey_lib_common::run_cargo_nextest_run 0
         flowey e 25 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+        flowey e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
       shell: bash
     - name: rename and create new log dir
-      run: flowey e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+      run: flowey e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 5
       shell: bash
     - name: summarize failing vmm tests
       run: |-
-        flowey e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 5
         flowey e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 6
+        flowey e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 7
         flowey e 25 flowey_lib_common::publish_test_results 0
         flowey e 25 flowey_lib_common::publish_test_results 1
         flowey v 25 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
@@ -5489,7 +5501,7 @@ jobs:
       name: 'publish test results: x64-linux-intel-mshv-vmm-tests (logs)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: flowey e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 7
+      run: flowey e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 8
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
       run: flowey e 25 flowey_lib_common::cache 3

--- a/.github/workflows/openvmm-pr-release.yaml
+++ b/.github/workflows/openvmm-pr-release.yaml
@@ -1487,7 +1487,9 @@ jobs:
       name: 'publish test results: x64-windows-unit-tests-base (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey.exe e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: |-
+        flowey.exe e 13 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey.exe e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: run 'x64-windows-unit-tests-crypto-native' nextest tests
       run: |-
@@ -1507,7 +1509,9 @@ jobs:
       name: 'publish test results: x64-windows-unit-tests-crypto-native (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey.exe e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      run: |-
+        flowey.exe e 13 flowey_lib_hvlite::run_cargo_nextest_run 2
+        flowey.exe e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
     - name: run 'x64-windows-unit-tests-crypto-rust' nextest tests
       run: |-
@@ -1713,7 +1717,7 @@ jobs:
       run: |-
         flowey e 14 flowey_lib_common::install_cargo_nextest 0
         flowey e 14 flowey_lib_hvlite::init_cross_build 0
-        flowey e 14 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey e 14 flowey_lib_hvlite::run_cargo_nextest_run 4
       shell: bash
     - name: generate nextest command
       run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 3
@@ -1736,7 +1740,9 @@ jobs:
       name: 'publish test results: x64-linux-unit-tests-crypto-rust (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      run: |-
+        flowey e 14 flowey_lib_hvlite::run_cargo_nextest_run 3
+        flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 2
       shell: bash
     - name: run 'x64-linux-unit-tests-crypto-openssl' nextest tests
       run: |-
@@ -1756,7 +1762,9 @@ jobs:
       name: 'publish test results: x64-linux-unit-tests-crypto-openssl (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: |-
+        flowey e 14 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: run 'x64-linux-unit-tests-crypto-all' nextest tests
       run: |-
@@ -1788,7 +1796,9 @@ jobs:
         flowey e 14 flowey_lib_hvlite::build_xtask 1
       shell: bash
     - name: determine unit test exclusions
-      run: flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 0
+      run: |-
+        flowey e 14 flowey_lib_hvlite::build_nextest_unit_tests 0
+        flowey e 14 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
       run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 4
@@ -1811,7 +1821,9 @@ jobs:
       name: 'publish test results: x64-linux-unit-tests-base (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      run: |-
+        flowey e 14 flowey_lib_hvlite::run_cargo_nextest_run 2
+        flowey e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
     - name: run 'x64-linux-unit-tests-crypto-native' nextest tests
       run: |-
@@ -2039,7 +2051,7 @@ jobs:
       run: |-
         flowey e 15 flowey_lib_common::install_cargo_nextest 0
         flowey e 15 flowey_lib_hvlite::init_cross_build 3
-        flowey e 15 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey e 15 flowey_lib_hvlite::run_cargo_nextest_run 4
       shell: bash
     - name: generate nextest command
       run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 3
@@ -2062,7 +2074,9 @@ jobs:
       name: 'publish test results: x64-linux-musl-unit-tests-crypto-rust (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      run: |-
+        flowey e 15 flowey_lib_hvlite::run_cargo_nextest_run 3
+        flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 2
       shell: bash
     - name: run 'x64-linux-musl-unit-tests-crypto-openssl' nextest tests
       run: |-
@@ -2082,7 +2096,9 @@ jobs:
       name: 'publish test results: x64-linux-musl-unit-tests-crypto-openssl (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 4
+      run: |-
+        flowey e 15 flowey_lib_hvlite::run_cargo_nextest_run 5
+        flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 4
       shell: bash
     - name: run 'x64-linux-musl-unit-tests-crypto-symcrypt' nextest tests
       run: |-
@@ -2102,7 +2118,9 @@ jobs:
       name: 'publish test results: x64-linux-musl-unit-tests-crypto-symcrypt (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: |-
+        flowey e 15 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: run 'x64-linux-musl-unit-tests-crypto-all' nextest tests
       run: |-
@@ -2134,7 +2152,9 @@ jobs:
         flowey e 15 flowey_lib_hvlite::build_xtask 1
       shell: bash
     - name: determine unit test exclusions
-      run: flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 0
+      run: |-
+        flowey e 15 flowey_lib_hvlite::build_nextest_unit_tests 0
+        flowey e 15 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
       run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 5
@@ -2157,7 +2177,9 @@ jobs:
       name: 'publish test results: x64-linux-musl-unit-tests-base (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      run: |-
+        flowey e 15 flowey_lib_hvlite::run_cargo_nextest_run 2
+        flowey e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
     - name: run 'x64-linux-musl-unit-tests-crypto-native' nextest tests
       run: |-
@@ -2431,7 +2453,9 @@ jobs:
       name: 'publish test results: aarch64-windows-unit-tests-base (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey.exe e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: |-
+        flowey.exe e 16 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey.exe e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: run 'aarch64-windows-unit-tests-crypto-native' nextest tests
       run: |-
@@ -2451,7 +2475,9 @@ jobs:
       name: 'publish test results: aarch64-windows-unit-tests-crypto-native (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey.exe e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      run: |-
+        flowey.exe e 16 flowey_lib_hvlite::run_cargo_nextest_run 2
+        flowey.exe e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
     - name: run 'aarch64-windows-unit-tests-crypto-rust' nextest tests
       run: |-
@@ -2709,7 +2735,7 @@ jobs:
       run: |-
         flowey e 17 flowey_lib_common::install_cargo_nextest 0
         flowey e 17 flowey_lib_hvlite::init_cross_build 1
-        flowey e 17 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey e 17 flowey_lib_hvlite::run_cargo_nextest_run 4
       shell: bash
     - name: generate nextest command
       run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 3
@@ -2732,7 +2758,9 @@ jobs:
       name: 'publish test results: aarch64-linux-unit-tests-crypto-rust (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      run: |-
+        flowey e 17 flowey_lib_hvlite::run_cargo_nextest_run 3
+        flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 2
       shell: bash
     - name: run 'aarch64-linux-unit-tests-crypto-openssl' nextest tests
       run: |-
@@ -2752,7 +2780,9 @@ jobs:
       name: 'publish test results: aarch64-linux-unit-tests-crypto-openssl (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: |-
+        flowey e 17 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: run 'aarch64-linux-unit-tests-crypto-all' nextest tests
       run: |-
@@ -2784,7 +2814,9 @@ jobs:
         flowey e 17 flowey_lib_hvlite::build_xtask 1
       shell: bash
     - name: determine unit test exclusions
-      run: flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 0
+      run: |-
+        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 0
+        flowey e 17 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
       run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 4
@@ -2807,7 +2839,9 @@ jobs:
       name: 'publish test results: aarch64-linux-unit-tests-base (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      run: |-
+        flowey e 17 flowey_lib_hvlite::run_cargo_nextest_run 2
+        flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
     - name: run 'aarch64-linux-unit-tests-crypto-native' nextest tests
       run: |-
@@ -3079,7 +3113,7 @@ jobs:
       run: |-
         flowey e 18 flowey_lib_common::install_cargo_nextest 0
         flowey e 18 flowey_lib_hvlite::init_cross_build 3
-        flowey e 18 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey e 18 flowey_lib_hvlite::run_cargo_nextest_run 4
       shell: bash
     - name: generate nextest command
       run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 3
@@ -3102,7 +3136,9 @@ jobs:
       name: 'publish test results: aarch64-linux-musl-unit-tests-crypto-rust (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      run: |-
+        flowey e 18 flowey_lib_hvlite::run_cargo_nextest_run 3
+        flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 2
       shell: bash
     - name: run 'aarch64-linux-musl-unit-tests-crypto-openssl' nextest tests
       run: |-
@@ -3122,7 +3158,9 @@ jobs:
       name: 'publish test results: aarch64-linux-musl-unit-tests-crypto-openssl (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 4
+      run: |-
+        flowey e 18 flowey_lib_hvlite::run_cargo_nextest_run 5
+        flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 4
       shell: bash
     - name: run 'aarch64-linux-musl-unit-tests-crypto-symcrypt' nextest tests
       run: |-
@@ -3142,7 +3180,9 @@ jobs:
       name: 'publish test results: aarch64-linux-musl-unit-tests-crypto-symcrypt (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: |-
+        flowey e 18 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: run 'aarch64-linux-musl-unit-tests-crypto-all' nextest tests
       run: |-
@@ -3174,7 +3214,9 @@ jobs:
         flowey e 18 flowey_lib_hvlite::build_xtask 1
       shell: bash
     - name: determine unit test exclusions
-      run: flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 0
+      run: |-
+        flowey e 18 flowey_lib_hvlite::build_nextest_unit_tests 0
+        flowey e 18 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
       run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 5
@@ -3197,7 +3239,9 @@ jobs:
       name: 'publish test results: aarch64-linux-musl-unit-tests-base (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      run: |-
+        flowey e 18 flowey_lib_hvlite::run_cargo_nextest_run 2
+        flowey e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
     - name: run 'aarch64-linux-musl-unit-tests-crypto-native' nextest tests
       run: |-
@@ -3340,7 +3384,7 @@ jobs:
       run: |-
         flowey.exe e 19 flowey_lib_common::system_info 0
         flowey.exe e 19 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey.exe e 19 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
         flowey.exe e 19 flowey_core::pipeline::artifact::resolve 8
         flowey.exe e 19 flowey_core::pipeline::artifact::resolve 9
         flowey.exe e 19 flowey_core::pipeline::artifact::resolve 12
@@ -3447,39 +3491,41 @@ jobs:
     - name: setting up vmm_tests env
       run: |-
         flowey.exe e 19 flowey_lib_hvlite::init_vmm_tests_env 0
-        flowey.exe e 19 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey.exe e 19 flowey_lib_hvlite::run_cargo_nextest_run 0
         flowey.exe e 19 flowey_core::pipeline::artifact::resolve 16
         flowey.exe e 19 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: generate nextest command
-      run: flowey.exe e 19 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-      shell: bash
-    - name: install vmm tests deps (windows)
-      run: flowey.exe e 19 flowey_lib_hvlite::install_vmm_tests_deps 0
-      shell: bash
-    - name: starting test_igvm_agent_rpc_server
       run: |-
-        flowey.exe e 19 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+        flowey.exe e 19 flowey_lib_common::gen_cargo_nextest_run_cmd 0
         flowey.exe e 19 flowey_core::pipeline::artifact::resolve 10
       shell: bash
     - name: running vmm_test prep_steps
       run: flowey.exe e 19 flowey_lib_hvlite::run_prep_steps 0
       shell: bash
+    - name: starting test_igvm_agent_rpc_server
+      run: flowey.exe e 19 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+      shell: bash
+    - name: install vmm tests deps (windows)
+      run: flowey.exe e 19 flowey_lib_hvlite::install_vmm_tests_deps 0
+      shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
         flowey.exe e 19 flowey_lib_common::run_cargo_nextest_run 0
         flowey.exe e 19 flowey_lib_common::run_cargo_nextest_run 1
-        flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
-      shell: bash
-    - name: summarize failing vmm tests
-      run: |-
-        flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
-        flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
       shell: bash
     - name: stopping test_igvm_agent_rpc_server
       run: |-
         flowey.exe e 19 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
+        flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+      shell: bash
+    - name: rename and create new log dir
+      run: flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+      shell: bash
+    - name: summarize failing vmm tests
+      run: |-
         flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 5
+        flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 6
         flowey.exe e 19 flowey_lib_common::publish_test_results 0
         flowey.exe e 19 flowey_lib_common::publish_test_results 1
         flowey.exe v 19 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
@@ -3507,7 +3553,7 @@ jobs:
       name: 'publish test results: x64-windows-intel-vmm-tests (logs)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 6
+      run: flowey.exe e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 7
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
       run: flowey.exe e 19 flowey_lib_common::cache 3
@@ -3764,8 +3810,59 @@ jobs:
         echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmgstool-dev" | flowey.exe v 20 'artifact_use_from_x64-windows-vmgstool-dev' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 20 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
       shell: bash
-    - name: create gh-release-download cache dir
+    - name: create cargo-nextest cache dir
       run: |-
+        flowey.exe e 20 flowey_lib_common::download_cargo_nextest 0
+        flowey.exe e 20 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 20 flowey_lib_common::download_cargo_nextest 2
+        flowey.exe e 20 flowey_lib_common::download_cargo_nextest 3
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey.exe e 20 flowey_lib_common::cache 0
+        flowey.exe v 20 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 20 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25
+      with:
+        key: ${{ env.floweyvar4 }}
+        path: ${{ env.floweyvar5 }}
+      name: 'Restore cache: cargo-nextest'
+    - name: downloading cargo-nextest
+      run: |-
+        flowey.exe v 20 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey.exe e 20 flowey_lib_common::cache 2
+        flowey.exe e 20 flowey_lib_common::download_cargo_nextest 4
+      shell: bash
+    - name: check if openvmm needs to be cloned
+      run: |-
+        flowey.exe e 20 flowey_lib_common::git_checkout 0
+        flowey.exe v 20 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar3
+        flowey.exe v 20 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__git_checkout__1
+      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
+      with:
+        fetch-depth: '1'
+        path: repo0
+        persist-credentials: ${{ env.floweyvar3 }}
+      name: checkout repo openvmm
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report cloned repo directories
+      run: |-
+        flowey.exe v 20 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
+        ${{ github.workspace }}
+        EOF
+        flowey.exe e 20 flowey_lib_common::git_checkout 3
+      shell: bash
+    - name: print system info
+      run: |-
+        flowey.exe e 20 flowey_lib_common::system_info 0
+        flowey.exe e 20 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey.exe e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
         flowey.exe e 20 flowey_core::pipeline::artifact::resolve 11
         flowey.exe e 20 flowey_core::pipeline::artifact::resolve 4
         flowey.exe e 20 flowey_core::pipeline::artifact::resolve 5
@@ -3785,7 +3882,9 @@ jobs:
         ${{ runner.temp }}
         EOF
         flowey.exe e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
-        flowey.exe e 20 flowey_lib_common::download_gh_release 0
+      shell: bash
+    - name: create gh-release-download cache dir
+      run: flowey.exe e 20 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
@@ -3868,89 +3967,38 @@ jobs:
       run: flowey.exe e 20 flowey_lib_hvlite::resolve_openvmm_test_virtio_win 0
       shell: bash
     - name: setting up vmm_tests env
-      run: flowey.exe e 20 flowey_lib_hvlite::init_vmm_tests_env 0
-      shell: bash
-    - name: create cargo-nextest cache dir
       run: |-
-        flowey.exe e 20 flowey_lib_common::download_cargo_nextest 0
-        flowey.exe e 20 flowey_lib_common::download_cargo_nextest 1
-        flowey.exe e 20 flowey_lib_common::download_cargo_nextest 2
-        flowey.exe e 20 flowey_lib_common::download_cargo_nextest 3
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey.exe e 20 flowey_lib_common::cache 0
-        flowey.exe v 20 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 20 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
-      shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25
-      with:
-        key: ${{ env.floweyvar4 }}
-        path: ${{ env.floweyvar5 }}
-      name: 'Restore cache: cargo-nextest'
-    - name: downloading cargo-nextest
-      run: |-
-        flowey.exe v 20 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey.exe e 20 flowey_lib_common::cache 2
-        flowey.exe e 20 flowey_lib_common::download_cargo_nextest 4
-      shell: bash
-    - name: check if openvmm needs to be cloned
-      run: |-
-        flowey.exe e 20 flowey_lib_common::git_checkout 0
-        flowey.exe v 20 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar3
-        flowey.exe v 20 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__git_checkout__1
-      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
-      with:
-        fetch-depth: '1'
-        path: repo0
-        persist-credentials: ${{ env.floweyvar3 }}
-      name: checkout repo openvmm
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report cloned repo directories
-      run: |-
-        flowey.exe v 20 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
-        ${{ github.workspace }}
-        EOF
-        flowey.exe e 20 flowey_lib_common::git_checkout 3
-      shell: bash
-    - name: print system info
-      run: |-
-        flowey.exe e 20 flowey_lib_common::system_info 0
-        flowey.exe e 20 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey.exe e 20 flowey_lib_hvlite::init_vmm_tests_env 0
         flowey.exe e 20 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey.exe e 20 flowey_lib_hvlite::run_cargo_nextest_run 1
         flowey.exe e 20 flowey_core::pipeline::artifact::resolve 16
         flowey.exe e 20 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: generate nextest command
       run: flowey.exe e 20 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
-    - name: install vmm tests deps (windows)
-      run: flowey.exe e 20 flowey_lib_hvlite::install_vmm_tests_deps 0
-      shell: bash
     - name: starting test_igvm_agent_rpc_server
       run: flowey.exe e 20 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+      shell: bash
+    - name: install vmm tests deps (windows)
+      run: flowey.exe e 20 flowey_lib_hvlite::install_vmm_tests_deps 0
       shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
         flowey.exe e 20 flowey_lib_common::run_cargo_nextest_run 0
         flowey.exe e 20 flowey_lib_common::run_cargo_nextest_run 1
-        flowey.exe e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
-      shell: bash
-    - name: summarize failing vmm tests
-      run: |-
-        flowey.exe e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
-        flowey.exe e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
       shell: bash
     - name: stopping test_igvm_agent_rpc_server
       run: |-
         flowey.exe e 20 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
+        flowey.exe e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+      shell: bash
+    - name: rename and create new log dir
+      run: flowey.exe e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+      shell: bash
+    - name: summarize failing vmm tests
+      run: |-
         flowey.exe e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 5
+        flowey.exe e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 6
         flowey.exe e 20 flowey_lib_common::publish_test_results 0
         flowey.exe e 20 flowey_lib_common::publish_test_results 1
         flowey.exe v 20 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
@@ -3978,7 +4026,7 @@ jobs:
       name: 'publish test results: x64-windows-intel-mi-secure-vmm-tests (logs)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: flowey.exe e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 6
+      run: flowey.exe e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 7
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
       run: flowey.exe e 20 flowey_lib_common::cache 3
@@ -4100,7 +4148,7 @@ jobs:
       run: |-
         flowey.exe e 21 flowey_lib_common::system_info 0
         flowey.exe e 21 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey.exe e 21 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
         flowey.exe e 21 flowey_core::pipeline::artifact::resolve 8
         flowey.exe e 21 flowey_core::pipeline::artifact::resolve 9
         flowey.exe e 21 flowey_core::pipeline::artifact::resolve 12
@@ -4207,39 +4255,41 @@ jobs:
     - name: setting up vmm_tests env
       run: |-
         flowey.exe e 21 flowey_lib_hvlite::init_vmm_tests_env 0
-        flowey.exe e 21 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey.exe e 21 flowey_lib_hvlite::run_cargo_nextest_run 0
         flowey.exe e 21 flowey_core::pipeline::artifact::resolve 16
         flowey.exe e 21 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: generate nextest command
-      run: flowey.exe e 21 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-      shell: bash
-    - name: install vmm tests deps (windows)
-      run: flowey.exe e 21 flowey_lib_hvlite::install_vmm_tests_deps 0
-      shell: bash
-    - name: starting test_igvm_agent_rpc_server
       run: |-
-        flowey.exe e 21 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+        flowey.exe e 21 flowey_lib_common::gen_cargo_nextest_run_cmd 0
         flowey.exe e 21 flowey_core::pipeline::artifact::resolve 10
       shell: bash
     - name: running vmm_test prep_steps
       run: flowey.exe e 21 flowey_lib_hvlite::run_prep_steps 0
       shell: bash
+    - name: starting test_igvm_agent_rpc_server
+      run: flowey.exe e 21 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+      shell: bash
+    - name: install vmm tests deps (windows)
+      run: flowey.exe e 21 flowey_lib_hvlite::install_vmm_tests_deps 0
+      shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
         flowey.exe e 21 flowey_lib_common::run_cargo_nextest_run 0
         flowey.exe e 21 flowey_lib_common::run_cargo_nextest_run 1
-        flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
-      shell: bash
-    - name: summarize failing vmm tests
-      run: |-
-        flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
-        flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
       shell: bash
     - name: stopping test_igvm_agent_rpc_server
       run: |-
         flowey.exe e 21 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
+        flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+      shell: bash
+    - name: rename and create new log dir
+      run: flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+      shell: bash
+    - name: summarize failing vmm tests
+      run: |-
         flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 5
+        flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 6
         flowey.exe e 21 flowey_lib_common::publish_test_results 0
         flowey.exe e 21 flowey_lib_common::publish_test_results 1
         flowey.exe v 21 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
@@ -4267,7 +4317,7 @@ jobs:
       name: 'publish test results: x64-windows-intel-tdx-vmm-tests (logs)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 6
+      run: flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 7
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
       run: flowey.exe e 21 flowey_lib_common::cache 3
@@ -4388,7 +4438,7 @@ jobs:
       run: |-
         flowey.exe e 22 flowey_lib_common::system_info 0
         flowey.exe e 22 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey.exe e 22 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
         flowey.exe e 22 flowey_core::pipeline::artifact::resolve 8
         flowey.exe e 22 flowey_core::pipeline::artifact::resolve 9
         flowey.exe e 22 flowey_core::pipeline::artifact::resolve 12
@@ -4495,39 +4545,41 @@ jobs:
     - name: setting up vmm_tests env
       run: |-
         flowey.exe e 22 flowey_lib_hvlite::init_vmm_tests_env 0
-        flowey.exe e 22 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey.exe e 22 flowey_lib_hvlite::run_cargo_nextest_run 0
         flowey.exe e 22 flowey_core::pipeline::artifact::resolve 16
         flowey.exe e 22 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: generate nextest command
-      run: flowey.exe e 22 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-      shell: bash
-    - name: install vmm tests deps (windows)
-      run: flowey.exe e 22 flowey_lib_hvlite::install_vmm_tests_deps 0
-      shell: bash
-    - name: starting test_igvm_agent_rpc_server
       run: |-
-        flowey.exe e 22 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+        flowey.exe e 22 flowey_lib_common::gen_cargo_nextest_run_cmd 0
         flowey.exe e 22 flowey_core::pipeline::artifact::resolve 10
       shell: bash
     - name: running vmm_test prep_steps
       run: flowey.exe e 22 flowey_lib_hvlite::run_prep_steps 0
       shell: bash
+    - name: starting test_igvm_agent_rpc_server
+      run: flowey.exe e 22 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+      shell: bash
+    - name: install vmm tests deps (windows)
+      run: flowey.exe e 22 flowey_lib_hvlite::install_vmm_tests_deps 0
+      shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
         flowey.exe e 22 flowey_lib_common::run_cargo_nextest_run 0
         flowey.exe e 22 flowey_lib_common::run_cargo_nextest_run 1
-        flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
-      shell: bash
-    - name: summarize failing vmm tests
-      run: |-
-        flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
-        flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
       shell: bash
     - name: stopping test_igvm_agent_rpc_server
       run: |-
         flowey.exe e 22 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
+        flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+      shell: bash
+    - name: rename and create new log dir
+      run: flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+      shell: bash
+    - name: summarize failing vmm tests
+      run: |-
         flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 5
+        flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 6
         flowey.exe e 22 flowey_lib_common::publish_test_results 0
         flowey.exe e 22 flowey_lib_common::publish_test_results 1
         flowey.exe v 22 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
@@ -4555,7 +4607,7 @@ jobs:
       name: 'publish test results: x64-windows-amd-vmm-tests (logs)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 6
+      run: flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 7
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
       run: flowey.exe e 22 flowey_lib_common::cache 3
@@ -4676,7 +4728,7 @@ jobs:
       run: |-
         flowey.exe e 23 flowey_lib_common::system_info 0
         flowey.exe e 23 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey.exe e 23 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
         flowey.exe e 23 flowey_core::pipeline::artifact::resolve 8
         flowey.exe e 23 flowey_core::pipeline::artifact::resolve 9
         flowey.exe e 23 flowey_core::pipeline::artifact::resolve 12
@@ -4783,39 +4835,41 @@ jobs:
     - name: setting up vmm_tests env
       run: |-
         flowey.exe e 23 flowey_lib_hvlite::init_vmm_tests_env 0
-        flowey.exe e 23 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey.exe e 23 flowey_lib_hvlite::run_cargo_nextest_run 0
         flowey.exe e 23 flowey_core::pipeline::artifact::resolve 16
         flowey.exe e 23 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: generate nextest command
-      run: flowey.exe e 23 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-      shell: bash
-    - name: install vmm tests deps (windows)
-      run: flowey.exe e 23 flowey_lib_hvlite::install_vmm_tests_deps 0
-      shell: bash
-    - name: starting test_igvm_agent_rpc_server
       run: |-
-        flowey.exe e 23 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+        flowey.exe e 23 flowey_lib_common::gen_cargo_nextest_run_cmd 0
         flowey.exe e 23 flowey_core::pipeline::artifact::resolve 10
       shell: bash
     - name: running vmm_test prep_steps
       run: flowey.exe e 23 flowey_lib_hvlite::run_prep_steps 0
       shell: bash
+    - name: starting test_igvm_agent_rpc_server
+      run: flowey.exe e 23 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+      shell: bash
+    - name: install vmm tests deps (windows)
+      run: flowey.exe e 23 flowey_lib_hvlite::install_vmm_tests_deps 0
+      shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
         flowey.exe e 23 flowey_lib_common::run_cargo_nextest_run 0
         flowey.exe e 23 flowey_lib_common::run_cargo_nextest_run 1
-        flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
-      shell: bash
-    - name: summarize failing vmm tests
-      run: |-
-        flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
-        flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
       shell: bash
     - name: stopping test_igvm_agent_rpc_server
       run: |-
         flowey.exe e 23 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
+        flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+      shell: bash
+    - name: rename and create new log dir
+      run: flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+      shell: bash
+    - name: summarize failing vmm tests
+      run: |-
         flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 5
+        flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 6
         flowey.exe e 23 flowey_lib_common::publish_test_results 0
         flowey.exe e 23 flowey_lib_common::publish_test_results 1
         flowey.exe v 23 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
@@ -4843,7 +4897,7 @@ jobs:
       name: 'publish test results: x64-windows-amd-snp-vmm-tests (logs)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 6
+      run: flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 7
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
       run: flowey.exe e 23 flowey_lib_common::cache 3
@@ -4903,8 +4957,59 @@ jobs:
         echo "$AgentTempDirNormal/used_artifacts/x64-tmks" | flowey v 24 'artifact_use_from_x64-tmks' --is-raw-string update
         echo "$AgentTempDirNormal/used_artifacts/x64-windows-pipette" | flowey v 24 'artifact_use_from_x64-windows-pipette' --is-raw-string update
       shell: bash
-    - name: checking if packages need to be installed
+    - name: create cargo-nextest cache dir
       run: |-
+        flowey e 24 flowey_lib_common::download_cargo_nextest 0
+        flowey e 24 flowey_lib_common::download_cargo_nextest 1
+        flowey e 24 flowey_lib_common::download_cargo_nextest 2
+        flowey e 24 flowey_lib_common::download_cargo_nextest 3
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 24 flowey_lib_common::cache 0
+        flowey v 24 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
+        flowey v 24 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25
+      with:
+        key: ${{ env.floweyvar4 }}
+        path: ${{ env.floweyvar5 }}
+      name: 'Restore cache: cargo-nextest'
+    - name: downloading cargo-nextest
+      run: |-
+        flowey v 24 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey e 24 flowey_lib_common::cache 2
+        flowey e 24 flowey_lib_common::download_cargo_nextest 4
+      shell: bash
+    - name: check if openvmm needs to be cloned
+      run: |-
+        flowey e 24 flowey_lib_common::git_checkout 0
+        flowey v 24 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar3
+        flowey v 24 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__git_checkout__1
+      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
+      with:
+        fetch-depth: '1'
+        path: repo0
+        persist-credentials: ${{ env.floweyvar3 }}
+      name: checkout repo openvmm
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report cloned repo directories
+      run: |-
+        flowey v 24 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
+        ${{ github.workspace }}
+        EOF
+        flowey e 24 flowey_lib_common::git_checkout 3
+      shell: bash
+    - name: print system info
+      run: |-
+        flowey e 24 flowey_lib_common::system_info 0
+        flowey e 24 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
         flowey e 24 flowey_core::pipeline::artifact::resolve 8
         flowey e 24 flowey_core::pipeline::artifact::resolve 2
         flowey e 24 flowey_core::pipeline::artifact::resolve 3
@@ -4916,7 +5021,9 @@ jobs:
         ${{ runner.temp }}
         EOF
         flowey e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
-        flowey e 24 flowey_lib_common::install_dist_pkg 0
+      shell: bash
+    - name: checking if packages need to be installed
+      run: flowey e 24 flowey_lib_common::install_dist_pkg 0
       shell: bash
     - name: installing packages
       run: flowey e 24 flowey_lib_common::install_dist_pkg 1
@@ -5005,96 +5112,36 @@ jobs:
       run: flowey e 24 flowey_lib_hvlite::resolve_openvmm_test_virtio_win 0
       shell: bash
     - name: setting up vmm_tests env
-      run: flowey e 24 flowey_lib_hvlite::init_vmm_tests_env 0
-      shell: bash
-    - name: ensure hypervisor device is accessible
-      run: flowey e 24 flowey_lib_hvlite::test_nextest_vmm_tests_archive 1
-      shell: bash
-    - name: ensure 2 MiB hugetlb pages are available
-      run: flowey e 24 flowey_lib_hvlite::test_nextest_vmm_tests_archive 2
-      shell: bash
-    - name: prepare vhost-vsock
-      run: flowey e 24 flowey_lib_hvlite::test_nextest_vmm_tests_archive 3
-      shell: bash
-    - name: create cargo-nextest cache dir
       run: |-
-        flowey e 24 flowey_lib_common::download_cargo_nextest 0
-        flowey e 24 flowey_lib_common::download_cargo_nextest 1
-        flowey e 24 flowey_lib_common::download_cargo_nextest 2
-        flowey e 24 flowey_lib_common::download_cargo_nextest 3
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 24 flowey_lib_common::cache 0
-        flowey v 24 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
-        flowey v 24 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
-      shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25
-      with:
-        key: ${{ env.floweyvar4 }}
-        path: ${{ env.floweyvar5 }}
-      name: 'Restore cache: cargo-nextest'
-    - name: downloading cargo-nextest
-      run: |-
-        flowey v 24 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey e 24 flowey_lib_common::cache 2
-        flowey e 24 flowey_lib_common::download_cargo_nextest 4
-      shell: bash
-    - name: check if openvmm needs to be cloned
-      run: |-
-        flowey e 24 flowey_lib_common::git_checkout 0
-        flowey v 24 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar3
-        flowey v 24 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__git_checkout__1
-      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
-      with:
-        fetch-depth: '1'
-        path: repo0
-        persist-credentials: ${{ env.floweyvar3 }}
-      name: checkout repo openvmm
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report cloned repo directories
-      run: |-
-        flowey v 24 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
-        ${{ github.workspace }}
-        EOF
-        flowey e 24 flowey_lib_common::git_checkout 3
-      shell: bash
-    - name: print system info
-      run: |-
-        flowey e 24 flowey_lib_common::system_info 0
-        flowey e 24 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 24 flowey_lib_hvlite::init_vmm_tests_env 0
         flowey e 24 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey e 24 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
-        flowey e 24 flowey_lib_hvlite::run_cargo_nextest_run 1
         flowey e 24 flowey_core::pipeline::artifact::resolve 6
-        flowey e 24 flowey_lib_hvlite::test_nextest_vmm_tests_archive 4
+        flowey e 24 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 24 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-      shell: bash
-    - name: install vmm tests deps (linux)
       run: |-
-        flowey e 24 flowey_lib_hvlite::install_vmm_tests_deps 0
+        flowey e 24 flowey_lib_common::gen_cargo_nextest_run_cmd 0
         flowey e 24 flowey_core::pipeline::artifact::resolve 5
       shell: bash
     - name: running vmm_test prep_steps
       run: flowey e 24 flowey_lib_hvlite::run_prep_steps 0
       shell: bash
+    - name: install vmm tests deps (linux)
+      run: flowey e 24 flowey_lib_hvlite::install_vmm_tests_deps 0
+      shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
         flowey e 24 flowey_lib_common::run_cargo_nextest_run 0
         flowey e 24 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+        flowey e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+      shell: bash
+    - name: rename and create new log dir
+      run: flowey e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
       shell: bash
     - name: summarize failing vmm tests
       run: |-
-        flowey e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
-        flowey e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+        flowey e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 5
+        flowey e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 6
         flowey e 24 flowey_lib_common::publish_test_results 0
         flowey e 24 flowey_lib_common::publish_test_results 1
         flowey v 24 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
@@ -5122,7 +5169,7 @@ jobs:
       name: 'publish test results: x64-linux-amd-kvm-vmm-tests (logs)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: flowey e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 5
+      run: flowey e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 7
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
       run: flowey e 24 flowey_lib_common::cache 3
@@ -5230,8 +5277,59 @@ jobs:
         echo "$AgentTempDirNormal/used_artifacts/x64-tmks" | flowey v 25 'artifact_use_from_x64-tmks' --is-raw-string update
         echo "$AgentTempDirNormal/used_artifacts/x64-windows-pipette" | flowey v 25 'artifact_use_from_x64-windows-pipette' --is-raw-string update
       shell: bash
-    - name: checking if packages need to be installed
+    - name: create cargo-nextest cache dir
       run: |-
+        flowey e 25 flowey_lib_common::download_cargo_nextest 0
+        flowey e 25 flowey_lib_common::download_cargo_nextest 1
+        flowey e 25 flowey_lib_common::download_cargo_nextest 2
+        flowey e 25 flowey_lib_common::download_cargo_nextest 3
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 25 flowey_lib_common::cache 0
+        flowey v 25 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
+        flowey v 25 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25
+      with:
+        key: ${{ env.floweyvar4 }}
+        path: ${{ env.floweyvar5 }}
+      name: 'Restore cache: cargo-nextest'
+    - name: downloading cargo-nextest
+      run: |-
+        flowey v 25 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey e 25 flowey_lib_common::cache 2
+        flowey e 25 flowey_lib_common::download_cargo_nextest 4
+      shell: bash
+    - name: check if openvmm needs to be cloned
+      run: |-
+        flowey e 25 flowey_lib_common::git_checkout 0
+        flowey v 25 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar3
+        flowey v 25 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__git_checkout__1
+      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
+      with:
+        fetch-depth: '1'
+        path: repo0
+        persist-credentials: ${{ env.floweyvar3 }}
+      name: checkout repo openvmm
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report cloned repo directories
+      run: |-
+        flowey v 25 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
+        ${{ github.workspace }}
+        EOF
+        flowey e 25 flowey_lib_common::git_checkout 3
+      shell: bash
+    - name: print system info
+      run: |-
+        flowey e 25 flowey_lib_common::system_info 0
+        flowey e 25 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
         flowey e 25 flowey_core::pipeline::artifact::resolve 8
         flowey e 25 flowey_core::pipeline::artifact::resolve 4
         flowey e 25 flowey_core::pipeline::artifact::resolve 1
@@ -5243,7 +5341,9 @@ jobs:
         ${{ runner.temp }}
         EOF
         flowey e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
-        flowey e 25 flowey_lib_common::install_dist_pkg 0
+      shell: bash
+    - name: checking if packages need to be installed
+      run: flowey e 25 flowey_lib_common::install_dist_pkg 0
       shell: bash
     - name: installing packages
       run: flowey e 25 flowey_lib_common::install_dist_pkg 1
@@ -5332,92 +5432,36 @@ jobs:
       run: flowey e 25 flowey_lib_hvlite::resolve_openvmm_test_virtio_win 0
       shell: bash
     - name: setting up vmm_tests env
-      run: flowey e 25 flowey_lib_hvlite::init_vmm_tests_env 0
-      shell: bash
-    - name: ensure hypervisor device is accessible
-      run: flowey e 25 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
-      shell: bash
-    - name: prepare vhost-vsock
-      run: flowey e 25 flowey_lib_hvlite::test_nextest_vmm_tests_archive 1
-      shell: bash
-    - name: create cargo-nextest cache dir
       run: |-
-        flowey e 25 flowey_lib_common::download_cargo_nextest 0
-        flowey e 25 flowey_lib_common::download_cargo_nextest 1
-        flowey e 25 flowey_lib_common::download_cargo_nextest 2
-        flowey e 25 flowey_lib_common::download_cargo_nextest 3
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 25 flowey_lib_common::cache 0
-        flowey v 25 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
-        flowey v 25 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
-      shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25
-      with:
-        key: ${{ env.floweyvar4 }}
-        path: ${{ env.floweyvar5 }}
-      name: 'Restore cache: cargo-nextest'
-    - name: downloading cargo-nextest
-      run: |-
-        flowey v 25 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey e 25 flowey_lib_common::cache 2
-        flowey e 25 flowey_lib_common::download_cargo_nextest 4
-      shell: bash
-    - name: check if openvmm needs to be cloned
-      run: |-
-        flowey e 25 flowey_lib_common::git_checkout 0
-        flowey v 25 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar3
-        flowey v 25 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__git_checkout__1
-      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
-      with:
-        fetch-depth: '1'
-        path: repo0
-        persist-credentials: ${{ env.floweyvar3 }}
-      name: checkout repo openvmm
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report cloned repo directories
-      run: |-
-        flowey v 25 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
-        ${{ github.workspace }}
-        EOF
-        flowey e 25 flowey_lib_common::git_checkout 3
-      shell: bash
-    - name: print system info
-      run: |-
-        flowey e 25 flowey_lib_common::system_info 0
-        flowey e 25 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 25 flowey_lib_hvlite::init_vmm_tests_env 0
         flowey e 25 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey e 25 flowey_lib_hvlite::run_cargo_nextest_run 1
         flowey e 25 flowey_core::pipeline::artifact::resolve 5
-        flowey e 25 flowey_lib_hvlite::test_nextest_vmm_tests_archive 2
+        flowey e 25 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 25 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-      shell: bash
-    - name: install vmm tests deps (linux)
       run: |-
-        flowey e 25 flowey_lib_hvlite::install_vmm_tests_deps 0
+        flowey e 25 flowey_lib_common::gen_cargo_nextest_run_cmd 0
         flowey e 25 flowey_core::pipeline::artifact::resolve 6
       shell: bash
     - name: running vmm_test prep_steps
       run: flowey e 25 flowey_lib_hvlite::run_prep_steps 0
       shell: bash
+    - name: install vmm tests deps (linux)
+      run: flowey e 25 flowey_lib_hvlite::install_vmm_tests_deps 0
+      shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
         flowey e 25 flowey_lib_common::run_cargo_nextest_run 0
         flowey e 25 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+        flowey e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+      shell: bash
+    - name: rename and create new log dir
+      run: flowey e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
       shell: bash
     - name: summarize failing vmm tests
       run: |-
-        flowey e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
-        flowey e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+        flowey e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 5
+        flowey e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 6
         flowey e 25 flowey_lib_common::publish_test_results 0
         flowey e 25 flowey_lib_common::publish_test_results 1
         flowey v 25 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
@@ -5445,7 +5489,7 @@ jobs:
       name: 'publish test results: x64-linux-intel-mshv-vmm-tests (logs)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: flowey e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 5
+      run: flowey e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 7
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
       run: flowey e 25 flowey_lib_common::cache 3
@@ -5557,8 +5601,59 @@ jobs:
         echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmgstool-dev" | flowey.exe v 26 'artifact_use_from_aarch64-windows-vmgstool-dev' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmm-tests-archive" | flowey.exe v 26 'artifact_use_from_aarch64-windows-vmm-tests-archive' --is-raw-string update
       shell: bash
-    - name: create gh-release-download cache dir
+    - name: create cargo-nextest cache dir
       run: |-
+        flowey.exe e 26 flowey_lib_common::download_cargo_nextest 0
+        flowey.exe e 26 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 26 flowey_lib_common::download_cargo_nextest 2
+        flowey.exe e 26 flowey_lib_common::download_cargo_nextest 3
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey.exe e 26 flowey_lib_common::cache 0
+        flowey.exe v 26 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 26 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25
+      with:
+        key: ${{ env.floweyvar4 }}
+        path: ${{ env.floweyvar5 }}
+      name: 'Restore cache: cargo-nextest'
+    - name: downloading cargo-nextest
+      run: |-
+        flowey.exe v 26 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey.exe e 26 flowey_lib_common::cache 2
+        flowey.exe e 26 flowey_lib_common::download_cargo_nextest 4
+      shell: bash
+    - name: check if openvmm needs to be cloned
+      run: |-
+        flowey.exe e 26 flowey_lib_common::git_checkout 0
+        flowey.exe v 26 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar3
+        flowey.exe v 26 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__git_checkout__1
+      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
+      with:
+        fetch-depth: '1'
+        path: repo0
+        persist-credentials: ${{ env.floweyvar3 }}
+      name: checkout repo openvmm
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report cloned repo directories
+      run: |-
+        flowey.exe v 26 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
+        ${{ github.workspace }}
+        EOF
+        flowey.exe e 26 flowey_lib_common::git_checkout 3
+      shell: bash
+    - name: print system info
+      run: |-
+        flowey.exe e 26 flowey_lib_common::system_info 0
+        flowey.exe e 26 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey.exe e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
         flowey.exe e 26 flowey_core::pipeline::artifact::resolve 5
         flowey.exe e 26 flowey_core::pipeline::artifact::resolve 6
         flowey.exe e 26 flowey_core::pipeline::artifact::resolve 7
@@ -5573,7 +5668,9 @@ jobs:
         ${{ runner.temp }}
         EOF
         flowey.exe e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
-        flowey.exe e 26 flowey_lib_common::download_gh_release 0
+      shell: bash
+    - name: create gh-release-download cache dir
+      run: flowey.exe e 26 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
@@ -5656,89 +5753,38 @@ jobs:
       run: flowey.exe e 26 flowey_lib_hvlite::resolve_openvmm_test_virtio_win 0
       shell: bash
     - name: setting up vmm_tests env
-      run: flowey.exe e 26 flowey_lib_hvlite::init_vmm_tests_env 0
-      shell: bash
-    - name: create cargo-nextest cache dir
       run: |-
-        flowey.exe e 26 flowey_lib_common::download_cargo_nextest 0
-        flowey.exe e 26 flowey_lib_common::download_cargo_nextest 1
-        flowey.exe e 26 flowey_lib_common::download_cargo_nextest 2
-        flowey.exe e 26 flowey_lib_common::download_cargo_nextest 3
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey.exe e 26 flowey_lib_common::cache 0
-        flowey.exe v 26 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 26 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
-      shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25
-      with:
-        key: ${{ env.floweyvar4 }}
-        path: ${{ env.floweyvar5 }}
-      name: 'Restore cache: cargo-nextest'
-    - name: downloading cargo-nextest
-      run: |-
-        flowey.exe v 26 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey.exe e 26 flowey_lib_common::cache 2
-        flowey.exe e 26 flowey_lib_common::download_cargo_nextest 4
-      shell: bash
-    - name: check if openvmm needs to be cloned
-      run: |-
-        flowey.exe e 26 flowey_lib_common::git_checkout 0
-        flowey.exe v 26 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar3
-        flowey.exe v 26 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__git_checkout__1
-      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
-      with:
-        fetch-depth: '1'
-        path: repo0
-        persist-credentials: ${{ env.floweyvar3 }}
-      name: checkout repo openvmm
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report cloned repo directories
-      run: |-
-        flowey.exe v 26 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
-        ${{ github.workspace }}
-        EOF
-        flowey.exe e 26 flowey_lib_common::git_checkout 3
-      shell: bash
-    - name: print system info
-      run: |-
-        flowey.exe e 26 flowey_lib_common::system_info 0
-        flowey.exe e 26 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey.exe e 26 flowey_lib_hvlite::init_vmm_tests_env 0
         flowey.exe e 26 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey.exe e 26 flowey_lib_hvlite::run_cargo_nextest_run 1
         flowey.exe e 26 flowey_core::pipeline::artifact::resolve 10
         flowey.exe e 26 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: generate nextest command
       run: flowey.exe e 26 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
-    - name: install vmm tests deps (windows)
-      run: flowey.exe e 26 flowey_lib_hvlite::install_vmm_tests_deps 0
-      shell: bash
     - name: starting test_igvm_agent_rpc_server
       run: flowey.exe e 26 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+      shell: bash
+    - name: install vmm tests deps (windows)
+      run: flowey.exe e 26 flowey_lib_hvlite::install_vmm_tests_deps 0
       shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
         flowey.exe e 26 flowey_lib_common::run_cargo_nextest_run 0
         flowey.exe e 26 flowey_lib_common::run_cargo_nextest_run 1
-        flowey.exe e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
-      shell: bash
-    - name: summarize failing vmm tests
-      run: |-
-        flowey.exe e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
-        flowey.exe e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
       shell: bash
     - name: stopping test_igvm_agent_rpc_server
       run: |-
         flowey.exe e 26 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
+        flowey.exe e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+      shell: bash
+    - name: rename and create new log dir
+      run: flowey.exe e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+      shell: bash
+    - name: summarize failing vmm tests
+      run: |-
         flowey.exe e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 5
+        flowey.exe e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 6
         flowey.exe e 26 flowey_lib_common::publish_test_results 0
         flowey.exe e 26 flowey_lib_common::publish_test_results 1
         flowey.exe v 26 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
@@ -5766,7 +5812,7 @@ jobs:
       name: 'publish test results: aarch64-windows-vmm-tests (logs)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: flowey.exe e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 6
+      run: flowey.exe e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 7
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
       run: flowey.exe e 26 flowey_lib_common::cache 3
@@ -5823,9 +5869,6 @@ jobs:
         echo "$AgentTempDirNormal/used_artifacts/aarch64-tmks" | flowey v 27 'artifact_use_from_aarch64-tmks' --is-raw-string update
         echo "$AgentTempDirNormal/used_artifacts/x64-linux-incubator" | flowey v 27 'artifact_use_from_x64-linux-incubator' --is-raw-string update
       shell: bash
-    - name: ensure hypervisor device is accessible
-      run: flowey e 27 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
-      shell: bash
     - name: create cargo-nextest cache dir
       run: |-
         flowey e 27 flowey_lib_common::download_cargo_nextest 0
@@ -5878,7 +5921,7 @@ jobs:
       run: |-
         flowey e 27 flowey_lib_common::system_info 0
         flowey e 27 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+        flowey e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
       shell: bash
     - name: create gh-release-download cache dir
       run: flowey e 27 flowey_lib_common::download_gh_release 0
@@ -5903,12 +5946,18 @@ jobs:
         flowey e 27 flowey_lib_common::cache 10
         flowey e 27 flowey_lib_common::download_gh_release 1
       shell: bash
+    - name: unpack openvmm-test-linux archives
+      run: flowey e 27 flowey_lib_hvlite::resolve_openvmm_test_linux_kernel 0
+      shell: bash
+    - name: unpack openvmm-test-initrd archives
+      run: flowey e 27 flowey_lib_hvlite::resolve_openvmm_test_initrd 0
+      shell: bash
     - name: unpack QEMU archive
       run: |-
         flowey e 27 flowey_lib_hvlite::resolve_openvmm_qemu 0
         flowey e 27 flowey_core::pipeline::artifact::resolve 6
-        flowey e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
         flowey e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+        flowey e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
         flowey e 27 flowey_core::pipeline::artifact::resolve 4
         flowey e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 5
         flowey v 27 'flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:0:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source runner.temp <<EOF
@@ -5975,12 +6024,6 @@ jobs:
         flowey e 27 flowey_lib_common::download_gh_artifact 0
         flowey e 27 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
       shell: bash
-    - name: unpack openvmm-test-initrd archives
-      run: flowey e 27 flowey_lib_hvlite::resolve_openvmm_test_initrd 0
-      shell: bash
-    - name: unpack openvmm-test-linux archives
-      run: flowey e 27 flowey_lib_hvlite::resolve_openvmm_test_linux_kernel 0
-      shell: bash
     - name: unpack mu_msvm package (aarch64)
       run: flowey e 27 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
@@ -5993,16 +6036,14 @@ jobs:
     - name: compute incubator target runner env
       run: |-
         flowey e 27 flowey_lib_hvlite::write_incubator_target_runner 0
-        flowey e 27 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey e 27 flowey_lib_hvlite::test_nextest_vmm_tests_archive 1
+        flowey e 27 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey e 27 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: generate nextest command
       run: flowey e 27 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: install vmm tests deps (linux)
-      run: |-
-        flowey e 27 flowey_lib_hvlite::install_vmm_tests_deps 0
-        flowey e 27 flowey_lib_hvlite::run_cargo_nextest_run 0
+      run: flowey e 27 flowey_lib_hvlite::install_vmm_tests_deps 0
       shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
@@ -6010,10 +6051,13 @@ jobs:
         flowey e 27 flowey_lib_common::run_cargo_nextest_run 1
         flowey e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 6
       shell: bash
+    - name: rename and create new log dir
+      run: flowey e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 7
+      shell: bash
     - name: summarize failing vmm tests
       run: |-
-        flowey e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 7
         flowey e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 8
+        flowey e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 9
         flowey e 27 flowey_lib_common::publish_test_results 0
         flowey e 27 flowey_lib_common::publish_test_results 1
         flowey v 27 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
@@ -6041,7 +6085,7 @@ jobs:
       name: 'publish test results: aarch64-linux-tcg-vmm-tests (logs)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: flowey e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 9
+      run: flowey e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 10
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
       run: flowey e 27 flowey_lib_common::cache 3

--- a/.github/workflows/openvmm-pr.yaml
+++ b/.github/workflows/openvmm-pr.yaml
@@ -4101,14 +4101,16 @@ jobs:
         flowey.exe e 21 flowey_lib_common::gen_cargo_nextest_run_cmd 0
         flowey.exe e 21 flowey_core::pipeline::artifact::resolve 10
       shell: bash
+    - name: install vmm tests deps (windows)
+      run: |-
+        flowey.exe e 21 flowey_lib_hvlite::install_vmm_tests_deps 0
+        flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+      shell: bash
     - name: running vmm_test prep_steps
       run: flowey.exe e 21 flowey_lib_hvlite::run_prep_steps 0
       shell: bash
     - name: starting test_igvm_agent_rpc_server
       run: flowey.exe e 21 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
-      shell: bash
-    - name: install vmm tests deps (windows)
-      run: flowey.exe e 21 flowey_lib_hvlite::install_vmm_tests_deps 0
       shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
@@ -4118,15 +4120,15 @@ jobs:
     - name: stopping test_igvm_agent_rpc_server
       run: |-
         flowey.exe e 21 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
-        flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+        flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
       shell: bash
     - name: rename and create new log dir
-      run: flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+      run: flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 5
       shell: bash
     - name: summarize failing vmm tests
       run: |-
-        flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 5
         flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 6
+        flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 7
         flowey.exe e 21 flowey_lib_common::publish_test_results 0
         flowey.exe e 21 flowey_lib_common::publish_test_results 1
         flowey.exe v 21 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
@@ -4154,7 +4156,7 @@ jobs:
       name: 'publish test results: x64-windows-intel-vmm-tests (logs)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 7
+      run: flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 8
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
       run: flowey.exe e 21 flowey_lib_common::cache 3
@@ -4677,14 +4679,16 @@ jobs:
         flowey.exe e 23 flowey_lib_common::gen_cargo_nextest_run_cmd 0
         flowey.exe e 23 flowey_core::pipeline::artifact::resolve 10
       shell: bash
+    - name: install vmm tests deps (windows)
+      run: |-
+        flowey.exe e 23 flowey_lib_hvlite::install_vmm_tests_deps 0
+        flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+      shell: bash
     - name: running vmm_test prep_steps
       run: flowey.exe e 23 flowey_lib_hvlite::run_prep_steps 0
       shell: bash
     - name: starting test_igvm_agent_rpc_server
       run: flowey.exe e 23 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
-      shell: bash
-    - name: install vmm tests deps (windows)
-      run: flowey.exe e 23 flowey_lib_hvlite::install_vmm_tests_deps 0
       shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
@@ -4694,15 +4698,15 @@ jobs:
     - name: stopping test_igvm_agent_rpc_server
       run: |-
         flowey.exe e 23 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
-        flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+        flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
       shell: bash
     - name: rename and create new log dir
-      run: flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+      run: flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 5
       shell: bash
     - name: summarize failing vmm tests
       run: |-
-        flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 5
         flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 6
+        flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 7
         flowey.exe e 23 flowey_lib_common::publish_test_results 0
         flowey.exe e 23 flowey_lib_common::publish_test_results 1
         flowey.exe v 23 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
@@ -4730,7 +4734,7 @@ jobs:
       name: 'publish test results: x64-windows-intel-tdx-vmm-tests (logs)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 7
+      run: flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 8
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
       run: flowey.exe e 23 flowey_lib_common::cache 3
@@ -4967,14 +4971,16 @@ jobs:
         flowey.exe e 24 flowey_lib_common::gen_cargo_nextest_run_cmd 0
         flowey.exe e 24 flowey_core::pipeline::artifact::resolve 10
       shell: bash
+    - name: install vmm tests deps (windows)
+      run: |-
+        flowey.exe e 24 flowey_lib_hvlite::install_vmm_tests_deps 0
+        flowey.exe e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+      shell: bash
     - name: running vmm_test prep_steps
       run: flowey.exe e 24 flowey_lib_hvlite::run_prep_steps 0
       shell: bash
     - name: starting test_igvm_agent_rpc_server
       run: flowey.exe e 24 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
-      shell: bash
-    - name: install vmm tests deps (windows)
-      run: flowey.exe e 24 flowey_lib_hvlite::install_vmm_tests_deps 0
       shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
@@ -4984,15 +4990,15 @@ jobs:
     - name: stopping test_igvm_agent_rpc_server
       run: |-
         flowey.exe e 24 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
-        flowey.exe e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+        flowey.exe e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
       shell: bash
     - name: rename and create new log dir
-      run: flowey.exe e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+      run: flowey.exe e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 5
       shell: bash
     - name: summarize failing vmm tests
       run: |-
-        flowey.exe e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 5
         flowey.exe e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 6
+        flowey.exe e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 7
         flowey.exe e 24 flowey_lib_common::publish_test_results 0
         flowey.exe e 24 flowey_lib_common::publish_test_results 1
         flowey.exe v 24 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
@@ -5020,7 +5026,7 @@ jobs:
       name: 'publish test results: x64-windows-amd-vmm-tests (logs)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: flowey.exe e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 7
+      run: flowey.exe e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 8
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
       run: flowey.exe e 24 flowey_lib_common::cache 3
@@ -5257,14 +5263,16 @@ jobs:
         flowey.exe e 25 flowey_lib_common::gen_cargo_nextest_run_cmd 0
         flowey.exe e 25 flowey_core::pipeline::artifact::resolve 10
       shell: bash
+    - name: install vmm tests deps (windows)
+      run: |-
+        flowey.exe e 25 flowey_lib_hvlite::install_vmm_tests_deps 0
+        flowey.exe e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+      shell: bash
     - name: running vmm_test prep_steps
       run: flowey.exe e 25 flowey_lib_hvlite::run_prep_steps 0
       shell: bash
     - name: starting test_igvm_agent_rpc_server
       run: flowey.exe e 25 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
-      shell: bash
-    - name: install vmm tests deps (windows)
-      run: flowey.exe e 25 flowey_lib_hvlite::install_vmm_tests_deps 0
       shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
@@ -5274,15 +5282,15 @@ jobs:
     - name: stopping test_igvm_agent_rpc_server
       run: |-
         flowey.exe e 25 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
-        flowey.exe e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+        flowey.exe e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
       shell: bash
     - name: rename and create new log dir
-      run: flowey.exe e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+      run: flowey.exe e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 5
       shell: bash
     - name: summarize failing vmm tests
       run: |-
-        flowey.exe e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 5
         flowey.exe e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 6
+        flowey.exe e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 7
         flowey.exe e 25 flowey_lib_common::publish_test_results 0
         flowey.exe e 25 flowey_lib_common::publish_test_results 1
         flowey.exe v 25 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
@@ -5310,7 +5318,7 @@ jobs:
       name: 'publish test results: x64-windows-amd-snp-vmm-tests (logs)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: flowey.exe e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 7
+      run: flowey.exe e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 8
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
       run: flowey.exe e 25 flowey_lib_common::cache 3
@@ -5536,25 +5544,27 @@ jobs:
         flowey e 26 flowey_lib_common::gen_cargo_nextest_run_cmd 0
         flowey e 26 flowey_core::pipeline::artifact::resolve 5
       shell: bash
+    - name: install vmm tests deps (linux)
+      run: |-
+        flowey e 26 flowey_lib_hvlite::install_vmm_tests_deps 0
+        flowey e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+      shell: bash
     - name: running vmm_test prep_steps
       run: flowey e 26 flowey_lib_hvlite::run_prep_steps 0
-      shell: bash
-    - name: install vmm tests deps (linux)
-      run: flowey e 26 flowey_lib_hvlite::install_vmm_tests_deps 0
       shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
         flowey e 26 flowey_lib_common::run_cargo_nextest_run 0
         flowey e 26 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+        flowey e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
       shell: bash
     - name: rename and create new log dir
-      run: flowey e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+      run: flowey e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 5
       shell: bash
     - name: summarize failing vmm tests
       run: |-
-        flowey e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 5
         flowey e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 6
+        flowey e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 7
         flowey e 26 flowey_lib_common::publish_test_results 0
         flowey e 26 flowey_lib_common::publish_test_results 1
         flowey v 26 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
@@ -5582,7 +5592,7 @@ jobs:
       name: 'publish test results: x64-linux-amd-kvm-vmm-tests (logs)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: flowey e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 7
+      run: flowey e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 8
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
       run: flowey e 26 flowey_lib_common::cache 3
@@ -5856,25 +5866,27 @@ jobs:
         flowey e 27 flowey_lib_common::gen_cargo_nextest_run_cmd 0
         flowey e 27 flowey_core::pipeline::artifact::resolve 6
       shell: bash
+    - name: install vmm tests deps (linux)
+      run: |-
+        flowey e 27 flowey_lib_hvlite::install_vmm_tests_deps 0
+        flowey e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+      shell: bash
     - name: running vmm_test prep_steps
       run: flowey e 27 flowey_lib_hvlite::run_prep_steps 0
-      shell: bash
-    - name: install vmm tests deps (linux)
-      run: flowey e 27 flowey_lib_hvlite::install_vmm_tests_deps 0
       shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
         flowey e 27 flowey_lib_common::run_cargo_nextest_run 0
         flowey e 27 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+        flowey e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
       shell: bash
     - name: rename and create new log dir
-      run: flowey e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+      run: flowey e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 5
       shell: bash
     - name: summarize failing vmm tests
       run: |-
-        flowey e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 5
         flowey e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 6
+        flowey e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 7
         flowey e 27 flowey_lib_common::publish_test_results 0
         flowey e 27 flowey_lib_common::publish_test_results 1
         flowey v 27 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
@@ -5902,7 +5914,7 @@ jobs:
       name: 'publish test results: x64-linux-intel-mshv-vmm-tests (logs)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: flowey e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 7
+      run: flowey e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 8
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
       run: flowey e 27 flowey_lib_common::cache 3

--- a/.github/workflows/openvmm-pr.yaml
+++ b/.github/workflows/openvmm-pr.yaml
@@ -1900,7 +1900,9 @@ jobs:
       name: 'publish test results: x64-windows-unit-tests-base (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey.exe e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: |-
+        flowey.exe e 15 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey.exe e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: run 'x64-windows-unit-tests-crypto-native' nextest tests
       run: |-
@@ -1920,7 +1922,9 @@ jobs:
       name: 'publish test results: x64-windows-unit-tests-crypto-native (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey.exe e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      run: |-
+        flowey.exe e 15 flowey_lib_hvlite::run_cargo_nextest_run 2
+        flowey.exe e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
     - name: run 'x64-windows-unit-tests-crypto-rust' nextest tests
       run: |-
@@ -2126,7 +2130,7 @@ jobs:
       run: |-
         flowey e 16 flowey_lib_common::install_cargo_nextest 0
         flowey e 16 flowey_lib_hvlite::init_cross_build 0
-        flowey e 16 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey e 16 flowey_lib_hvlite::run_cargo_nextest_run 4
       shell: bash
     - name: generate nextest command
       run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 3
@@ -2149,7 +2153,9 @@ jobs:
       name: 'publish test results: x64-linux-unit-tests-crypto-rust (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      run: |-
+        flowey e 16 flowey_lib_hvlite::run_cargo_nextest_run 3
+        flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 2
       shell: bash
     - name: run 'x64-linux-unit-tests-crypto-openssl' nextest tests
       run: |-
@@ -2169,7 +2175,9 @@ jobs:
       name: 'publish test results: x64-linux-unit-tests-crypto-openssl (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: |-
+        flowey e 16 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: run 'x64-linux-unit-tests-crypto-all' nextest tests
       run: |-
@@ -2201,7 +2209,9 @@ jobs:
         flowey e 16 flowey_lib_hvlite::build_xtask 1
       shell: bash
     - name: determine unit test exclusions
-      run: flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 0
+      run: |-
+        flowey e 16 flowey_lib_hvlite::build_nextest_unit_tests 0
+        flowey e 16 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
       run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 4
@@ -2224,7 +2234,9 @@ jobs:
       name: 'publish test results: x64-linux-unit-tests-base (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      run: |-
+        flowey e 16 flowey_lib_hvlite::run_cargo_nextest_run 2
+        flowey e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
     - name: run 'x64-linux-unit-tests-crypto-native' nextest tests
       run: |-
@@ -2452,7 +2464,7 @@ jobs:
       run: |-
         flowey e 17 flowey_lib_common::install_cargo_nextest 0
         flowey e 17 flowey_lib_hvlite::init_cross_build 3
-        flowey e 17 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey e 17 flowey_lib_hvlite::run_cargo_nextest_run 4
       shell: bash
     - name: generate nextest command
       run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 3
@@ -2475,7 +2487,9 @@ jobs:
       name: 'publish test results: x64-linux-musl-unit-tests-crypto-rust (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      run: |-
+        flowey e 17 flowey_lib_hvlite::run_cargo_nextest_run 3
+        flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 2
       shell: bash
     - name: run 'x64-linux-musl-unit-tests-crypto-openssl' nextest tests
       run: |-
@@ -2495,7 +2509,9 @@ jobs:
       name: 'publish test results: x64-linux-musl-unit-tests-crypto-openssl (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 4
+      run: |-
+        flowey e 17 flowey_lib_hvlite::run_cargo_nextest_run 5
+        flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 4
       shell: bash
     - name: run 'x64-linux-musl-unit-tests-crypto-symcrypt' nextest tests
       run: |-
@@ -2515,7 +2531,9 @@ jobs:
       name: 'publish test results: x64-linux-musl-unit-tests-crypto-symcrypt (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: |-
+        flowey e 17 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: run 'x64-linux-musl-unit-tests-crypto-all' nextest tests
       run: |-
@@ -2547,7 +2565,9 @@ jobs:
         flowey e 17 flowey_lib_hvlite::build_xtask 1
       shell: bash
     - name: determine unit test exclusions
-      run: flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 0
+      run: |-
+        flowey e 17 flowey_lib_hvlite::build_nextest_unit_tests 0
+        flowey e 17 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
       run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 5
@@ -2570,7 +2590,9 @@ jobs:
       name: 'publish test results: x64-linux-musl-unit-tests-base (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      run: |-
+        flowey e 17 flowey_lib_hvlite::run_cargo_nextest_run 2
+        flowey e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
     - name: run 'x64-linux-musl-unit-tests-crypto-native' nextest tests
       run: |-
@@ -2844,7 +2866,9 @@ jobs:
       name: 'publish test results: aarch64-windows-unit-tests-base (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey.exe e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: |-
+        flowey.exe e 18 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey.exe e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: run 'aarch64-windows-unit-tests-crypto-native' nextest tests
       run: |-
@@ -2864,7 +2888,9 @@ jobs:
       name: 'publish test results: aarch64-windows-unit-tests-crypto-native (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey.exe e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      run: |-
+        flowey.exe e 18 flowey_lib_hvlite::run_cargo_nextest_run 2
+        flowey.exe e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
     - name: run 'aarch64-windows-unit-tests-crypto-rust' nextest tests
       run: |-
@@ -3122,7 +3148,7 @@ jobs:
       run: |-
         flowey e 19 flowey_lib_common::install_cargo_nextest 0
         flowey e 19 flowey_lib_hvlite::init_cross_build 1
-        flowey e 19 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey e 19 flowey_lib_hvlite::run_cargo_nextest_run 4
       shell: bash
     - name: generate nextest command
       run: flowey e 19 flowey_lib_common::gen_cargo_nextest_run_cmd 3
@@ -3145,7 +3171,9 @@ jobs:
       name: 'publish test results: aarch64-linux-unit-tests-crypto-rust (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 19 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      run: |-
+        flowey e 19 flowey_lib_hvlite::run_cargo_nextest_run 3
+        flowey e 19 flowey_lib_common::gen_cargo_nextest_run_cmd 2
       shell: bash
     - name: run 'aarch64-linux-unit-tests-crypto-openssl' nextest tests
       run: |-
@@ -3165,7 +3193,9 @@ jobs:
       name: 'publish test results: aarch64-linux-unit-tests-crypto-openssl (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 19 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: |-
+        flowey e 19 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey e 19 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: run 'aarch64-linux-unit-tests-crypto-all' nextest tests
       run: |-
@@ -3197,7 +3227,9 @@ jobs:
         flowey e 19 flowey_lib_hvlite::build_xtask 1
       shell: bash
     - name: determine unit test exclusions
-      run: flowey e 19 flowey_lib_hvlite::build_nextest_unit_tests 0
+      run: |-
+        flowey e 19 flowey_lib_hvlite::build_nextest_unit_tests 0
+        flowey e 19 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
       run: flowey e 19 flowey_lib_common::gen_cargo_nextest_run_cmd 4
@@ -3220,7 +3252,9 @@ jobs:
       name: 'publish test results: aarch64-linux-unit-tests-base (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 19 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      run: |-
+        flowey e 19 flowey_lib_hvlite::run_cargo_nextest_run 2
+        flowey e 19 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
     - name: run 'aarch64-linux-unit-tests-crypto-native' nextest tests
       run: |-
@@ -3680,7 +3714,7 @@ jobs:
       run: |-
         flowey e 20 flowey_lib_common::install_cargo_nextest 0
         flowey e 20 flowey_lib_hvlite::init_cross_build 3
-        flowey e 20 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey e 20 flowey_lib_hvlite::run_cargo_nextest_run 4
       shell: bash
     - name: generate nextest command
       run: flowey e 20 flowey_lib_common::gen_cargo_nextest_run_cmd 3
@@ -3703,7 +3737,9 @@ jobs:
       name: 'publish test results: aarch64-linux-musl-unit-tests-crypto-rust (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 20 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+      run: |-
+        flowey e 20 flowey_lib_hvlite::run_cargo_nextest_run 3
+        flowey e 20 flowey_lib_common::gen_cargo_nextest_run_cmd 2
       shell: bash
     - name: run 'aarch64-linux-musl-unit-tests-crypto-openssl' nextest tests
       run: |-
@@ -3723,7 +3759,9 @@ jobs:
       name: 'publish test results: aarch64-linux-musl-unit-tests-crypto-openssl (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 20 flowey_lib_common::gen_cargo_nextest_run_cmd 4
+      run: |-
+        flowey e 20 flowey_lib_hvlite::run_cargo_nextest_run 5
+        flowey e 20 flowey_lib_common::gen_cargo_nextest_run_cmd 4
       shell: bash
     - name: run 'aarch64-linux-musl-unit-tests-crypto-symcrypt' nextest tests
       run: |-
@@ -3743,7 +3781,9 @@ jobs:
       name: 'publish test results: aarch64-linux-musl-unit-tests-crypto-symcrypt (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 20 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      run: |-
+        flowey e 20 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey e 20 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: run 'aarch64-linux-musl-unit-tests-crypto-all' nextest tests
       run: |-
@@ -3775,7 +3815,9 @@ jobs:
         flowey e 20 flowey_lib_hvlite::build_xtask 1
       shell: bash
     - name: determine unit test exclusions
-      run: flowey e 20 flowey_lib_hvlite::build_nextest_unit_tests 0
+      run: |-
+        flowey e 20 flowey_lib_hvlite::build_nextest_unit_tests 0
+        flowey e 20 flowey_lib_hvlite::run_cargo_nextest_run 0
       shell: bash
     - name: generate nextest command
       run: flowey e 20 flowey_lib_common::gen_cargo_nextest_run_cmd 5
@@ -3798,7 +3840,9 @@ jobs:
       name: 'publish test results: aarch64-linux-musl-unit-tests-base (JUnit XML)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: generate nextest command
-      run: flowey e 20 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+      run: |-
+        flowey e 20 flowey_lib_hvlite::run_cargo_nextest_run 2
+        flowey e 20 flowey_lib_common::gen_cargo_nextest_run_cmd 1
       shell: bash
     - name: run 'aarch64-linux-musl-unit-tests-crypto-native' nextest tests
       run: |-
@@ -3941,7 +3985,7 @@ jobs:
       run: |-
         flowey.exe e 21 flowey_lib_common::system_info 0
         flowey.exe e 21 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey.exe e 21 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
         flowey.exe e 21 flowey_core::pipeline::artifact::resolve 8
         flowey.exe e 21 flowey_core::pipeline::artifact::resolve 9
         flowey.exe e 21 flowey_core::pipeline::artifact::resolve 12
@@ -4048,39 +4092,41 @@ jobs:
     - name: setting up vmm_tests env
       run: |-
         flowey.exe e 21 flowey_lib_hvlite::init_vmm_tests_env 0
-        flowey.exe e 21 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey.exe e 21 flowey_lib_hvlite::run_cargo_nextest_run 0
         flowey.exe e 21 flowey_core::pipeline::artifact::resolve 16
         flowey.exe e 21 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: generate nextest command
-      run: flowey.exe e 21 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-      shell: bash
-    - name: install vmm tests deps (windows)
-      run: flowey.exe e 21 flowey_lib_hvlite::install_vmm_tests_deps 0
-      shell: bash
-    - name: starting test_igvm_agent_rpc_server
       run: |-
-        flowey.exe e 21 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+        flowey.exe e 21 flowey_lib_common::gen_cargo_nextest_run_cmd 0
         flowey.exe e 21 flowey_core::pipeline::artifact::resolve 10
       shell: bash
     - name: running vmm_test prep_steps
       run: flowey.exe e 21 flowey_lib_hvlite::run_prep_steps 0
       shell: bash
+    - name: starting test_igvm_agent_rpc_server
+      run: flowey.exe e 21 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+      shell: bash
+    - name: install vmm tests deps (windows)
+      run: flowey.exe e 21 flowey_lib_hvlite::install_vmm_tests_deps 0
+      shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
         flowey.exe e 21 flowey_lib_common::run_cargo_nextest_run 0
         flowey.exe e 21 flowey_lib_common::run_cargo_nextest_run 1
-        flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
-      shell: bash
-    - name: summarize failing vmm tests
-      run: |-
-        flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
-        flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
       shell: bash
     - name: stopping test_igvm_agent_rpc_server
       run: |-
         flowey.exe e 21 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
+        flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+      shell: bash
+    - name: rename and create new log dir
+      run: flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+      shell: bash
+    - name: summarize failing vmm tests
+      run: |-
         flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 5
+        flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 6
         flowey.exe e 21 flowey_lib_common::publish_test_results 0
         flowey.exe e 21 flowey_lib_common::publish_test_results 1
         flowey.exe v 21 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
@@ -4108,7 +4154,7 @@ jobs:
       name: 'publish test results: x64-windows-intel-vmm-tests (logs)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 6
+      run: flowey.exe e 21 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 7
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
       run: flowey.exe e 21 flowey_lib_common::cache 3
@@ -4177,8 +4223,59 @@ jobs:
         echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmgstool-dev" | flowey.exe v 22 'artifact_use_from_x64-windows-vmgstool-dev' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\x64-windows-vmm-tests-archive" | flowey.exe v 22 'artifact_use_from_x64-windows-vmm-tests-archive' --is-raw-string update
       shell: bash
-    - name: create gh-release-download cache dir
+    - name: create cargo-nextest cache dir
       run: |-
+        flowey.exe e 22 flowey_lib_common::download_cargo_nextest 0
+        flowey.exe e 22 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 22 flowey_lib_common::download_cargo_nextest 2
+        flowey.exe e 22 flowey_lib_common::download_cargo_nextest 3
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey.exe e 22 flowey_lib_common::cache 0
+        flowey.exe v 22 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 22 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25
+      with:
+        key: ${{ env.floweyvar4 }}
+        path: ${{ env.floweyvar5 }}
+      name: 'Restore cache: cargo-nextest'
+    - name: downloading cargo-nextest
+      run: |-
+        flowey.exe v 22 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey.exe e 22 flowey_lib_common::cache 2
+        flowey.exe e 22 flowey_lib_common::download_cargo_nextest 4
+      shell: bash
+    - name: check if openvmm needs to be cloned
+      run: |-
+        flowey.exe e 22 flowey_lib_common::git_checkout 0
+        flowey.exe v 22 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar3
+        flowey.exe v 22 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__git_checkout__1
+      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
+      with:
+        fetch-depth: '1'
+        path: repo0
+        persist-credentials: ${{ env.floweyvar3 }}
+      name: checkout repo openvmm
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report cloned repo directories
+      run: |-
+        flowey.exe v 22 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
+        ${{ github.workspace }}
+        EOF
+        flowey.exe e 22 flowey_lib_common::git_checkout 3
+      shell: bash
+    - name: print system info
+      run: |-
+        flowey.exe e 22 flowey_lib_common::system_info 0
+        flowey.exe e 22 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
         flowey.exe e 22 flowey_core::pipeline::artifact::resolve 11
         flowey.exe e 22 flowey_core::pipeline::artifact::resolve 4
         flowey.exe e 22 flowey_core::pipeline::artifact::resolve 5
@@ -4198,7 +4295,9 @@ jobs:
         ${{ runner.temp }}
         EOF
         flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
-        flowey.exe e 22 flowey_lib_common::download_gh_release 0
+      shell: bash
+    - name: create gh-release-download cache dir
+      run: flowey.exe e 22 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
@@ -4281,89 +4380,38 @@ jobs:
       run: flowey.exe e 22 flowey_lib_hvlite::resolve_openvmm_test_virtio_win 0
       shell: bash
     - name: setting up vmm_tests env
-      run: flowey.exe e 22 flowey_lib_hvlite::init_vmm_tests_env 0
-      shell: bash
-    - name: create cargo-nextest cache dir
       run: |-
-        flowey.exe e 22 flowey_lib_common::download_cargo_nextest 0
-        flowey.exe e 22 flowey_lib_common::download_cargo_nextest 1
-        flowey.exe e 22 flowey_lib_common::download_cargo_nextest 2
-        flowey.exe e 22 flowey_lib_common::download_cargo_nextest 3
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey.exe e 22 flowey_lib_common::cache 0
-        flowey.exe v 22 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 22 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
-      shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25
-      with:
-        key: ${{ env.floweyvar4 }}
-        path: ${{ env.floweyvar5 }}
-      name: 'Restore cache: cargo-nextest'
-    - name: downloading cargo-nextest
-      run: |-
-        flowey.exe v 22 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey.exe e 22 flowey_lib_common::cache 2
-        flowey.exe e 22 flowey_lib_common::download_cargo_nextest 4
-      shell: bash
-    - name: check if openvmm needs to be cloned
-      run: |-
-        flowey.exe e 22 flowey_lib_common::git_checkout 0
-        flowey.exe v 22 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar3
-        flowey.exe v 22 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__git_checkout__1
-      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
-      with:
-        fetch-depth: '1'
-        path: repo0
-        persist-credentials: ${{ env.floweyvar3 }}
-      name: checkout repo openvmm
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report cloned repo directories
-      run: |-
-        flowey.exe v 22 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
-        ${{ github.workspace }}
-        EOF
-        flowey.exe e 22 flowey_lib_common::git_checkout 3
-      shell: bash
-    - name: print system info
-      run: |-
-        flowey.exe e 22 flowey_lib_common::system_info 0
-        flowey.exe e 22 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey.exe e 22 flowey_lib_hvlite::init_vmm_tests_env 0
         flowey.exe e 22 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey.exe e 22 flowey_lib_hvlite::run_cargo_nextest_run 1
         flowey.exe e 22 flowey_core::pipeline::artifact::resolve 16
         flowey.exe e 22 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: generate nextest command
       run: flowey.exe e 22 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
-    - name: install vmm tests deps (windows)
-      run: flowey.exe e 22 flowey_lib_hvlite::install_vmm_tests_deps 0
-      shell: bash
     - name: starting test_igvm_agent_rpc_server
       run: flowey.exe e 22 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+      shell: bash
+    - name: install vmm tests deps (windows)
+      run: flowey.exe e 22 flowey_lib_hvlite::install_vmm_tests_deps 0
       shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
         flowey.exe e 22 flowey_lib_common::run_cargo_nextest_run 0
         flowey.exe e 22 flowey_lib_common::run_cargo_nextest_run 1
-        flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
-      shell: bash
-    - name: summarize failing vmm tests
-      run: |-
-        flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
-        flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
       shell: bash
     - name: stopping test_igvm_agent_rpc_server
       run: |-
         flowey.exe e 22 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
+        flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+      shell: bash
+    - name: rename and create new log dir
+      run: flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+      shell: bash
+    - name: summarize failing vmm tests
+      run: |-
         flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 5
+        flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 6
         flowey.exe e 22 flowey_lib_common::publish_test_results 0
         flowey.exe e 22 flowey_lib_common::publish_test_results 1
         flowey.exe v 22 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
@@ -4391,7 +4439,7 @@ jobs:
       name: 'publish test results: x64-windows-intel-mi-secure-vmm-tests (logs)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 6
+      run: flowey.exe e 22 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 7
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
       run: flowey.exe e 22 flowey_lib_common::cache 3
@@ -4513,7 +4561,7 @@ jobs:
       run: |-
         flowey.exe e 23 flowey_lib_common::system_info 0
         flowey.exe e 23 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey.exe e 23 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
         flowey.exe e 23 flowey_core::pipeline::artifact::resolve 8
         flowey.exe e 23 flowey_core::pipeline::artifact::resolve 9
         flowey.exe e 23 flowey_core::pipeline::artifact::resolve 12
@@ -4620,39 +4668,41 @@ jobs:
     - name: setting up vmm_tests env
       run: |-
         flowey.exe e 23 flowey_lib_hvlite::init_vmm_tests_env 0
-        flowey.exe e 23 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey.exe e 23 flowey_lib_hvlite::run_cargo_nextest_run 0
         flowey.exe e 23 flowey_core::pipeline::artifact::resolve 16
         flowey.exe e 23 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: generate nextest command
-      run: flowey.exe e 23 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-      shell: bash
-    - name: install vmm tests deps (windows)
-      run: flowey.exe e 23 flowey_lib_hvlite::install_vmm_tests_deps 0
-      shell: bash
-    - name: starting test_igvm_agent_rpc_server
       run: |-
-        flowey.exe e 23 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+        flowey.exe e 23 flowey_lib_common::gen_cargo_nextest_run_cmd 0
         flowey.exe e 23 flowey_core::pipeline::artifact::resolve 10
       shell: bash
     - name: running vmm_test prep_steps
       run: flowey.exe e 23 flowey_lib_hvlite::run_prep_steps 0
       shell: bash
+    - name: starting test_igvm_agent_rpc_server
+      run: flowey.exe e 23 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+      shell: bash
+    - name: install vmm tests deps (windows)
+      run: flowey.exe e 23 flowey_lib_hvlite::install_vmm_tests_deps 0
+      shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
         flowey.exe e 23 flowey_lib_common::run_cargo_nextest_run 0
         flowey.exe e 23 flowey_lib_common::run_cargo_nextest_run 1
-        flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
-      shell: bash
-    - name: summarize failing vmm tests
-      run: |-
-        flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
-        flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
       shell: bash
     - name: stopping test_igvm_agent_rpc_server
       run: |-
         flowey.exe e 23 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
+        flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+      shell: bash
+    - name: rename and create new log dir
+      run: flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+      shell: bash
+    - name: summarize failing vmm tests
+      run: |-
         flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 5
+        flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 6
         flowey.exe e 23 flowey_lib_common::publish_test_results 0
         flowey.exe e 23 flowey_lib_common::publish_test_results 1
         flowey.exe v 23 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
@@ -4680,7 +4730,7 @@ jobs:
       name: 'publish test results: x64-windows-intel-tdx-vmm-tests (logs)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 6
+      run: flowey.exe e 23 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 7
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
       run: flowey.exe e 23 flowey_lib_common::cache 3
@@ -4801,7 +4851,7 @@ jobs:
       run: |-
         flowey.exe e 24 flowey_lib_common::system_info 0
         flowey.exe e 24 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey.exe e 24 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
         flowey.exe e 24 flowey_core::pipeline::artifact::resolve 8
         flowey.exe e 24 flowey_core::pipeline::artifact::resolve 9
         flowey.exe e 24 flowey_core::pipeline::artifact::resolve 12
@@ -4908,39 +4958,41 @@ jobs:
     - name: setting up vmm_tests env
       run: |-
         flowey.exe e 24 flowey_lib_hvlite::init_vmm_tests_env 0
-        flowey.exe e 24 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey.exe e 24 flowey_lib_hvlite::run_cargo_nextest_run 0
         flowey.exe e 24 flowey_core::pipeline::artifact::resolve 16
         flowey.exe e 24 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: generate nextest command
-      run: flowey.exe e 24 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-      shell: bash
-    - name: install vmm tests deps (windows)
-      run: flowey.exe e 24 flowey_lib_hvlite::install_vmm_tests_deps 0
-      shell: bash
-    - name: starting test_igvm_agent_rpc_server
       run: |-
-        flowey.exe e 24 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+        flowey.exe e 24 flowey_lib_common::gen_cargo_nextest_run_cmd 0
         flowey.exe e 24 flowey_core::pipeline::artifact::resolve 10
       shell: bash
     - name: running vmm_test prep_steps
       run: flowey.exe e 24 flowey_lib_hvlite::run_prep_steps 0
       shell: bash
+    - name: starting test_igvm_agent_rpc_server
+      run: flowey.exe e 24 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+      shell: bash
+    - name: install vmm tests deps (windows)
+      run: flowey.exe e 24 flowey_lib_hvlite::install_vmm_tests_deps 0
+      shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
         flowey.exe e 24 flowey_lib_common::run_cargo_nextest_run 0
         flowey.exe e 24 flowey_lib_common::run_cargo_nextest_run 1
-        flowey.exe e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
-      shell: bash
-    - name: summarize failing vmm tests
-      run: |-
-        flowey.exe e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
-        flowey.exe e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
       shell: bash
     - name: stopping test_igvm_agent_rpc_server
       run: |-
         flowey.exe e 24 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
+        flowey.exe e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+      shell: bash
+    - name: rename and create new log dir
+      run: flowey.exe e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+      shell: bash
+    - name: summarize failing vmm tests
+      run: |-
         flowey.exe e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 5
+        flowey.exe e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 6
         flowey.exe e 24 flowey_lib_common::publish_test_results 0
         flowey.exe e 24 flowey_lib_common::publish_test_results 1
         flowey.exe v 24 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
@@ -4968,7 +5020,7 @@ jobs:
       name: 'publish test results: x64-windows-amd-vmm-tests (logs)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: flowey.exe e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 6
+      run: flowey.exe e 24 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 7
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
       run: flowey.exe e 24 flowey_lib_common::cache 3
@@ -5089,7 +5141,7 @@ jobs:
       run: |-
         flowey.exe e 25 flowey_lib_common::system_info 0
         flowey.exe e 25 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey.exe e 25 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey.exe e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
         flowey.exe e 25 flowey_core::pipeline::artifact::resolve 8
         flowey.exe e 25 flowey_core::pipeline::artifact::resolve 9
         flowey.exe e 25 flowey_core::pipeline::artifact::resolve 12
@@ -5196,39 +5248,41 @@ jobs:
     - name: setting up vmm_tests env
       run: |-
         flowey.exe e 25 flowey_lib_hvlite::init_vmm_tests_env 0
-        flowey.exe e 25 flowey_lib_hvlite::run_cargo_nextest_run 1
+        flowey.exe e 25 flowey_lib_hvlite::run_cargo_nextest_run 0
         flowey.exe e 25 flowey_core::pipeline::artifact::resolve 16
         flowey.exe e 25 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: generate nextest command
-      run: flowey.exe e 25 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-      shell: bash
-    - name: install vmm tests deps (windows)
-      run: flowey.exe e 25 flowey_lib_hvlite::install_vmm_tests_deps 0
-      shell: bash
-    - name: starting test_igvm_agent_rpc_server
       run: |-
-        flowey.exe e 25 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+        flowey.exe e 25 flowey_lib_common::gen_cargo_nextest_run_cmd 0
         flowey.exe e 25 flowey_core::pipeline::artifact::resolve 10
       shell: bash
     - name: running vmm_test prep_steps
       run: flowey.exe e 25 flowey_lib_hvlite::run_prep_steps 0
       shell: bash
+    - name: starting test_igvm_agent_rpc_server
+      run: flowey.exe e 25 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+      shell: bash
+    - name: install vmm tests deps (windows)
+      run: flowey.exe e 25 flowey_lib_hvlite::install_vmm_tests_deps 0
+      shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
         flowey.exe e 25 flowey_lib_common::run_cargo_nextest_run 0
         flowey.exe e 25 flowey_lib_common::run_cargo_nextest_run 1
-        flowey.exe e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
-      shell: bash
-    - name: summarize failing vmm tests
-      run: |-
-        flowey.exe e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
-        flowey.exe e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
       shell: bash
     - name: stopping test_igvm_agent_rpc_server
       run: |-
         flowey.exe e 25 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
+        flowey.exe e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+      shell: bash
+    - name: rename and create new log dir
+      run: flowey.exe e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+      shell: bash
+    - name: summarize failing vmm tests
+      run: |-
         flowey.exe e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 5
+        flowey.exe e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 6
         flowey.exe e 25 flowey_lib_common::publish_test_results 0
         flowey.exe e 25 flowey_lib_common::publish_test_results 1
         flowey.exe v 25 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
@@ -5256,7 +5310,7 @@ jobs:
       name: 'publish test results: x64-windows-amd-snp-vmm-tests (logs)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: flowey.exe e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 6
+      run: flowey.exe e 25 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 7
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
       run: flowey.exe e 25 flowey_lib_common::cache 3
@@ -5316,8 +5370,59 @@ jobs:
         echo "$AgentTempDirNormal/used_artifacts/x64-tmks" | flowey v 26 'artifact_use_from_x64-tmks' --is-raw-string update
         echo "$AgentTempDirNormal/used_artifacts/x64-windows-pipette" | flowey v 26 'artifact_use_from_x64-windows-pipette' --is-raw-string update
       shell: bash
-    - name: checking if packages need to be installed
+    - name: create cargo-nextest cache dir
       run: |-
+        flowey e 26 flowey_lib_common::download_cargo_nextest 0
+        flowey e 26 flowey_lib_common::download_cargo_nextest 1
+        flowey e 26 flowey_lib_common::download_cargo_nextest 2
+        flowey e 26 flowey_lib_common::download_cargo_nextest 3
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 26 flowey_lib_common::cache 0
+        flowey v 26 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
+        flowey v 26 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25
+      with:
+        key: ${{ env.floweyvar4 }}
+        path: ${{ env.floweyvar5 }}
+      name: 'Restore cache: cargo-nextest'
+    - name: downloading cargo-nextest
+      run: |-
+        flowey v 26 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey e 26 flowey_lib_common::cache 2
+        flowey e 26 flowey_lib_common::download_cargo_nextest 4
+      shell: bash
+    - name: check if openvmm needs to be cloned
+      run: |-
+        flowey e 26 flowey_lib_common::git_checkout 0
+        flowey v 26 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar3
+        flowey v 26 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__git_checkout__1
+      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
+      with:
+        fetch-depth: '1'
+        path: repo0
+        persist-credentials: ${{ env.floweyvar3 }}
+      name: checkout repo openvmm
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report cloned repo directories
+      run: |-
+        flowey v 26 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
+        ${{ github.workspace }}
+        EOF
+        flowey e 26 flowey_lib_common::git_checkout 3
+      shell: bash
+    - name: print system info
+      run: |-
+        flowey e 26 flowey_lib_common::system_info 0
+        flowey e 26 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
         flowey e 26 flowey_core::pipeline::artifact::resolve 8
         flowey e 26 flowey_core::pipeline::artifact::resolve 2
         flowey e 26 flowey_core::pipeline::artifact::resolve 3
@@ -5329,7 +5434,9 @@ jobs:
         ${{ runner.temp }}
         EOF
         flowey e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
-        flowey e 26 flowey_lib_common::install_dist_pkg 0
+      shell: bash
+    - name: checking if packages need to be installed
+      run: flowey e 26 flowey_lib_common::install_dist_pkg 0
       shell: bash
     - name: installing packages
       run: flowey e 26 flowey_lib_common::install_dist_pkg 1
@@ -5418,96 +5525,36 @@ jobs:
       run: flowey e 26 flowey_lib_hvlite::resolve_openvmm_test_virtio_win 0
       shell: bash
     - name: setting up vmm_tests env
-      run: flowey e 26 flowey_lib_hvlite::init_vmm_tests_env 0
-      shell: bash
-    - name: ensure hypervisor device is accessible
-      run: flowey e 26 flowey_lib_hvlite::test_nextest_vmm_tests_archive 1
-      shell: bash
-    - name: ensure 2 MiB hugetlb pages are available
-      run: flowey e 26 flowey_lib_hvlite::test_nextest_vmm_tests_archive 2
-      shell: bash
-    - name: prepare vhost-vsock
-      run: flowey e 26 flowey_lib_hvlite::test_nextest_vmm_tests_archive 3
-      shell: bash
-    - name: create cargo-nextest cache dir
       run: |-
-        flowey e 26 flowey_lib_common::download_cargo_nextest 0
-        flowey e 26 flowey_lib_common::download_cargo_nextest 1
-        flowey e 26 flowey_lib_common::download_cargo_nextest 2
-        flowey e 26 flowey_lib_common::download_cargo_nextest 3
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 26 flowey_lib_common::cache 0
-        flowey v 26 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
-        flowey v 26 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
-      shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25
-      with:
-        key: ${{ env.floweyvar4 }}
-        path: ${{ env.floweyvar5 }}
-      name: 'Restore cache: cargo-nextest'
-    - name: downloading cargo-nextest
-      run: |-
-        flowey v 26 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey e 26 flowey_lib_common::cache 2
-        flowey e 26 flowey_lib_common::download_cargo_nextest 4
-      shell: bash
-    - name: check if openvmm needs to be cloned
-      run: |-
-        flowey e 26 flowey_lib_common::git_checkout 0
-        flowey v 26 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar3
-        flowey v 26 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__git_checkout__1
-      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
-      with:
-        fetch-depth: '1'
-        path: repo0
-        persist-credentials: ${{ env.floweyvar3 }}
-      name: checkout repo openvmm
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report cloned repo directories
-      run: |-
-        flowey v 26 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
-        ${{ github.workspace }}
-        EOF
-        flowey e 26 flowey_lib_common::git_checkout 3
-      shell: bash
-    - name: print system info
-      run: |-
-        flowey e 26 flowey_lib_common::system_info 0
-        flowey e 26 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 26 flowey_lib_hvlite::init_vmm_tests_env 0
         flowey e 26 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey e 26 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
-        flowey e 26 flowey_lib_hvlite::run_cargo_nextest_run 1
         flowey e 26 flowey_core::pipeline::artifact::resolve 6
-        flowey e 26 flowey_lib_hvlite::test_nextest_vmm_tests_archive 4
+        flowey e 26 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 26 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-      shell: bash
-    - name: install vmm tests deps (linux)
       run: |-
-        flowey e 26 flowey_lib_hvlite::install_vmm_tests_deps 0
+        flowey e 26 flowey_lib_common::gen_cargo_nextest_run_cmd 0
         flowey e 26 flowey_core::pipeline::artifact::resolve 5
       shell: bash
     - name: running vmm_test prep_steps
       run: flowey e 26 flowey_lib_hvlite::run_prep_steps 0
       shell: bash
+    - name: install vmm tests deps (linux)
+      run: flowey e 26 flowey_lib_hvlite::install_vmm_tests_deps 0
+      shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
         flowey e 26 flowey_lib_common::run_cargo_nextest_run 0
         flowey e 26 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+        flowey e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+      shell: bash
+    - name: rename and create new log dir
+      run: flowey e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
       shell: bash
     - name: summarize failing vmm tests
       run: |-
-        flowey e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
-        flowey e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+        flowey e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 5
+        flowey e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 6
         flowey e 26 flowey_lib_common::publish_test_results 0
         flowey e 26 flowey_lib_common::publish_test_results 1
         flowey v 26 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
@@ -5535,7 +5582,7 @@ jobs:
       name: 'publish test results: x64-linux-amd-kvm-vmm-tests (logs)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: flowey e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 5
+      run: flowey e 26 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 7
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
       run: flowey e 26 flowey_lib_common::cache 3
@@ -5643,8 +5690,59 @@ jobs:
         echo "$AgentTempDirNormal/used_artifacts/x64-tmks" | flowey v 27 'artifact_use_from_x64-tmks' --is-raw-string update
         echo "$AgentTempDirNormal/used_artifacts/x64-windows-pipette" | flowey v 27 'artifact_use_from_x64-windows-pipette' --is-raw-string update
       shell: bash
-    - name: checking if packages need to be installed
+    - name: create cargo-nextest cache dir
       run: |-
+        flowey e 27 flowey_lib_common::download_cargo_nextest 0
+        flowey e 27 flowey_lib_common::download_cargo_nextest 1
+        flowey e 27 flowey_lib_common::download_cargo_nextest 2
+        flowey e 27 flowey_lib_common::download_cargo_nextest 3
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey e 27 flowey_lib_common::cache 0
+        flowey v 27 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
+        flowey v 27 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25
+      with:
+        key: ${{ env.floweyvar4 }}
+        path: ${{ env.floweyvar5 }}
+      name: 'Restore cache: cargo-nextest'
+    - name: downloading cargo-nextest
+      run: |-
+        flowey v 27 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey e 27 flowey_lib_common::cache 2
+        flowey e 27 flowey_lib_common::download_cargo_nextest 4
+      shell: bash
+    - name: check if openvmm needs to be cloned
+      run: |-
+        flowey e 27 flowey_lib_common::git_checkout 0
+        flowey v 27 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar3
+        flowey v 27 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__git_checkout__1
+      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
+      with:
+        fetch-depth: '1'
+        path: repo0
+        persist-credentials: ${{ env.floweyvar3 }}
+      name: checkout repo openvmm
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report cloned repo directories
+      run: |-
+        flowey v 27 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
+        ${{ github.workspace }}
+        EOF
+        flowey e 27 flowey_lib_common::git_checkout 3
+      shell: bash
+    - name: print system info
+      run: |-
+        flowey e 27 flowey_lib_common::system_info 0
+        flowey e 27 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
         flowey e 27 flowey_core::pipeline::artifact::resolve 8
         flowey e 27 flowey_core::pipeline::artifact::resolve 4
         flowey e 27 flowey_core::pipeline::artifact::resolve 1
@@ -5656,7 +5754,9 @@ jobs:
         ${{ runner.temp }}
         EOF
         flowey e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
-        flowey e 27 flowey_lib_common::install_dist_pkg 0
+      shell: bash
+    - name: checking if packages need to be installed
+      run: flowey e 27 flowey_lib_common::install_dist_pkg 0
       shell: bash
     - name: installing packages
       run: flowey e 27 flowey_lib_common::install_dist_pkg 1
@@ -5745,92 +5845,36 @@ jobs:
       run: flowey e 27 flowey_lib_hvlite::resolve_openvmm_test_virtio_win 0
       shell: bash
     - name: setting up vmm_tests env
-      run: flowey e 27 flowey_lib_hvlite::init_vmm_tests_env 0
-      shell: bash
-    - name: ensure hypervisor device is accessible
-      run: flowey e 27 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
-      shell: bash
-    - name: prepare vhost-vsock
-      run: flowey e 27 flowey_lib_hvlite::test_nextest_vmm_tests_archive 1
-      shell: bash
-    - name: create cargo-nextest cache dir
       run: |-
-        flowey e 27 flowey_lib_common::download_cargo_nextest 0
-        flowey e 27 flowey_lib_common::download_cargo_nextest 1
-        flowey e 27 flowey_lib_common::download_cargo_nextest 2
-        flowey e 27 flowey_lib_common::download_cargo_nextest 3
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey e 27 flowey_lib_common::cache 0
-        flowey v 27 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
-        flowey v 27 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
-      shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25
-      with:
-        key: ${{ env.floweyvar4 }}
-        path: ${{ env.floweyvar5 }}
-      name: 'Restore cache: cargo-nextest'
-    - name: downloading cargo-nextest
-      run: |-
-        flowey v 27 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey e 27 flowey_lib_common::cache 2
-        flowey e 27 flowey_lib_common::download_cargo_nextest 4
-      shell: bash
-    - name: check if openvmm needs to be cloned
-      run: |-
-        flowey e 27 flowey_lib_common::git_checkout 0
-        flowey v 27 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar3
-        flowey v 27 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__git_checkout__1
-      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
-      with:
-        fetch-depth: '1'
-        path: repo0
-        persist-credentials: ${{ env.floweyvar3 }}
-      name: checkout repo openvmm
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report cloned repo directories
-      run: |-
-        flowey v 27 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
-        ${{ github.workspace }}
-        EOF
-        flowey e 27 flowey_lib_common::git_checkout 3
-      shell: bash
-    - name: print system info
-      run: |-
-        flowey e 27 flowey_lib_common::system_info 0
-        flowey e 27 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey e 27 flowey_lib_hvlite::init_vmm_tests_env 0
         flowey e 27 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey e 27 flowey_lib_hvlite::run_cargo_nextest_run 1
         flowey e 27 flowey_core::pipeline::artifact::resolve 5
-        flowey e 27 flowey_lib_hvlite::test_nextest_vmm_tests_archive 2
+        flowey e 27 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: generate nextest command
-      run: flowey e 27 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-      shell: bash
-    - name: install vmm tests deps (linux)
       run: |-
-        flowey e 27 flowey_lib_hvlite::install_vmm_tests_deps 0
+        flowey e 27 flowey_lib_common::gen_cargo_nextest_run_cmd 0
         flowey e 27 flowey_core::pipeline::artifact::resolve 6
       shell: bash
     - name: running vmm_test prep_steps
       run: flowey e 27 flowey_lib_hvlite::run_prep_steps 0
       shell: bash
+    - name: install vmm tests deps (linux)
+      run: flowey e 27 flowey_lib_hvlite::install_vmm_tests_deps 0
+      shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
         flowey e 27 flowey_lib_common::run_cargo_nextest_run 0
         flowey e 27 flowey_lib_common::run_cargo_nextest_run 1
-        flowey e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+        flowey e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+      shell: bash
+    - name: rename and create new log dir
+      run: flowey e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
       shell: bash
     - name: summarize failing vmm tests
       run: |-
-        flowey e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
-        flowey e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+        flowey e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 5
+        flowey e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 6
         flowey e 27 flowey_lib_common::publish_test_results 0
         flowey e 27 flowey_lib_common::publish_test_results 1
         flowey v 27 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
@@ -5858,7 +5902,7 @@ jobs:
       name: 'publish test results: x64-linux-intel-mshv-vmm-tests (logs)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: flowey e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 5
+      run: flowey e 27 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 7
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
       run: flowey e 27 flowey_lib_common::cache 3
@@ -5970,8 +6014,59 @@ jobs:
         echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmgstool-dev" | flowey.exe v 28 'artifact_use_from_aarch64-windows-vmgstool-dev' --is-raw-string update
         echo "${{ runner.temp }}\\used_artifacts\\aarch64-windows-vmm-tests-archive" | flowey.exe v 28 'artifact_use_from_aarch64-windows-vmm-tests-archive' --is-raw-string update
       shell: bash
-    - name: create gh-release-download cache dir
+    - name: create cargo-nextest cache dir
       run: |-
+        flowey.exe e 28 flowey_lib_common::download_cargo_nextest 0
+        flowey.exe e 28 flowey_lib_common::download_cargo_nextest 1
+        flowey.exe e 28 flowey_lib_common::download_cargo_nextest 2
+        flowey.exe e 28 flowey_lib_common::download_cargo_nextest 3
+      shell: bash
+    - name: Pre-processing cache vars
+      run: |-
+        flowey.exe e 28 flowey_lib_common::cache 0
+        flowey.exe v 28 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
+        flowey.exe v 28 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
+      shell: bash
+    - id: flowey_lib_common__cache__1
+      uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25
+      with:
+        key: ${{ env.floweyvar4 }}
+        path: ${{ env.floweyvar5 }}
+      name: 'Restore cache: cargo-nextest'
+    - name: downloading cargo-nextest
+      run: |-
+        flowey.exe v 28 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
+        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
+        EOF
+        flowey.exe e 28 flowey_lib_common::cache 2
+        flowey.exe e 28 flowey_lib_common::download_cargo_nextest 4
+      shell: bash
+    - name: check if openvmm needs to be cloned
+      run: |-
+        flowey.exe e 28 flowey_lib_common::git_checkout 0
+        flowey.exe v 28 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar3
+        flowey.exe v 28 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
+      shell: bash
+    - id: flowey_lib_common__git_checkout__1
+      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
+      with:
+        fetch-depth: '1'
+        path: repo0
+        persist-credentials: ${{ env.floweyvar3 }}
+      name: checkout repo openvmm
+      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
+    - name: report cloned repo directories
+      run: |-
+        flowey.exe v 28 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
+        ${{ github.workspace }}
+        EOF
+        flowey.exe e 28 flowey_lib_common::git_checkout 3
+      shell: bash
+    - name: print system info
+      run: |-
+        flowey.exe e 28 flowey_lib_common::system_info 0
+        flowey.exe e 28 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey.exe e 28 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
         flowey.exe e 28 flowey_core::pipeline::artifact::resolve 5
         flowey.exe e 28 flowey_core::pipeline::artifact::resolve 6
         flowey.exe e 28 flowey_core::pipeline::artifact::resolve 7
@@ -5986,7 +6081,9 @@ jobs:
         ${{ runner.temp }}
         EOF
         flowey.exe e 28 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
-        flowey.exe e 28 flowey_lib_common::download_gh_release 0
+      shell: bash
+    - name: create gh-release-download cache dir
+      run: flowey.exe e 28 flowey_lib_common::download_gh_release 0
       shell: bash
     - name: Pre-processing cache vars
       run: |-
@@ -6069,89 +6166,38 @@ jobs:
       run: flowey.exe e 28 flowey_lib_hvlite::resolve_openvmm_test_virtio_win 0
       shell: bash
     - name: setting up vmm_tests env
-      run: flowey.exe e 28 flowey_lib_hvlite::init_vmm_tests_env 0
-      shell: bash
-    - name: create cargo-nextest cache dir
       run: |-
-        flowey.exe e 28 flowey_lib_common::download_cargo_nextest 0
-        flowey.exe e 28 flowey_lib_common::download_cargo_nextest 1
-        flowey.exe e 28 flowey_lib_common::download_cargo_nextest 2
-        flowey.exe e 28 flowey_lib_common::download_cargo_nextest 3
-      shell: bash
-    - name: Pre-processing cache vars
-      run: |-
-        flowey.exe e 28 flowey_lib_common::cache 0
-        flowey.exe v 28 'flowey_lib_common::cache:2:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar4
-        flowey.exe v 28 'flowey_lib_common::cache:1:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env github floweyvar5
-      shell: bash
-    - id: flowey_lib_common__cache__1
-      uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25
-      with:
-        key: ${{ env.floweyvar4 }}
-        path: ${{ env.floweyvar5 }}
-      name: 'Restore cache: cargo-nextest'
-    - name: downloading cargo-nextest
-      run: |-
-        flowey.exe v 28 'flowey_lib_common::cache:4:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source steps.flowey_lib_common__cache__1.outputs.cache-hit <<EOF
-        ${{ steps.flowey_lib_common__cache__1.outputs.cache-hit }}
-        EOF
-        flowey.exe e 28 flowey_lib_common::cache 2
-        flowey.exe e 28 flowey_lib_common::download_cargo_nextest 4
-      shell: bash
-    - name: check if openvmm needs to be cloned
-      run: |-
-        flowey.exe e 28 flowey_lib_common::git_checkout 0
-        flowey.exe v 28 'flowey_lib_common::git_checkout:0:flowey_lib_common/src/git_checkout.rs' --is-raw-string --condvar flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs write-to-env github floweyvar3
-        flowey.exe v 28 'flowey_lib_common::git_checkout:1:flowey_lib_common/src/git_checkout.rs' write-to-env github FLOWEY_CONDITION
-      shell: bash
-    - id: flowey_lib_common__git_checkout__1
-      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
-      with:
-        fetch-depth: '1'
-        path: repo0
-        persist-credentials: ${{ env.floweyvar3 }}
-      name: checkout repo openvmm
-      if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
-    - name: report cloned repo directories
-      run: |-
-        flowey.exe v 28 'flowey_lib_common::git_checkout:4:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source github.workspace <<EOF
-        ${{ github.workspace }}
-        EOF
-        flowey.exe e 28 flowey_lib_common::git_checkout 3
-      shell: bash
-    - name: print system info
-      run: |-
-        flowey.exe e 28 flowey_lib_common::system_info 0
-        flowey.exe e 28 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+        flowey.exe e 28 flowey_lib_hvlite::init_vmm_tests_env 0
         flowey.exe e 28 flowey_lib_hvlite::run_cargo_nextest_run 0
-        flowey.exe e 28 flowey_lib_hvlite::run_cargo_nextest_run 1
         flowey.exe e 28 flowey_core::pipeline::artifact::resolve 10
         flowey.exe e 28 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: generate nextest command
       run: flowey.exe e 28 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
-    - name: install vmm tests deps (windows)
-      run: flowey.exe e 28 flowey_lib_hvlite::install_vmm_tests_deps 0
-      shell: bash
     - name: starting test_igvm_agent_rpc_server
       run: flowey.exe e 28 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+      shell: bash
+    - name: install vmm tests deps (windows)
+      run: flowey.exe e 28 flowey_lib_hvlite::install_vmm_tests_deps 0
       shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
         flowey.exe e 28 flowey_lib_common::run_cargo_nextest_run 0
         flowey.exe e 28 flowey_lib_common::run_cargo_nextest_run 1
-        flowey.exe e 28 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
-      shell: bash
-    - name: summarize failing vmm tests
-      run: |-
-        flowey.exe e 28 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
-        flowey.exe e 28 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
       shell: bash
     - name: stopping test_igvm_agent_rpc_server
       run: |-
         flowey.exe e 28 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
+        flowey.exe e 28 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+      shell: bash
+    - name: rename and create new log dir
+      run: flowey.exe e 28 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+      shell: bash
+    - name: summarize failing vmm tests
+      run: |-
         flowey.exe e 28 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 5
+        flowey.exe e 28 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 6
         flowey.exe e 28 flowey_lib_common::publish_test_results 0
         flowey.exe e 28 flowey_lib_common::publish_test_results 1
         flowey.exe v 28 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
@@ -6179,7 +6225,7 @@ jobs:
       name: 'publish test results: aarch64-windows-vmm-tests (logs)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: flowey.exe e 28 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 6
+      run: flowey.exe e 28 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 7
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
       run: flowey.exe e 28 flowey_lib_common::cache 3
@@ -6236,9 +6282,6 @@ jobs:
         echo "$AgentTempDirNormal/used_artifacts/aarch64-tmks" | flowey v 29 'artifact_use_from_aarch64-tmks' --is-raw-string update
         echo "$AgentTempDirNormal/used_artifacts/x64-linux-incubator" | flowey v 29 'artifact_use_from_x64-linux-incubator' --is-raw-string update
       shell: bash
-    - name: ensure hypervisor device is accessible
-      run: flowey e 29 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
-      shell: bash
     - name: create cargo-nextest cache dir
       run: |-
         flowey e 29 flowey_lib_common::download_cargo_nextest 0
@@ -6291,7 +6334,7 @@ jobs:
       run: |-
         flowey e 29 flowey_lib_common::system_info 0
         flowey e 29 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-        flowey e 29 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+        flowey e 29 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
       shell: bash
     - name: create gh-release-download cache dir
       run: flowey e 29 flowey_lib_common::download_gh_release 0
@@ -6316,12 +6359,18 @@ jobs:
         flowey e 29 flowey_lib_common::cache 10
         flowey e 29 flowey_lib_common::download_gh_release 1
       shell: bash
+    - name: unpack openvmm-test-linux archives
+      run: flowey e 29 flowey_lib_hvlite::resolve_openvmm_test_linux_kernel 0
+      shell: bash
+    - name: unpack openvmm-test-initrd archives
+      run: flowey e 29 flowey_lib_hvlite::resolve_openvmm_test_initrd 0
+      shell: bash
     - name: unpack QEMU archive
       run: |-
         flowey e 29 flowey_lib_hvlite::resolve_openvmm_qemu 0
         flowey e 29 flowey_core::pipeline::artifact::resolve 6
-        flowey e 29 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
         flowey e 29 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+        flowey e 29 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
         flowey e 29 flowey_core::pipeline::artifact::resolve 4
         flowey e 29 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 5
         flowey v 29 'flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:0:flowey_core/src/node/github_context.rs' --is-raw-string update --env-source runner.temp <<EOF
@@ -6388,12 +6437,6 @@ jobs:
         flowey e 29 flowey_lib_common::download_gh_artifact 0
         flowey e 29 flowey_lib_hvlite::download_release_igvm_files_from_gh::resolve 0
       shell: bash
-    - name: unpack openvmm-test-initrd archives
-      run: flowey e 29 flowey_lib_hvlite::resolve_openvmm_test_initrd 0
-      shell: bash
-    - name: unpack openvmm-test-linux archives
-      run: flowey e 29 flowey_lib_hvlite::resolve_openvmm_test_linux_kernel 0
-      shell: bash
     - name: unpack mu_msvm package (aarch64)
       run: flowey e 29 flowey_lib_hvlite::download_uefi_mu_msvm 0
       shell: bash
@@ -6406,16 +6449,14 @@ jobs:
     - name: compute incubator target runner env
       run: |-
         flowey e 29 flowey_lib_hvlite::write_incubator_target_runner 0
-        flowey e 29 flowey_lib_hvlite::run_cargo_nextest_run 1
-        flowey e 29 flowey_lib_hvlite::test_nextest_vmm_tests_archive 1
+        flowey e 29 flowey_lib_hvlite::run_cargo_nextest_run 0
+        flowey e 29 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
       shell: bash
     - name: generate nextest command
       run: flowey e 29 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       shell: bash
     - name: install vmm tests deps (linux)
-      run: |-
-        flowey e 29 flowey_lib_hvlite::install_vmm_tests_deps 0
-        flowey e 29 flowey_lib_hvlite::run_cargo_nextest_run 0
+      run: flowey e 29 flowey_lib_hvlite::install_vmm_tests_deps 0
       shell: bash
     - name: run 'vmm_tests' nextest tests
       run: |-
@@ -6423,10 +6464,13 @@ jobs:
         flowey e 29 flowey_lib_common::run_cargo_nextest_run 1
         flowey e 29 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 6
       shell: bash
+    - name: rename and create new log dir
+      run: flowey e 29 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 7
+      shell: bash
     - name: summarize failing vmm tests
       run: |-
-        flowey e 29 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 7
         flowey e 29 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 8
+        flowey e 29 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 9
         flowey e 29 flowey_lib_common::publish_test_results 0
         flowey e 29 flowey_lib_common::publish_test_results 1
         flowey v 29 'flowey_lib_common::publish_test_results:2:flowey_lib_common/src/publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env github floweyvar1
@@ -6454,7 +6498,7 @@ jobs:
       name: 'publish test results: aarch64-linux-tcg-vmm-tests (logs)'
       if: ${{ fromJSON(env.FLOWEY_CONDITION) }}
     - name: report test results to overall pipeline status
-      run: flowey e 29 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 9
+      run: flowey e 29 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 10
       shell: bash
     - name: 'validate cache entry: cargo-nextest'
       run: flowey e 29 flowey_lib_common::cache 3

--- a/ci-flowey/openvmm-pr.yaml
+++ b/ci-flowey/openvmm-pr.yaml
@@ -473,7 +473,7 @@ jobs:
       set -e
       $(FLOWEY_BIN) e 15 flowey_lib_common::install_cargo_nextest 0
       $(FLOWEY_BIN) e 15 flowey_lib_hvlite::init_cross_build 3
-      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::run_cargo_nextest_run 0
+      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::run_cargo_nextest_run 4
     displayName: installing cargo-nextest
   - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 3
     displayName: generate nextest command
@@ -495,7 +495,10 @@ jobs:
       testRunTitle: x64-linux-musl-unit-tests-crypto-rust
     displayName: 'publish test results: x64-linux-musl-unit-tests-crypto-rust (JUnit XML)'
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
-  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::run_cargo_nextest_run 3
+      $(FLOWEY_BIN) e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 2
     displayName: generate nextest command
   - bash: |-
       set -e
@@ -515,7 +518,10 @@ jobs:
       testRunTitle: x64-linux-musl-unit-tests-crypto-openssl
     displayName: 'publish test results: x64-linux-musl-unit-tests-crypto-openssl (JUnit XML)'
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
-  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 4
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::run_cargo_nextest_run 5
+      $(FLOWEY_BIN) e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 4
     displayName: generate nextest command
   - bash: |-
       set -e
@@ -535,7 +541,10 @@ jobs:
       testRunTitle: x64-linux-musl-unit-tests-crypto-symcrypt
     displayName: 'publish test results: x64-linux-musl-unit-tests-crypto-symcrypt (JUnit XML)'
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
-  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::run_cargo_nextest_run 1
+      $(FLOWEY_BIN) e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 0
     displayName: generate nextest command
   - bash: |-
       set -e
@@ -567,7 +576,10 @@ jobs:
       $(FLOWEY_BIN) e 15 flowey_lib_hvlite::run_cargo_build 3
       $(FLOWEY_BIN) e 15 flowey_lib_hvlite::build_xtask 1
     displayName: split debug symbols
-  - bash: $(FLOWEY_BIN) e 15 flowey_lib_hvlite::build_nextest_unit_tests 0
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::build_nextest_unit_tests 0
+      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::run_cargo_nextest_run 0
     displayName: determine unit test exclusions
   - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 5
     displayName: generate nextest command
@@ -589,7 +601,10 @@ jobs:
       testRunTitle: x64-linux-musl-unit-tests-base
     displayName: 'publish test results: x64-linux-musl-unit-tests-base (JUnit XML)'
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
-  - bash: $(FLOWEY_BIN) e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 15 flowey_lib_hvlite::run_cargo_nextest_run 2
+      $(FLOWEY_BIN) e 15 flowey_lib_common::gen_cargo_nextest_run_cmd 1
     displayName: generate nextest command
   - bash: |-
       set -e
@@ -782,7 +797,7 @@ jobs:
       set -e
       $(FLOWEY_BIN) e 14 flowey_lib_common::install_cargo_nextest 0
       $(FLOWEY_BIN) e 14 flowey_lib_hvlite::init_cross_build 0
-      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::run_cargo_nextest_run 0
+      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::run_cargo_nextest_run 4
     displayName: installing cargo-nextest
   - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 3
     displayName: generate nextest command
@@ -804,7 +819,10 @@ jobs:
       testRunTitle: x64-linux-unit-tests-crypto-rust
     displayName: 'publish test results: x64-linux-unit-tests-crypto-rust (JUnit XML)'
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
-  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 2
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::run_cargo_nextest_run 3
+      $(FLOWEY_BIN) e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 2
     displayName: generate nextest command
   - bash: |-
       set -e
@@ -824,7 +842,10 @@ jobs:
       testRunTitle: x64-linux-unit-tests-crypto-openssl
     displayName: 'publish test results: x64-linux-unit-tests-crypto-openssl (JUnit XML)'
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
-  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::run_cargo_nextest_run 1
+      $(FLOWEY_BIN) e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 0
     displayName: generate nextest command
   - bash: |-
       set -e
@@ -856,7 +877,10 @@ jobs:
       $(FLOWEY_BIN) e 14 flowey_lib_hvlite::run_cargo_build 3
       $(FLOWEY_BIN) e 14 flowey_lib_hvlite::build_xtask 1
     displayName: split debug symbols
-  - bash: $(FLOWEY_BIN) e 14 flowey_lib_hvlite::build_nextest_unit_tests 0
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::build_nextest_unit_tests 0
+      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::run_cargo_nextest_run 0
     displayName: determine unit test exclusions
   - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 4
     displayName: generate nextest command
@@ -878,7 +902,10 @@ jobs:
       testRunTitle: x64-linux-unit-tests-base
     displayName: 'publish test results: x64-linux-unit-tests-base (JUnit XML)'
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
-  - bash: $(FLOWEY_BIN) e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 14 flowey_lib_hvlite::run_cargo_nextest_run 2
+      $(FLOWEY_BIN) e 14 flowey_lib_common::gen_cargo_nextest_run_cmd 1
     displayName: generate nextest command
   - bash: |-
       set -e
@@ -1141,7 +1168,10 @@ jobs:
       testRunTitle: x64-windows-unit-tests-base
     displayName: 'publish test results: x64-windows-unit-tests-base (JUnit XML)'
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
-  - bash: $(FLOWEY_BIN) e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::run_cargo_nextest_run 1
+      $(FLOWEY_BIN) e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 0
     displayName: generate nextest command
   - bash: |-
       set -e
@@ -1161,7 +1191,10 @@ jobs:
       testRunTitle: x64-windows-unit-tests-crypto-native
     displayName: 'publish test results: x64-windows-unit-tests-crypto-native (JUnit XML)'
     condition: and(eq(variables['FLOWEY_CONDITION'], true), succeeded(), not(canceled()))
-  - bash: $(FLOWEY_BIN) e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 1
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 13 flowey_lib_hvlite::run_cargo_nextest_run 2
+      $(FLOWEY_BIN) e 13 flowey_lib_common::gen_cargo_nextest_run_cmd 1
     displayName: generate nextest command
   - bash: |-
       set -e
@@ -4053,8 +4086,6 @@ jobs:
       echo "$(FLOWEY_TEMP_DIR)/used_artifacts/aarch64-tmks" | $FLOWEY_BIN v 20 'artifact_use_from_aarch64-tmks' --is-raw-string update
       echo "$(FLOWEY_TEMP_DIR)/used_artifacts/x64-linux-incubator" | $FLOWEY_BIN v 20 'artifact_use_from_x64-linux-incubator' --is-raw-string update
     displayName: 🌼🛫 Initialize job
-  - bash: $(FLOWEY_BIN) e 20 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
-    displayName: ensure hypervisor device is accessible
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 20 flowey_lib_common::download_cargo_nextest 0
@@ -4108,26 +4139,8 @@ jobs:
       set -e
       $(FLOWEY_BIN) e 20 flowey_lib_common::system_info 0
       $(FLOWEY_BIN) e 20 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
-      $(FLOWEY_BIN) e 20 flowey_core::pipeline::artifact::resolve 6
       $(FLOWEY_BIN) e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
-      $(FLOWEY_BIN) e 20 flowey_core::pipeline::artifact::resolve 4
-      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 5
-      $FLOWEY_BIN v 20 'flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:0:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs' --is-raw-string update --env-source Pipeline.Workspace <<'EOF'
-      $(Pipeline.Workspace)
-      EOF
-      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
-      $(FLOWEY_BIN) e 20 flowey_core::pipeline::artifact::resolve 1
-      $(FLOWEY_BIN) e 20 flowey_core::pipeline::artifact::resolve 2
-      $(FLOWEY_BIN) e 20 flowey_core::pipeline::artifact::resolve 0
-      $(FLOWEY_BIN) e 20 flowey_core::pipeline::artifact::resolve 5
-      $(FLOWEY_BIN) e 20 flowey_core::pipeline::artifact::resolve 3
     displayName: print system info
-  - bash: $(FLOWEY_BIN) e 20 flowey_lib_common::install_dist_pkg 0
-    displayName: checking if packages need to be installed
-  - bash: $(FLOWEY_BIN) e 20 flowey_lib_common::install_dist_pkg 1
-    displayName: installing packages
   - bash: $(FLOWEY_BIN) e 20 flowey_lib_common::download_gh_release 0
     displayName: create gh-release-download cache dir
   - bash: |-
@@ -4151,6 +4164,32 @@ jobs:
     displayName: map ADO hitvar to flowey
   - bash: $(FLOWEY_BIN) e 20 flowey_lib_common::download_gh_release 1
     displayName: download artifacts from github releases
+  - bash: $(FLOWEY_BIN) e 20 flowey_lib_hvlite::resolve_openvmm_test_linux_kernel 0
+    displayName: unpack openvmm-test-linux archives
+  - bash: $(FLOWEY_BIN) e 20 flowey_lib_hvlite::resolve_openvmm_test_initrd 0
+    displayName: unpack openvmm-test-initrd archives
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::resolve_openvmm_qemu 0
+      $(FLOWEY_BIN) e 20 flowey_core::pipeline::artifact::resolve 6
+      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+      $(FLOWEY_BIN) e 20 flowey_core::pipeline::artifact::resolve 4
+      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 5
+      $FLOWEY_BIN v 20 'flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:0:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs' --is-raw-string update --env-source Pipeline.Workspace <<'EOF'
+      $(Pipeline.Workspace)
+      EOF
+      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+      $(FLOWEY_BIN) e 20 flowey_core::pipeline::artifact::resolve 1
+      $(FLOWEY_BIN) e 20 flowey_core::pipeline::artifact::resolve 2
+      $(FLOWEY_BIN) e 20 flowey_core::pipeline::artifact::resolve 0
+      $(FLOWEY_BIN) e 20 flowey_core::pipeline::artifact::resolve 5
+      $(FLOWEY_BIN) e 20 flowey_core::pipeline::artifact::resolve 3
+    displayName: unpack QEMU archive
+  - bash: $(FLOWEY_BIN) e 20 flowey_lib_common::install_dist_pkg 0
+    displayName: checking if packages need to be installed
+  - bash: $(FLOWEY_BIN) e 20 flowey_lib_common::install_dist_pkg 1
+    displayName: installing packages
   - bash: $(FLOWEY_BIN) e 20 flowey_lib_common::download_azcopy 0
     displayName: extract azcopy from archive
   - bash: $(FLOWEY_BIN) e 20 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
@@ -4160,30 +4199,21 @@ jobs:
       $(FLOWEY_BIN) e 20 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
       $(FLOWEY_BIN) e 20 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
     displayName: downloading VMM test disk images
-  - bash: $(FLOWEY_BIN) e 20 flowey_lib_hvlite::resolve_openvmm_test_initrd 0
-    displayName: unpack openvmm-test-initrd archives
-  - bash: $(FLOWEY_BIN) e 20 flowey_lib_hvlite::resolve_openvmm_test_linux_kernel 0
-    displayName: unpack openvmm-test-linux archives
   - bash: $(FLOWEY_BIN) e 20 flowey_lib_hvlite::download_uefi_mu_msvm 0
     displayName: unpack mu_msvm package (aarch64)
   - bash: $(FLOWEY_BIN) e 20 flowey_lib_hvlite::resolve_openvmm_test_virtio_win 0
     displayName: unpack openvmm-test-virtio-win archive
   - bash: $(FLOWEY_BIN) e 20 flowey_lib_hvlite::init_vmm_tests_env 0
     displayName: setting up vmm_tests env
-  - bash: $(FLOWEY_BIN) e 20 flowey_lib_hvlite::resolve_openvmm_qemu 0
-    displayName: unpack QEMU archive
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 20 flowey_lib_hvlite::write_incubator_target_runner 0
-      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::run_cargo_nextest_run 1
-      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::test_nextest_vmm_tests_archive 1
+      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::run_cargo_nextest_run 0
+      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
     displayName: compute incubator target runner env
   - bash: $(FLOWEY_BIN) e 20 flowey_lib_common::gen_cargo_nextest_run_cmd 0
     displayName: generate nextest command
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::install_vmm_tests_deps 0
-      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::run_cargo_nextest_run 0
+  - bash: $(FLOWEY_BIN) e 20 flowey_lib_hvlite::install_vmm_tests_deps 0
     displayName: install vmm tests deps (linux)
   - bash: |-
       set -e
@@ -4191,10 +4221,12 @@ jobs:
       $(FLOWEY_BIN) e 20 flowey_lib_common::run_cargo_nextest_run 1
       $(FLOWEY_BIN) e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 6
     displayName: run 'vmm_tests' nextest tests
+  - bash: $(FLOWEY_BIN) e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 7
+    displayName: rename and create new log dir
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 7
       $(FLOWEY_BIN) e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 8
+      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 9
       $(FLOWEY_BIN) e 20 flowey_lib_common::publish_test_results 1
       $(FLOWEY_BIN) e 20 flowey_lib_common::ado_task_publish_test_results 0
       $(FLOWEY_BIN) e 20 flowey_lib_common::publish_test_results 0
@@ -4212,7 +4244,7 @@ jobs:
       set -e
       $(FLOWEY_BIN) e 20 flowey_lib_common::publish_test_results 2
       $(FLOWEY_BIN) e 20 flowey_lib_common::publish_test_results 3
-      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 9
+      $(FLOWEY_BIN) e 20 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 10
     displayName: report test results to overall pipeline status
   - bash: $(FLOWEY_BIN) e 20 flowey_lib_common::cache 3
     displayName: 'validate cache entry: cargo-nextest'
@@ -4491,71 +4523,6 @@ jobs:
     displayName: 🌼🛫 Initialize job
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 8
-      $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 2
-      $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 3
-      $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 4
-      $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 1
-      $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 0
-      $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 7
-      $FLOWEY_BIN v 19 'flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:0:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs' --is-raw-string update --env-source Pipeline.Workspace <<'EOF'
-      $(Pipeline.Workspace)
-      EOF
-      $(FLOWEY_BIN) e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
-      $(FLOWEY_BIN) e 19 flowey_lib_common::install_dist_pkg 0
-    displayName: checking if packages need to be installed
-  - bash: $(FLOWEY_BIN) e 19 flowey_lib_common::install_dist_pkg 1
-    displayName: installing packages
-  - bash: $(FLOWEY_BIN) e 19 flowey_lib_common::download_gh_release 0
-    displayName: create gh-release-download cache dir
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 19 flowey_lib_common::cache 4
-      $FLOWEY_BIN v 19 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar5
-      $FLOWEY_BIN v 19 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar6
-    displayName: Pre-processing cache vars
-  - task: Cache@2
-    inputs:
-      key: $(floweyvar6)
-      path: $(floweyvar5)
-      cacheHitVar: FLOWEY_CACHE_HITVAR
-    displayName: 'Restore cache: gh-release-download'
-  - bash: |-
-      set -e
-      $FLOWEY_BIN v 19 'flowey_lib_common::cache:11:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
-      $(FLOWEY_CACHE_HITVAR)
-      EOF
-      $(FLOWEY_BIN) e 19 flowey_lib_common::cache 6
-    displayName: map ADO hitvar to flowey
-  - bash: $(FLOWEY_BIN) e 19 flowey_lib_common::download_gh_release 1
-    displayName: download artifacts from github releases
-  - bash: $(FLOWEY_BIN) e 19 flowey_lib_common::download_azcopy 0
-    displayName: extract azcopy from archive
-  - bash: $(FLOWEY_BIN) e 19 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
-    displayName: calculating required VMM tests disk images
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 19 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
-      $(FLOWEY_BIN) e 19 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
-    displayName: downloading VMM test disk images
-  - bash: $(FLOWEY_BIN) e 19 flowey_lib_hvlite::resolve_openvmm_test_initrd 0
-    displayName: unpack openvmm-test-initrd archives
-  - bash: $(FLOWEY_BIN) e 19 flowey_lib_hvlite::resolve_openvmm_test_linux_kernel 0
-    displayName: unpack openvmm-test-linux archives
-  - bash: $(FLOWEY_BIN) e 19 flowey_lib_hvlite::download_uefi_mu_msvm 0
-    displayName: unpack mu_msvm package (x64)
-  - bash: $(FLOWEY_BIN) e 19 flowey_lib_hvlite::resolve_openvmm_test_virtio_win 0
-    displayName: unpack openvmm-test-virtio-win archive
-  - bash: $(FLOWEY_BIN) e 19 flowey_lib_hvlite::init_vmm_tests_env 0
-    displayName: setting up vmm_tests env
-  - bash: $(FLOWEY_BIN) e 19 flowey_lib_hvlite::test_nextest_vmm_tests_archive 1
-    displayName: ensure hypervisor device is accessible
-  - bash: $(FLOWEY_BIN) e 19 flowey_lib_hvlite::test_nextest_vmm_tests_archive 2
-    displayName: ensure 2 MiB hugetlb pages are available
-  - bash: $(FLOWEY_BIN) e 19 flowey_lib_hvlite::test_nextest_vmm_tests_archive 3
-    displayName: prepare vhost-vsock
-  - bash: |-
-      set -e
       $(FLOWEY_BIN) e 19 flowey_lib_common::download_cargo_nextest 0
       $(FLOWEY_BIN) e 19 flowey_lib_common::download_cargo_nextest 1
       $(FLOWEY_BIN) e 19 flowey_lib_common::download_cargo_nextest 2
@@ -4607,31 +4574,91 @@ jobs:
       set -e
       $(FLOWEY_BIN) e 19 flowey_lib_common::system_info 0
       $(FLOWEY_BIN) e 19 flowey_lib_hvlite::git_checkout_openvmm_repo 0
-      $(FLOWEY_BIN) e 19 flowey_lib_hvlite::run_cargo_nextest_run 0
-      $(FLOWEY_BIN) e 19 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
-      $(FLOWEY_BIN) e 19 flowey_lib_hvlite::run_cargo_nextest_run 1
-      $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 6
-      $(FLOWEY_BIN) e 19 flowey_lib_hvlite::test_nextest_vmm_tests_archive 4
+      $(FLOWEY_BIN) e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+      $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 8
+      $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 2
+      $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 3
+      $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 4
+      $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 1
+      $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 0
+      $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 7
+      $FLOWEY_BIN v 19 'flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:0:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs' --is-raw-string update --env-source Pipeline.Workspace <<'EOF'
+      $(Pipeline.Workspace)
+      EOF
+      $(FLOWEY_BIN) e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
     displayName: print system info
-  - bash: $(FLOWEY_BIN) e 19 flowey_lib_common::gen_cargo_nextest_run_cmd 0
-    displayName: generate nextest command
+  - bash: $(FLOWEY_BIN) e 19 flowey_lib_common::install_dist_pkg 0
+    displayName: checking if packages need to be installed
+  - bash: $(FLOWEY_BIN) e 19 flowey_lib_common::install_dist_pkg 1
+    displayName: installing packages
+  - bash: $(FLOWEY_BIN) e 19 flowey_lib_common::download_gh_release 0
+    displayName: create gh-release-download cache dir
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 19 flowey_lib_hvlite::install_vmm_tests_deps 0
+      $(FLOWEY_BIN) e 19 flowey_lib_common::cache 4
+      $FLOWEY_BIN v 19 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar5
+      $FLOWEY_BIN v 19 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar6
+    displayName: Pre-processing cache vars
+  - task: Cache@2
+    inputs:
+      key: $(floweyvar6)
+      path: $(floweyvar5)
+      cacheHitVar: FLOWEY_CACHE_HITVAR
+    displayName: 'Restore cache: gh-release-download'
+  - bash: |-
+      set -e
+      $FLOWEY_BIN v 19 'flowey_lib_common::cache:11:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $(FLOWEY_CACHE_HITVAR)
+      EOF
+      $(FLOWEY_BIN) e 19 flowey_lib_common::cache 6
+    displayName: map ADO hitvar to flowey
+  - bash: $(FLOWEY_BIN) e 19 flowey_lib_common::download_gh_release 1
+    displayName: download artifacts from github releases
+  - bash: $(FLOWEY_BIN) e 19 flowey_lib_common::download_azcopy 0
+    displayName: extract azcopy from archive
+  - bash: $(FLOWEY_BIN) e 19 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
+    displayName: calculating required VMM tests disk images
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 19 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+      $(FLOWEY_BIN) e 19 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
+    displayName: downloading VMM test disk images
+  - bash: $(FLOWEY_BIN) e 19 flowey_lib_hvlite::resolve_openvmm_test_initrd 0
+    displayName: unpack openvmm-test-initrd archives
+  - bash: $(FLOWEY_BIN) e 19 flowey_lib_hvlite::resolve_openvmm_test_linux_kernel 0
+    displayName: unpack openvmm-test-linux archives
+  - bash: $(FLOWEY_BIN) e 19 flowey_lib_hvlite::download_uefi_mu_msvm 0
+    displayName: unpack mu_msvm package (x64)
+  - bash: $(FLOWEY_BIN) e 19 flowey_lib_hvlite::resolve_openvmm_test_virtio_win 0
+    displayName: unpack openvmm-test-virtio-win archive
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 19 flowey_lib_hvlite::init_vmm_tests_env 0
+      $(FLOWEY_BIN) e 19 flowey_lib_hvlite::run_cargo_nextest_run 0
+      $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 6
+      $(FLOWEY_BIN) e 19 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
+    displayName: setting up vmm_tests env
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 19 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 5
-    displayName: install vmm tests deps (linux)
+    displayName: generate nextest command
   - bash: $(FLOWEY_BIN) e 19 flowey_lib_hvlite::run_prep_steps 0
     displayName: running vmm_test prep_steps
+  - bash: $(FLOWEY_BIN) e 19 flowey_lib_hvlite::install_vmm_tests_deps 0
+    displayName: install vmm tests deps (linux)
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 19 flowey_lib_common::run_cargo_nextest_run 0
       $(FLOWEY_BIN) e 19 flowey_lib_common::run_cargo_nextest_run 1
-      $(FLOWEY_BIN) e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+      $(FLOWEY_BIN) e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
     displayName: run 'vmm_tests' nextest tests
+  - bash: $(FLOWEY_BIN) e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+    displayName: rename and create new log dir
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
-      $(FLOWEY_BIN) e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+      $(FLOWEY_BIN) e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 5
+      $(FLOWEY_BIN) e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 6
       $(FLOWEY_BIN) e 19 flowey_lib_common::publish_test_results 1
       $(FLOWEY_BIN) e 19 flowey_lib_common::ado_task_publish_test_results 0
       $(FLOWEY_BIN) e 19 flowey_lib_common::publish_test_results 0
@@ -4649,7 +4676,7 @@ jobs:
       set -e
       $(FLOWEY_BIN) e 19 flowey_lib_common::publish_test_results 2
       $(FLOWEY_BIN) e 19 flowey_lib_common::publish_test_results 3
-      $(FLOWEY_BIN) e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 5
+      $(FLOWEY_BIN) e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 7
     displayName: report test results to overall pipeline status
   - bash: $(FLOWEY_BIN) e 19 flowey_lib_common::cache 3
     displayName: 'validate cache entry: cargo-nextest'
@@ -4800,69 +4827,6 @@ jobs:
     displayName: 🌼🛫 Initialize job
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 8
-      $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 9
-      $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 12
-      $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 14
-      $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 15
-      $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 13
-      $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 3
-      $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 11
-      $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 4
-      $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 5
-      $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 6
-      $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 1
-      $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 2
-      $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 0
-      $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 7
-      $FLOWEY_BIN v 18 'flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:0:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs' --is-raw-string update --env-source Pipeline.Workspace <<'EOF'
-      $(Pipeline.Workspace)
-      EOF
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
-      $(FLOWEY_BIN) e 18 flowey_lib_common::download_gh_release 0
-    displayName: create gh-release-download cache dir
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 18 flowey_lib_common::cache 4
-      $FLOWEY_BIN v 18 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar5
-      $FLOWEY_BIN v 18 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar6
-    displayName: Pre-processing cache vars
-  - task: Cache@2
-    inputs:
-      key: $(floweyvar6)
-      path: $(floweyvar5)
-      cacheHitVar: FLOWEY_CACHE_HITVAR
-    displayName: 'Restore cache: gh-release-download'
-  - bash: |-
-      set -e
-      $FLOWEY_BIN v 18 'flowey_lib_common::cache:11:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
-      $(FLOWEY_CACHE_HITVAR)
-      EOF
-      $(FLOWEY_BIN) e 18 flowey_lib_common::cache 6
-    displayName: map ADO hitvar to flowey
-  - bash: $(FLOWEY_BIN) e 18 flowey_lib_common::download_gh_release 1
-    displayName: download artifacts from github releases
-  - bash: $(FLOWEY_BIN) e 18 flowey_lib_common::download_azcopy 0
-    displayName: extract azcopy from archive
-  - bash: $(FLOWEY_BIN) e 18 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
-    displayName: calculating required VMM tests disk images
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
-    displayName: downloading VMM test disk images
-  - bash: $(FLOWEY_BIN) e 18 flowey_lib_hvlite::resolve_openvmm_test_initrd 0
-    displayName: unpack openvmm-test-initrd archives
-  - bash: $(FLOWEY_BIN) e 18 flowey_lib_hvlite::resolve_openvmm_test_linux_kernel 0
-    displayName: unpack openvmm-test-linux archives
-  - bash: $(FLOWEY_BIN) e 18 flowey_lib_hvlite::download_uefi_mu_msvm 0
-    displayName: unpack mu_msvm package (x64)
-  - bash: $(FLOWEY_BIN) e 18 flowey_lib_hvlite::resolve_openvmm_test_virtio_win 0
-    displayName: unpack openvmm-test-virtio-win archive
-  - bash: $(FLOWEY_BIN) e 18 flowey_lib_hvlite::init_vmm_tests_env 0
-    displayName: setting up vmm_tests env
-  - bash: |-
-      set -e
       $(FLOWEY_BIN) e 18 flowey_lib_common::download_cargo_nextest 0
       $(FLOWEY_BIN) e 18 flowey_lib_common::download_cargo_nextest 1
       $(FLOWEY_BIN) e 18 flowey_lib_common::download_cargo_nextest 2
@@ -4914,43 +4878,107 @@ jobs:
       set -e
       $(FLOWEY_BIN) e 18 flowey_lib_common::system_info 0
       $(FLOWEY_BIN) e 18 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+      $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 8
+      $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 9
+      $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 12
+      $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 14
+      $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 15
+      $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 13
+      $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 3
+      $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 11
+      $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 4
+      $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 5
+      $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 6
+      $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 1
+      $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 2
+      $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 0
+      $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 7
+      $FLOWEY_BIN v 18 'flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:0:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs' --is-raw-string update --env-source Pipeline.Workspace <<'EOF'
+      $(Pipeline.Workspace)
+      EOF
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+    displayName: print system info
+  - bash: $(FLOWEY_BIN) e 18 flowey_lib_common::download_gh_release 0
+    displayName: create gh-release-download cache dir
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 18 flowey_lib_common::cache 4
+      $FLOWEY_BIN v 18 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar5
+      $FLOWEY_BIN v 18 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar6
+    displayName: Pre-processing cache vars
+  - task: Cache@2
+    inputs:
+      key: $(floweyvar6)
+      path: $(floweyvar5)
+      cacheHitVar: FLOWEY_CACHE_HITVAR
+    displayName: 'Restore cache: gh-release-download'
+  - bash: |-
+      set -e
+      $FLOWEY_BIN v 18 'flowey_lib_common::cache:11:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $(FLOWEY_CACHE_HITVAR)
+      EOF
+      $(FLOWEY_BIN) e 18 flowey_lib_common::cache 6
+    displayName: map ADO hitvar to flowey
+  - bash: $(FLOWEY_BIN) e 18 flowey_lib_common::download_gh_release 1
+    displayName: download artifacts from github releases
+  - bash: $(FLOWEY_BIN) e 18 flowey_lib_common::download_azcopy 0
+    displayName: extract azcopy from archive
+  - bash: $(FLOWEY_BIN) e 18 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
+    displayName: calculating required VMM tests disk images
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
+    displayName: downloading VMM test disk images
+  - bash: $(FLOWEY_BIN) e 18 flowey_lib_hvlite::resolve_openvmm_test_initrd 0
+    displayName: unpack openvmm-test-initrd archives
+  - bash: $(FLOWEY_BIN) e 18 flowey_lib_hvlite::resolve_openvmm_test_linux_kernel 0
+    displayName: unpack openvmm-test-linux archives
+  - bash: $(FLOWEY_BIN) e 18 flowey_lib_hvlite::download_uefi_mu_msvm 0
+    displayName: unpack mu_msvm package (x64)
+  - bash: $(FLOWEY_BIN) e 18 flowey_lib_hvlite::resolve_openvmm_test_virtio_win 0
+    displayName: unpack openvmm-test-virtio-win archive
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::init_vmm_tests_env 0
       $(FLOWEY_BIN) e 18 flowey_lib_hvlite::run_cargo_nextest_run 0
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::run_cargo_nextest_run 1
       $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 16
       $(FLOWEY_BIN) e 18 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
-    displayName: print system info
-  - bash: $(FLOWEY_BIN) e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+    displayName: setting up vmm_tests env
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 10
     displayName: generate nextest command
+  - bash: $(FLOWEY_BIN) e 18 flowey_lib_hvlite::run_prep_steps 0
+    displayName: running vmm_test prep_steps
+  - bash: $(FLOWEY_BIN) e 18 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+    displayName: starting test_igvm_agent_rpc_server
   - bash: $(FLOWEY_BIN) e 18 flowey_lib_hvlite::install_vmm_tests_deps 0
     displayName: install vmm tests deps (windows)
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
-      $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 10
-    displayName: starting test_igvm_agent_rpc_server
-  - bash: $(FLOWEY_BIN) e 18 flowey_lib_hvlite::run_prep_steps 0
-    displayName: running vmm_test prep_steps
-  - bash: |-
-      set -e
       $(FLOWEY_BIN) e 18 flowey_lib_common::run_cargo_nextest_run 0
       $(FLOWEY_BIN) e 18 flowey_lib_common::run_cargo_nextest_run 1
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
     displayName: run 'vmm_tests' nextest tests
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-    displayName: summarize failing vmm tests
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+    displayName: stopping test_igvm_agent_rpc_server
+  - bash: $(FLOWEY_BIN) e 18 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+    displayName: rename and create new log dir
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
       $(FLOWEY_BIN) e 18 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 5
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 6
       $(FLOWEY_BIN) e 18 flowey_lib_common::publish_test_results 1
       $(FLOWEY_BIN) e 18 flowey_lib_common::ado_task_publish_test_results 0
       $(FLOWEY_BIN) e 18 flowey_lib_common::publish_test_results 0
       $FLOWEY_BIN v 18 'flowey_lib_common::ado_task_publish_test_results:0:flowey_lib_common/src/ado_task_publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env ado floweyvar1
       $FLOWEY_BIN v 18 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs' write-to-env ado FLOWEY_CONDITION
-    displayName: stopping test_igvm_agent_rpc_server
+    displayName: summarize failing vmm tests
   - task: PublishTestResults@2
     inputs:
       testResultsFormat: JUnit
@@ -4962,7 +4990,7 @@ jobs:
       set -e
       $(FLOWEY_BIN) e 18 flowey_lib_common::publish_test_results 2
       $(FLOWEY_BIN) e 18 flowey_lib_common::publish_test_results 3
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 6
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 7
     displayName: report test results to overall pipeline status
   - bash: $(FLOWEY_BIN) e 18 flowey_lib_common::cache 3
     displayName: 'validate cache entry: cargo-nextest'
@@ -5113,69 +5141,6 @@ jobs:
     displayName: 🌼🛫 Initialize job
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 11
-      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 4
-      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 5
-      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 6
-      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 1
-      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 2
-      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 0
-      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 7
-      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 8
-      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 9
-      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 12
-      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 14
-      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 15
-      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 13
-      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 3
-      $FLOWEY_BIN v 17 'flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:0:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs' --is-raw-string update --env-source Pipeline.Workspace <<'EOF'
-      $(Pipeline.Workspace)
-      EOF
-      $(FLOWEY_BIN) e 17 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
-      $(FLOWEY_BIN) e 17 flowey_lib_common::download_gh_release 0
-    displayName: create gh-release-download cache dir
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 17 flowey_lib_common::cache 4
-      $FLOWEY_BIN v 17 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar5
-      $FLOWEY_BIN v 17 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar6
-    displayName: Pre-processing cache vars
-  - task: Cache@2
-    inputs:
-      key: $(floweyvar6)
-      path: $(floweyvar5)
-      cacheHitVar: FLOWEY_CACHE_HITVAR
-    displayName: 'Restore cache: gh-release-download'
-  - bash: |-
-      set -e
-      $FLOWEY_BIN v 17 'flowey_lib_common::cache:11:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
-      $(FLOWEY_CACHE_HITVAR)
-      EOF
-      $(FLOWEY_BIN) e 17 flowey_lib_common::cache 6
-    displayName: map ADO hitvar to flowey
-  - bash: $(FLOWEY_BIN) e 17 flowey_lib_common::download_gh_release 1
-    displayName: download artifacts from github releases
-  - bash: $(FLOWEY_BIN) e 17 flowey_lib_common::download_azcopy 0
-    displayName: extract azcopy from archive
-  - bash: $(FLOWEY_BIN) e 17 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
-    displayName: calculating required VMM tests disk images
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 17 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
-      $(FLOWEY_BIN) e 17 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
-    displayName: downloading VMM test disk images
-  - bash: $(FLOWEY_BIN) e 17 flowey_lib_hvlite::resolve_openvmm_test_initrd 0
-    displayName: unpack openvmm-test-initrd archives
-  - bash: $(FLOWEY_BIN) e 17 flowey_lib_hvlite::resolve_openvmm_test_linux_kernel 0
-    displayName: unpack openvmm-test-linux archives
-  - bash: $(FLOWEY_BIN) e 17 flowey_lib_hvlite::download_uefi_mu_msvm 0
-    displayName: unpack mu_msvm package (x64)
-  - bash: $(FLOWEY_BIN) e 17 flowey_lib_hvlite::resolve_openvmm_test_virtio_win 0
-    displayName: unpack openvmm-test-virtio-win archive
-  - bash: $(FLOWEY_BIN) e 17 flowey_lib_hvlite::init_vmm_tests_env 0
-    displayName: setting up vmm_tests env
-  - bash: |-
-      set -e
       $(FLOWEY_BIN) e 17 flowey_lib_common::download_cargo_nextest 0
       $(FLOWEY_BIN) e 17 flowey_lib_common::download_cargo_nextest 1
       $(FLOWEY_BIN) e 17 flowey_lib_common::download_cargo_nextest 2
@@ -5227,38 +5192,102 @@ jobs:
       set -e
       $(FLOWEY_BIN) e 17 flowey_lib_common::system_info 0
       $(FLOWEY_BIN) e 17 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+      $(FLOWEY_BIN) e 17 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 11
+      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 4
+      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 5
+      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 6
+      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 1
+      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 2
+      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 0
+      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 7
+      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 8
+      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 9
+      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 12
+      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 14
+      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 15
+      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 13
+      $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 3
+      $FLOWEY_BIN v 17 'flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:0:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs' --is-raw-string update --env-source Pipeline.Workspace <<'EOF'
+      $(Pipeline.Workspace)
+      EOF
+      $(FLOWEY_BIN) e 17 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+    displayName: print system info
+  - bash: $(FLOWEY_BIN) e 17 flowey_lib_common::download_gh_release 0
+    displayName: create gh-release-download cache dir
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 17 flowey_lib_common::cache 4
+      $FLOWEY_BIN v 17 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar5
+      $FLOWEY_BIN v 17 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar6
+    displayName: Pre-processing cache vars
+  - task: Cache@2
+    inputs:
+      key: $(floweyvar6)
+      path: $(floweyvar5)
+      cacheHitVar: FLOWEY_CACHE_HITVAR
+    displayName: 'Restore cache: gh-release-download'
+  - bash: |-
+      set -e
+      $FLOWEY_BIN v 17 'flowey_lib_common::cache:11:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $(FLOWEY_CACHE_HITVAR)
+      EOF
+      $(FLOWEY_BIN) e 17 flowey_lib_common::cache 6
+    displayName: map ADO hitvar to flowey
+  - bash: $(FLOWEY_BIN) e 17 flowey_lib_common::download_gh_release 1
+    displayName: download artifacts from github releases
+  - bash: $(FLOWEY_BIN) e 17 flowey_lib_common::download_azcopy 0
+    displayName: extract azcopy from archive
+  - bash: $(FLOWEY_BIN) e 17 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
+    displayName: calculating required VMM tests disk images
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 17 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+      $(FLOWEY_BIN) e 17 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
+    displayName: downloading VMM test disk images
+  - bash: $(FLOWEY_BIN) e 17 flowey_lib_hvlite::resolve_openvmm_test_initrd 0
+    displayName: unpack openvmm-test-initrd archives
+  - bash: $(FLOWEY_BIN) e 17 flowey_lib_hvlite::resolve_openvmm_test_linux_kernel 0
+    displayName: unpack openvmm-test-linux archives
+  - bash: $(FLOWEY_BIN) e 17 flowey_lib_hvlite::download_uefi_mu_msvm 0
+    displayName: unpack mu_msvm package (x64)
+  - bash: $(FLOWEY_BIN) e 17 flowey_lib_hvlite::resolve_openvmm_test_virtio_win 0
+    displayName: unpack openvmm-test-virtio-win archive
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 17 flowey_lib_hvlite::init_vmm_tests_env 0
       $(FLOWEY_BIN) e 17 flowey_lib_hvlite::run_cargo_nextest_run 0
-      $(FLOWEY_BIN) e 17 flowey_lib_hvlite::run_cargo_nextest_run 1
       $(FLOWEY_BIN) e 17 flowey_core::pipeline::artifact::resolve 16
       $(FLOWEY_BIN) e 17 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
-    displayName: print system info
+    displayName: setting up vmm_tests env
   - bash: $(FLOWEY_BIN) e 17 flowey_lib_common::gen_cargo_nextest_run_cmd 0
     displayName: generate nextest command
-  - bash: $(FLOWEY_BIN) e 17 flowey_lib_hvlite::install_vmm_tests_deps 0
-    displayName: install vmm tests deps (windows)
   - bash: $(FLOWEY_BIN) e 17 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
     displayName: starting test_igvm_agent_rpc_server
+  - bash: $(FLOWEY_BIN) e 17 flowey_lib_hvlite::install_vmm_tests_deps 0
+    displayName: install vmm tests deps (windows)
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 17 flowey_lib_common::run_cargo_nextest_run 0
       $(FLOWEY_BIN) e 17 flowey_lib_common::run_cargo_nextest_run 1
-      $(FLOWEY_BIN) e 17 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
     displayName: run 'vmm_tests' nextest tests
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 17 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
-      $(FLOWEY_BIN) e 17 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-    displayName: summarize failing vmm tests
+      $(FLOWEY_BIN) e 17 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
+      $(FLOWEY_BIN) e 17 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+    displayName: stopping test_igvm_agent_rpc_server
+  - bash: $(FLOWEY_BIN) e 17 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+    displayName: rename and create new log dir
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 17 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
       $(FLOWEY_BIN) e 17 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 5
+      $(FLOWEY_BIN) e 17 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 6
       $(FLOWEY_BIN) e 17 flowey_lib_common::publish_test_results 1
       $(FLOWEY_BIN) e 17 flowey_lib_common::ado_task_publish_test_results 0
       $(FLOWEY_BIN) e 17 flowey_lib_common::publish_test_results 0
       $FLOWEY_BIN v 17 'flowey_lib_common::ado_task_publish_test_results:0:flowey_lib_common/src/ado_task_publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env ado floweyvar1
       $FLOWEY_BIN v 17 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs' write-to-env ado FLOWEY_CONDITION
-    displayName: stopping test_igvm_agent_rpc_server
+    displayName: summarize failing vmm tests
   - task: PublishTestResults@2
     inputs:
       testResultsFormat: JUnit
@@ -5270,7 +5299,7 @@ jobs:
       set -e
       $(FLOWEY_BIN) e 17 flowey_lib_common::publish_test_results 2
       $(FLOWEY_BIN) e 17 flowey_lib_common::publish_test_results 3
-      $(FLOWEY_BIN) e 17 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 6
+      $(FLOWEY_BIN) e 17 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 7
     displayName: report test results to overall pipeline status
   - bash: $(FLOWEY_BIN) e 17 flowey_lib_common::cache 3
     displayName: 'validate cache entry: cargo-nextest'
@@ -5421,69 +5450,6 @@ jobs:
     displayName: 🌼🛫 Initialize job
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 8
-      $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 9
-      $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 12
-      $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 14
-      $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 15
-      $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 13
-      $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 3
-      $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 11
-      $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 4
-      $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 5
-      $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 6
-      $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 1
-      $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 2
-      $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 0
-      $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 7
-      $FLOWEY_BIN v 16 'flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:0:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs' --is-raw-string update --env-source Pipeline.Workspace <<'EOF'
-      $(Pipeline.Workspace)
-      EOF
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
-      $(FLOWEY_BIN) e 16 flowey_lib_common::download_gh_release 0
-    displayName: create gh-release-download cache dir
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 16 flowey_lib_common::cache 4
-      $FLOWEY_BIN v 16 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar5
-      $FLOWEY_BIN v 16 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar6
-    displayName: Pre-processing cache vars
-  - task: Cache@2
-    inputs:
-      key: $(floweyvar6)
-      path: $(floweyvar5)
-      cacheHitVar: FLOWEY_CACHE_HITVAR
-    displayName: 'Restore cache: gh-release-download'
-  - bash: |-
-      set -e
-      $FLOWEY_BIN v 16 'flowey_lib_common::cache:11:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
-      $(FLOWEY_CACHE_HITVAR)
-      EOF
-      $(FLOWEY_BIN) e 16 flowey_lib_common::cache 6
-    displayName: map ADO hitvar to flowey
-  - bash: $(FLOWEY_BIN) e 16 flowey_lib_common::download_gh_release 1
-    displayName: download artifacts from github releases
-  - bash: $(FLOWEY_BIN) e 16 flowey_lib_common::download_azcopy 0
-    displayName: extract azcopy from archive
-  - bash: $(FLOWEY_BIN) e 16 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
-    displayName: calculating required VMM tests disk images
-  - bash: |-
-      set -e
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
-    displayName: downloading VMM test disk images
-  - bash: $(FLOWEY_BIN) e 16 flowey_lib_hvlite::resolve_openvmm_test_initrd 0
-    displayName: unpack openvmm-test-initrd archives
-  - bash: $(FLOWEY_BIN) e 16 flowey_lib_hvlite::resolve_openvmm_test_linux_kernel 0
-    displayName: unpack openvmm-test-linux archives
-  - bash: $(FLOWEY_BIN) e 16 flowey_lib_hvlite::download_uefi_mu_msvm 0
-    displayName: unpack mu_msvm package (x64)
-  - bash: $(FLOWEY_BIN) e 16 flowey_lib_hvlite::resolve_openvmm_test_virtio_win 0
-    displayName: unpack openvmm-test-virtio-win archive
-  - bash: $(FLOWEY_BIN) e 16 flowey_lib_hvlite::init_vmm_tests_env 0
-    displayName: setting up vmm_tests env
-  - bash: |-
-      set -e
       $(FLOWEY_BIN) e 16 flowey_lib_common::download_cargo_nextest 0
       $(FLOWEY_BIN) e 16 flowey_lib_common::download_cargo_nextest 1
       $(FLOWEY_BIN) e 16 flowey_lib_common::download_cargo_nextest 2
@@ -5535,43 +5501,107 @@ jobs:
       set -e
       $(FLOWEY_BIN) e 16 flowey_lib_common::system_info 0
       $(FLOWEY_BIN) e 16 flowey_lib_hvlite::git_checkout_openvmm_repo 0
+      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
+      $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 8
+      $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 9
+      $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 12
+      $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 14
+      $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 15
+      $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 13
+      $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 3
+      $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 11
+      $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 4
+      $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 5
+      $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 6
+      $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 1
+      $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 2
+      $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 0
+      $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 7
+      $FLOWEY_BIN v 16 'flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive:0:flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs' --is-raw-string update --env-source Pipeline.Workspace <<'EOF'
+      $(Pipeline.Workspace)
+      EOF
+      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 1
+    displayName: print system info
+  - bash: $(FLOWEY_BIN) e 16 flowey_lib_common::download_gh_release 0
+    displayName: create gh-release-download cache dir
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 16 flowey_lib_common::cache 4
+      $FLOWEY_BIN v 16 'flowey_lib_common::cache:8:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar5
+      $FLOWEY_BIN v 16 'flowey_lib_common::cache:9:flowey_lib_common/src/cache.rs' --is-raw-string write-to-env ado floweyvar6
+    displayName: Pre-processing cache vars
+  - task: Cache@2
+    inputs:
+      key: $(floweyvar6)
+      path: $(floweyvar5)
+      cacheHitVar: FLOWEY_CACHE_HITVAR
+    displayName: 'Restore cache: gh-release-download'
+  - bash: |-
+      set -e
+      $FLOWEY_BIN v 16 'flowey_lib_common::cache:11:flowey_lib_common/src/cache.rs' --is-raw-string update --env-source FLOWEY_CACHE_HITVAR <<'EOF'
+      $(FLOWEY_CACHE_HITVAR)
+      EOF
+      $(FLOWEY_BIN) e 16 flowey_lib_common::cache 6
+    displayName: map ADO hitvar to flowey
+  - bash: $(FLOWEY_BIN) e 16 flowey_lib_common::download_gh_release 1
+    displayName: download artifacts from github releases
+  - bash: $(FLOWEY_BIN) e 16 flowey_lib_common::download_azcopy 0
+    displayName: extract azcopy from archive
+  - bash: $(FLOWEY_BIN) e 16 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 0
+    displayName: calculating required VMM tests disk images
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 1
+      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts 2
+    displayName: downloading VMM test disk images
+  - bash: $(FLOWEY_BIN) e 16 flowey_lib_hvlite::resolve_openvmm_test_initrd 0
+    displayName: unpack openvmm-test-initrd archives
+  - bash: $(FLOWEY_BIN) e 16 flowey_lib_hvlite::resolve_openvmm_test_linux_kernel 0
+    displayName: unpack openvmm-test-linux archives
+  - bash: $(FLOWEY_BIN) e 16 flowey_lib_hvlite::download_uefi_mu_msvm 0
+    displayName: unpack mu_msvm package (x64)
+  - bash: $(FLOWEY_BIN) e 16 flowey_lib_hvlite::resolve_openvmm_test_virtio_win 0
+    displayName: unpack openvmm-test-virtio-win archive
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::init_vmm_tests_env 0
       $(FLOWEY_BIN) e 16 flowey_lib_hvlite::run_cargo_nextest_run 0
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::run_cargo_nextest_run 1
       $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 16
       $(FLOWEY_BIN) e 16 flowey_lib_hvlite::test_nextest_vmm_tests_archive 0
-    displayName: print system info
-  - bash: $(FLOWEY_BIN) e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+    displayName: setting up vmm_tests env
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 0
+      $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 10
     displayName: generate nextest command
+  - bash: $(FLOWEY_BIN) e 16 flowey_lib_hvlite::run_prep_steps 0
+    displayName: running vmm_test prep_steps
+  - bash: $(FLOWEY_BIN) e 16 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
+    displayName: starting test_igvm_agent_rpc_server
   - bash: $(FLOWEY_BIN) e 16 flowey_lib_hvlite::install_vmm_tests_deps 0
     displayName: install vmm tests deps (windows)
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
-      $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 10
-    displayName: starting test_igvm_agent_rpc_server
-  - bash: $(FLOWEY_BIN) e 16 flowey_lib_hvlite::run_prep_steps 0
-    displayName: running vmm_test prep_steps
-  - bash: |-
-      set -e
       $(FLOWEY_BIN) e 16 flowey_lib_common::run_cargo_nextest_run 0
       $(FLOWEY_BIN) e 16 flowey_lib_common::run_cargo_nextest_run 1
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
     displayName: run 'vmm_tests' nextest tests
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 2
-    displayName: summarize failing vmm tests
+      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
+      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+    displayName: stopping test_igvm_agent_rpc_server
+  - bash: $(FLOWEY_BIN) e 16 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+    displayName: rename and create new log dir
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
       $(FLOWEY_BIN) e 16 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 5
+      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 6
       $(FLOWEY_BIN) e 16 flowey_lib_common::publish_test_results 1
       $(FLOWEY_BIN) e 16 flowey_lib_common::ado_task_publish_test_results 0
       $(FLOWEY_BIN) e 16 flowey_lib_common::publish_test_results 0
       $FLOWEY_BIN v 16 'flowey_lib_common::ado_task_publish_test_results:0:flowey_lib_common/src/ado_task_publish_test_results.rs' --is-raw-string --condvar flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs write-to-env ado floweyvar1
       $FLOWEY_BIN v 16 'flowey_lib_common::publish_test_results:0:flowey_lib_common/src/publish_test_results.rs' write-to-env ado FLOWEY_CONDITION
-    displayName: stopping test_igvm_agent_rpc_server
+    displayName: summarize failing vmm tests
   - task: PublishTestResults@2
     inputs:
       testResultsFormat: JUnit
@@ -5583,7 +5613,7 @@ jobs:
       set -e
       $(FLOWEY_BIN) e 16 flowey_lib_common::publish_test_results 2
       $(FLOWEY_BIN) e 16 flowey_lib_common::publish_test_results 3
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 6
+      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 7
     displayName: report test results to overall pipeline status
   - bash: $(FLOWEY_BIN) e 16 flowey_lib_common::cache 3
     displayName: 'validate cache entry: cargo-nextest'

--- a/ci-flowey/openvmm-pr.yaml
+++ b/ci-flowey/openvmm-pr.yaml
@@ -4643,22 +4643,25 @@ jobs:
       $(FLOWEY_BIN) e 19 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       $(FLOWEY_BIN) e 19 flowey_core::pipeline::artifact::resolve 5
     displayName: generate nextest command
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 19 flowey_lib_hvlite::install_vmm_tests_deps 0
+      $(FLOWEY_BIN) e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+    displayName: install vmm tests deps (linux)
   - bash: $(FLOWEY_BIN) e 19 flowey_lib_hvlite::run_prep_steps 0
     displayName: running vmm_test prep_steps
-  - bash: $(FLOWEY_BIN) e 19 flowey_lib_hvlite::install_vmm_tests_deps 0
-    displayName: install vmm tests deps (linux)
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 19 flowey_lib_common::run_cargo_nextest_run 0
       $(FLOWEY_BIN) e 19 flowey_lib_common::run_cargo_nextest_run 1
-      $(FLOWEY_BIN) e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+      $(FLOWEY_BIN) e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
     displayName: run 'vmm_tests' nextest tests
-  - bash: $(FLOWEY_BIN) e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+  - bash: $(FLOWEY_BIN) e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 5
     displayName: rename and create new log dir
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 5
       $(FLOWEY_BIN) e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 6
+      $(FLOWEY_BIN) e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 7
       $(FLOWEY_BIN) e 19 flowey_lib_common::publish_test_results 1
       $(FLOWEY_BIN) e 19 flowey_lib_common::ado_task_publish_test_results 0
       $(FLOWEY_BIN) e 19 flowey_lib_common::publish_test_results 0
@@ -4676,7 +4679,7 @@ jobs:
       set -e
       $(FLOWEY_BIN) e 19 flowey_lib_common::publish_test_results 2
       $(FLOWEY_BIN) e 19 flowey_lib_common::publish_test_results 3
-      $(FLOWEY_BIN) e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 7
+      $(FLOWEY_BIN) e 19 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 8
     displayName: report test results to overall pipeline status
   - bash: $(FLOWEY_BIN) e 19 flowey_lib_common::cache 3
     displayName: 'validate cache entry: cargo-nextest'
@@ -4951,12 +4954,15 @@ jobs:
       $(FLOWEY_BIN) e 18 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       $(FLOWEY_BIN) e 18 flowey_core::pipeline::artifact::resolve 10
     displayName: generate nextest command
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::install_vmm_tests_deps 0
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+    displayName: install vmm tests deps (windows)
   - bash: $(FLOWEY_BIN) e 18 flowey_lib_hvlite::run_prep_steps 0
     displayName: running vmm_test prep_steps
   - bash: $(FLOWEY_BIN) e 18 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
     displayName: starting test_igvm_agent_rpc_server
-  - bash: $(FLOWEY_BIN) e 18 flowey_lib_hvlite::install_vmm_tests_deps 0
-    displayName: install vmm tests deps (windows)
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 18 flowey_lib_common::run_cargo_nextest_run 0
@@ -4965,14 +4971,14 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 18 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
     displayName: stopping test_igvm_agent_rpc_server
-  - bash: $(FLOWEY_BIN) e 18 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+  - bash: $(FLOWEY_BIN) e 18 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 5
     displayName: rename and create new log dir
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 5
       $(FLOWEY_BIN) e 18 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 6
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 7
       $(FLOWEY_BIN) e 18 flowey_lib_common::publish_test_results 1
       $(FLOWEY_BIN) e 18 flowey_lib_common::ado_task_publish_test_results 0
       $(FLOWEY_BIN) e 18 flowey_lib_common::publish_test_results 0
@@ -4990,7 +4996,7 @@ jobs:
       set -e
       $(FLOWEY_BIN) e 18 flowey_lib_common::publish_test_results 2
       $(FLOWEY_BIN) e 18 flowey_lib_common::publish_test_results 3
-      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 7
+      $(FLOWEY_BIN) e 18 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 8
     displayName: report test results to overall pipeline status
   - bash: $(FLOWEY_BIN) e 18 flowey_lib_common::cache 3
     displayName: 'validate cache entry: cargo-nextest'
@@ -5574,12 +5580,15 @@ jobs:
       $(FLOWEY_BIN) e 16 flowey_lib_common::gen_cargo_nextest_run_cmd 0
       $(FLOWEY_BIN) e 16 flowey_core::pipeline::artifact::resolve 10
     displayName: generate nextest command
+  - bash: |-
+      set -e
+      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::install_vmm_tests_deps 0
+      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+    displayName: install vmm tests deps (windows)
   - bash: $(FLOWEY_BIN) e 16 flowey_lib_hvlite::run_prep_steps 0
     displayName: running vmm_test prep_steps
   - bash: $(FLOWEY_BIN) e 16 flowey_lib_hvlite::run_test_igvm_agent_rpc_server 0
     displayName: starting test_igvm_agent_rpc_server
-  - bash: $(FLOWEY_BIN) e 16 flowey_lib_hvlite::install_vmm_tests_deps 0
-    displayName: install vmm tests deps (windows)
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 16 flowey_lib_common::run_cargo_nextest_run 0
@@ -5588,14 +5597,14 @@ jobs:
   - bash: |-
       set -e
       $(FLOWEY_BIN) e 16 flowey_lib_hvlite::stop_test_igvm_agent_rpc_server 0
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 3
+      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
     displayName: stopping test_igvm_agent_rpc_server
-  - bash: $(FLOWEY_BIN) e 16 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 4
+  - bash: $(FLOWEY_BIN) e 16 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 5
     displayName: rename and create new log dir
   - bash: |-
       set -e
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 5
       $(FLOWEY_BIN) e 16 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 6
+      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 7
       $(FLOWEY_BIN) e 16 flowey_lib_common::publish_test_results 1
       $(FLOWEY_BIN) e 16 flowey_lib_common::ado_task_publish_test_results 0
       $(FLOWEY_BIN) e 16 flowey_lib_common::publish_test_results 0
@@ -5613,7 +5622,7 @@ jobs:
       set -e
       $(FLOWEY_BIN) e 16 flowey_lib_common::publish_test_results 2
       $(FLOWEY_BIN) e 16 flowey_lib_common::publish_test_results 3
-      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 7
+      $(FLOWEY_BIN) e 16 flowey_lib_hvlite::_jobs::consume_and_test_nextest_vmm_tests_archive 8
     displayName: report test results to overall pipeline status
   - bash: $(FLOWEY_BIN) e 16 flowey_lib_common::cache 3
     displayName: 'validate cache entry: cargo-nextest'

--- a/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
+++ b/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
@@ -1701,12 +1701,6 @@ impl IntoPipeline for CheckinGatesCli {
             let nextest_filter_expr = exclude_checkin_disabled_vmm_tests(nextest_filter_expr);
             let test_label = format!("{label}-vmm-tests");
 
-            let pub_vmm_tests_results = if matches!(backend_hint, PipelineBackendHint::Local) {
-                Some(pipeline.new_artifact(&test_label).0)
-            } else {
-                None
-            };
-
             let use_vmm_tests_archive = match target {
                 CommonTriple::X86_64_WINDOWS_MSVC => &use_vmm_tests_archive_windows_x86,
                 CommonTriple::X86_64_LINUX_GNU => &use_vmm_tests_archive_linux_x86,
@@ -1735,9 +1729,9 @@ impl IntoPipeline for CheckinGatesCli {
                     test_artifacts,
                     incubator_profile: incubator_profile.map(Into::into),
                     fail_job_on_test_fail: true,
-                    artifact_dir: pub_vmm_tests_results.map(|x| ctx.publish_artifact(x)),
                     prep_steps_variants,
                     hugetlb_2mb_overcommit_pages,
+                    repetitions: std::num::NonZeroU64::new(1).unwrap(),
                     done: ctx.new_done_handle(),
                 }
             });

--- a/flowey/flowey_hvlite/src/pipelines/vmm_tests_run.rs
+++ b/flowey/flowey_hvlite/src/pipelines/vmm_tests_run.rs
@@ -17,6 +17,7 @@ use flowey_lib_hvlite::_jobs::local_build_and_run_nextest_vmm_tests::VmmTestSele
 use flowey_lib_hvlite::common::CommonPlatform;
 use flowey_lib_hvlite::common::CommonTriple;
 use flowey_lib_hvlite::install_vmm_tests_deps::VmmTestsDepSelections;
+use flowey_lib_hvlite::install_vmm_tests_deps::VmmTestsDepSelectionsLinux;
 use flowey_lib_hvlite::install_vmm_tests_deps::VmmTestsDepSelectionsWindows;
 use petri_artifacts_core::ArtifactId;
 use petri_artifacts_core::ArtifactListOutput;
@@ -729,7 +730,12 @@ fn selections_from_resolved(
                     hardware_isolation: resolved.needs_hardware_isolation,
                 })
             }
-            target_lexicon::OperatingSystem::Linux => VmmTestsDepSelections::Linux,
+            target_lexicon::OperatingSystem::Linux => {
+                VmmTestsDepSelections::Linux(VmmTestsDepSelectionsLinux {
+                    hugetlb_2mb_overcommit_pages: None, // TODO
+                    prepare_vhost_vsock: false,         // TODO
+                })
+            }
             _ => unreachable!(),
         },
         needs_release_igvm: resolved.needs_release_igvm,

--- a/flowey/flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs
@@ -475,7 +475,7 @@ impl SimpleFlowNode for Node {
                     // error here would replace "encountered test failures"
                     // with an unrelated error and hide what actually broke.
                     for (i, log_dir) in all_log_dirs.iter().enumerate() {
-                        match failure_summary::collect_failed_tests(&log_dir) {
+                        match failure_summary::collect_failed_tests(log_dir) {
                             Ok(failures) => {
                                 let log_artifact_name =
                                     format!("{}-logs", test_label_for_iteration(i));

--- a/flowey/flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs
@@ -17,6 +17,7 @@ use crate::build_tmks::TmksOutput;
 use crate::build_tpm_guest_tests::TpmGuestTestsOutput;
 use crate::build_vmgstool::VmgstoolOutput;
 use crate::install_vmm_tests_deps::VmmTestsDepSelections;
+use crate::install_vmm_tests_deps::VmmTestsDepSelectionsLinux;
 use crate::install_vmm_tests_deps::VmmTestsDepSelectionsWindows;
 use crate::run_cargo_nextest_run::NextestProfile;
 use flowey::node::prelude::*;
@@ -115,8 +116,9 @@ flowey_request! {
 
         /// Whether the job should fail if any test has failed
         pub fail_job_on_test_fail: bool,
-        /// If provided, also publish junit.xml test results as an artifact.
-        pub artifact_dir: Option<ReadVar<PathBuf>>,
+        /// Run the tests this number of times
+        pub repetitions: std::num::NonZeroU64,
+
         pub done: WriteVar<SideEffect>,
     }
 }
@@ -153,11 +155,11 @@ impl SimpleFlowNode for Node {
             nextest_filter_expr,
             dep_artifact_dirs,
             test_artifacts,
-            fail_job_on_test_fail,
-            incubator_profile,
             prep_steps_variants,
             hugetlb_2mb_overcommit_pages,
-            artifact_dir,
+            incubator_profile,
+            fail_job_on_test_fail,
+            repetitions,
             done,
         } = request;
 
@@ -208,16 +210,29 @@ impl SimpleFlowNode for Node {
         let disk_images_dir =
             ctx.reqv(crate::download_openvmm_vmm_tests_artifacts::Request::GetDownloadFolder);
 
+        let prepare_vhost_vsock = incubator_profile.is_none()
+            && matches!(
+                target.operating_system,
+                target_lexicon::OperatingSystem::Linux
+            )
+            && matches!(target.architecture, target_lexicon::Architecture::X86_64);
+
         ctx.config(crate::install_vmm_tests_deps::Config {
             selections: Some(match target.operating_system {
                 target_lexicon::OperatingSystem::Windows => {
                     VmmTestsDepSelections::Windows(VmmTestsDepSelectionsWindows {
                         hyperv: true,
                         whp: true,
+                        // this is currently manually set on CVM runners
                         hardware_isolation: false,
                     })
                 }
-                target_lexicon::OperatingSystem::Linux => VmmTestsDepSelections::Linux,
+                target_lexicon::OperatingSystem::Linux => {
+                    VmmTestsDepSelections::Linux(VmmTestsDepSelectionsLinux {
+                        hugetlb_2mb_overcommit_pages,
+                        prepare_vhost_vsock,
+                    })
+                }
                 os => anyhow::bail!("unsupported target operating system: {os}"),
             }),
             auto_install: None,
@@ -265,43 +280,17 @@ impl SimpleFlowNode for Node {
             use_relative_paths: false,
             disable_remote_artifacts: true,
             reuse_prepped_vhds: false,
+            require_2mb_hugetlb: hugetlb_2mb_overcommit_pages.is_some(),
         });
 
-        // Start the test_igvm_agent_rpc_server before running tests (Windows only).
-        // This must happen after init_vmm_tests_env which copies the binary.
-        // The server runs in the background for the duration of the test run.
-        if matches!(ctx.platform(), FlowPlatform::Windows) {
-            pre_run_deps.push(
-                ctx.reqv(|done| crate::run_test_igvm_agent_rpc_server::Request {
-                    env: extra_env.clone(),
-                    done,
-                }),
-            );
-        }
+        let openvmm_repo_path = ctx.reqv(crate::git_checkout_openvmm_repo::req::GetRepoDir);
+        let nextest_config_file = openvmm_repo_path
+            .clone()
+            .map(ctx, |p| p.join(".config").join("nextest.toml"));
 
-        if !prep_steps_variants.is_empty() {
-            let prep_steps = register_prep_steps.expect("Test run indicated prep_steps was needed but built prep_steps binary was not given");
-            for variant in &prep_steps_variants {
-                pre_run_deps.push(ctx.reqv(|done| crate::run_prep_steps::Request {
-                    prep_steps: prep_steps.clone(),
-                    args: vec![variant.clone()],
-                    env: extra_env.clone(),
-                    done,
-                }));
-            }
-        } else if let Some(register_prep_steps) = register_prep_steps {
-            register_prep_steps.claim_unused(ctx);
-        }
+        let igvm_agent_env = extra_env.clone();
 
-        let prepare_vhost_vsock = incubator_profile.is_none()
-            && matches!(
-                target.operating_system,
-                target_lexicon::OperatingSystem::Linux
-            )
-            && matches!(target.architecture, target_lexicon::Architecture::X86_64);
-        let (extra_env, nextest_working_dir, nextest_config_file) = if let Some(profile_name) =
-            incubator_profile
-        {
+        let extra_env = if let Some(profile_name) = incubator_profile {
             let incubator = register_incubator.ok_or_else(|| {
                 anyhow::anyhow!("incubator profile was set but no incubator artifact was provided")
             })?;
@@ -334,15 +323,11 @@ impl SimpleFlowNode for Node {
                 o.profiles.join(format!("{profile_name}.toml"))
             });
 
-            let openvmm_repo_path = ctx.reqv(crate::git_checkout_openvmm_repo::req::GetRepoDir);
-            let nextest_config_file = openvmm_repo_path
-                .clone()
-                .map(ctx, |p| p.join(".config").join("nextest.toml"));
             let nextest_archive = nextest_vmm_tests_archive
                 .clone()
                 .map(ctx, |x| x.archive_file);
 
-            let extra_env = ctx.reqv(|v| crate::write_incubator_target_runner::Request {
+            ctx.reqv(|v| crate::write_incubator_target_runner::Request {
                 incubator_bin,
                 profile_path,
                 kernel: Some(kernel),
@@ -354,52 +339,105 @@ impl SimpleFlowNode for Node {
                 qemu_binary: Some(qemu_binary),
                 target: target.clone(),
                 nextest_env: v,
+            })
+        } else {
+            extra_env
+        };
+
+        if !prep_steps_variants.is_empty() {
+            let prep_steps = register_prep_steps.expect("Test run indicated prep_steps was needed but built prep_steps binary was not given");
+            for variant in &prep_steps_variants {
+                pre_run_deps.push(ctx.reqv(|done| crate::run_prep_steps::Request {
+                    prep_steps: prep_steps.clone(),
+                    args: vec![variant.clone()],
+                    env: extra_env.clone(),
+                    done,
+                }));
+            }
+        } else if let Some(register_prep_steps) = register_prep_steps {
+            register_prep_steps.claim_unused(ctx);
+        }
+
+        let repetitions = repetitions.get();
+        let mut all_results = Vec::with_capacity(repetitions as usize);
+        let mut all_log_dirs = Vec::with_capacity(repetitions as usize);
+        for i in 0..repetitions {
+            let mut pre_run_deps_iteration = pre_run_deps.clone();
+            // Start the test_igvm_agent_rpc_server before running tests.
+            // Currently X64 Windows only.
+            // The binary must already exist in the test content dir.
+            // The server runs in the background for the duration of the test run.
+            let previous_done = all_log_dirs
+                .last()
+                .map(|x: &ReadVar<PathBuf>| x.clone().into_side_effect());
+            if matches!(ctx.platform(), FlowPlatform::Windows) {
+                pre_run_deps_iteration.push(ctx.reqv(|done| {
+                    crate::run_test_igvm_agent_rpc_server::Request {
+                        env: igvm_agent_env.clone(),
+                        done,
+                        previous_done,
+                    }
+                }));
+            // make the repetitions run in order
+            } else if let Some(previous) = previous_done {
+                pre_run_deps_iteration.push(previous);
+            }
+
+            let results = ctx.reqv(|v| crate::test_nextest_vmm_tests_archive::Request {
+                nextest_archive_file: nextest_vmm_tests_archive.clone(),
+                nextest_profile,
+                nextest_filter_expr: nextest_filter_expr.clone(),
+                nextest_working_dir: Some(openvmm_repo_path.clone()),
+                nextest_config_file: Some(nextest_config_file.clone()),
+                nextest_bin: None,
+                target: None,
+                extra_env: extra_env.clone(),
+                pre_run_deps: pre_run_deps_iteration,
+                results: v,
             });
 
-            (
-                extra_env,
-                Some(openvmm_repo_path),
-                Some(nextest_config_file),
-            )
-        } else {
-            if let Some(register_incubator) = register_incubator {
-                register_incubator.claim_unused(ctx);
-            }
-            (extra_env, None, None)
-        };
-
-        let results = ctx.reqv(|v| crate::test_nextest_vmm_tests_archive::Request {
-            nextest_archive_file: nextest_vmm_tests_archive,
-            nextest_profile,
-            nextest_filter_expr,
-            nextest_working_dir,
-            nextest_config_file,
-            nextest_bin: None,
-            target: None,
-            extra_env,
-            pre_run_deps,
-            hugetlb_2mb_overcommit_pages,
-            prepare_vhost_vsock,
-            results: v,
-        });
-
-        // Stop the test_igvm_agent_rpc_server after tests complete (Windows only).
-        // This ensures we clean up the background process.
-        let rpc_server_stopped = if matches!(ctx.platform(), FlowPlatform::Windows) {
-            let after_tests = results.map(ctx, |_| ());
-            Some(
+            // Stop the test_igvm_agent_rpc_server after tests complete (Windows only).
+            // This ensures we clean up the background process.
+            let rpc_server_stopped = matches!(ctx.platform(), FlowPlatform::Windows).then(|| {
                 ctx.reqv(|done| crate::stop_test_igvm_agent_rpc_server::Request {
-                    after_tests,
+                    after_tests: results.clone().into_side_effect(),
                     done,
-                }),
-            )
-        } else {
-            None
-        };
+                })
+            });
 
-        // Bind the externally generated output paths together with the results
-        // to create a dependency on the VMM tests having actually run.
-        let test_log_path = test_log_path.depending_on(ctx, &results);
+            let log_dir_archive = {
+                // Bind the externally generated output paths together with the results
+                // to create a dependency on the VMM tests having actually run.
+                let test_log_path = test_log_path.depending_on(
+                    ctx,
+                    &rpc_server_stopped.unwrap_or(results.clone().into_side_effect()),
+                );
+                ctx.emit_rust_stepv("rename and create new log dir", |ctx| {
+                    let test_log_path = test_log_path.claim(ctx);
+                    move |rt| {
+                        let log_dir = rt.read(test_log_path);
+
+                        // rename the log dir and create a fresh one
+                        let log_dir_archive = log_dir_for_iteration(&log_dir, i)?;
+                        log::info!(
+                            "renaming {} to {}",
+                            log_dir.to_string_lossy(),
+                            log_dir_archive.to_string_lossy()
+                        );
+                        if log_dir_archive.exists() {
+                            fs_err::remove_dir_all(&log_dir_archive)?;
+                        }
+                        fs_err::rename(&log_dir, &log_dir_archive)?;
+                        fs_err::create_dir(&log_dir)?;
+
+                        Ok(log_dir_archive)
+                    }
+                })
+            };
+
+            all_results.push((results, log_dir_archive.clone()));
+            all_log_dirs.push(log_dir_archive);
+        }
 
         // A failing VMM test dumps its entire captured stdout -- guest serial
         // console, OpenHCL kmsg, pipette, and petri tracing -- into the job
@@ -407,51 +445,76 @@ impl SimpleFlowNode for Node {
         // actually failed. Emit a scannable summary alongside it.
         let summarized = {
             let is_github = matches!(ctx.backend(), FlowBackend::Github);
-            let test_log_path = test_log_path.clone();
+            let all_log_dirs = all_log_dirs.clone();
             let log_artifact_name = format!("{junit_test_label}-logs");
             ctx.emit_rust_step("summarize failing vmm tests", |ctx| {
-                let test_log_path = test_log_path.claim(ctx);
+                let all_log_dirs = all_log_dirs.claim(ctx);
                 move |rt| {
-                    let log_dir = rt.read(test_log_path);
+                    let all_log_dirs = rt.read(all_log_dirs);
+
+                    let mut test_failures = Vec::new();
+
                     // Summarizing is ancillary to the test run. If it fails,
                     // warn rather than propagate: this step is ordered before
                     // the one that reports test failures, so returning an
                     // error here would replace "encountered test failures"
                     // with an unrelated error and hide what actually broke.
-                    match failure_summary::collect_failed_tests(&log_dir) {
-                        Ok(failures) => failure_summary::report_failed_tests(
-                            &failures,
-                            is_github,
-                            &log_artifact_name,
-                        ),
-                        Err(err) => failure_summary::warn_summary_unavailable(is_github, &err),
+                    for log_dir in all_log_dirs {
+                        match failure_summary::collect_failed_tests(&log_dir) {
+                            Ok(failures) => test_failures.extend(failures),
+                            Err(err) => {
+                                failure_summary::warn_summary_unavailable(is_github, &err);
+                            }
+                        };
                     }
+
+                    failure_summary::report_failed_tests(
+                        &test_failures,
+                        is_github,
+                        &log_artifact_name,
+                    );
+
+                    let (failures_by_test, failures_by_mode) =
+                        failure_summary::bucketize_failures(&test_failures);
+                    failure_summary::report_failure_buckets(failures_by_test, failures_by_mode);
+
                     Ok(())
                 }
             })
         };
 
-        let junit_xml = results.map(ctx, |r| r.junit_xml);
-        let reported_results = ctx.reqv(|v| flowey_lib_common::publish_test_results::Request {
-            junit_xml,
-            test_label: junit_test_label,
-            attachments: BTreeMap::from([("logs".to_string(), (test_log_path, false))]),
-            output_dir: artifact_dir,
-            done: v,
-        });
+        let mut reported_results = Vec::new();
+
+        for (i, (results, log_dir)) in all_results.iter().enumerate() {
+            let junit_xml = results.map(ctx, |r| r.junit_xml);
+            let test_label = if repetitions > 1 {
+                format!("{junit_test_label}-{i}")
+            } else {
+                junit_test_label.clone()
+            };
+            reported_results.push(
+                ctx.reqv(|v| flowey_lib_common::publish_test_results::Request {
+                    junit_xml,
+                    test_label,
+                    attachments: BTreeMap::from([(
+                        "logs".to_string(),
+                        (log_dir.to_owned(), false),
+                    )]),
+                    output_dir: None,
+                    done: v,
+                }),
+            );
+        }
 
         ctx.emit_rust_step("report test results to overall pipeline status", |ctx| {
             reported_results.claim(ctx);
             summarized.claim(ctx);
-            if let Some(rpc_server_stopped) = rpc_server_stopped {
-                rpc_server_stopped.claim(ctx);
-            }
             done.claim(ctx);
 
-            let results = results.clone().claim(ctx);
+            let all_results = all_results.clone().claim(ctx);
             move |rt| {
-                let results = rt.read(results);
-                if results.all_tests_passed {
+                let all_results = rt.read(all_results);
+                if all_results.iter().all(|x| x.0.all_tests_passed) {
                     log::info!("all tests passed!");
                 } else {
                     if fail_job_on_test_fail {
@@ -469,6 +532,15 @@ impl SimpleFlowNode for Node {
     }
 }
 
+fn log_dir_for_iteration(log_dir: &Path, i: u64) -> anyhow::Result<PathBuf> {
+    let mut log_dir_basename = log_dir.file_name().context("invalid path")?.to_owned();
+    log_dir_basename.push(format!("_{i}"));
+    Ok(log_dir
+        .parent()
+        .context("invalid path")?
+        .join(log_dir_basename))
+}
+
 /// Summarizes failing VMM tests by scanning the per-test output directories
 /// that petri writes during a run.
 ///
@@ -478,12 +550,14 @@ impl SimpleFlowNode for Node {
 /// failures under megabytes of log. This module produces a compact,
 /// linkable report to sit alongside that output.
 mod failure_summary {
-    use flowey::node::prelude::fs_err;
+    use flowey::node::prelude::*;
+    use std::collections::BTreeMap;
     use std::collections::VecDeque;
     use std::io::BufRead;
     use std::io::BufReader;
     use std::io::Read;
     use std::path::Path;
+    use std::path::PathBuf;
 
     /// Maximum number of log lines to show inline per failing test. The tail
     /// is kept, since the entries immediately preceding a failure are almost
@@ -496,8 +570,19 @@ mod failure_summary {
     /// Base URL of the petri log viewer.
     const LOG_VIEWER_BASE_URL: &str = "https://openvmm.dev/test-results";
 
+    const ERROR_BUCKETS: &[&str] = &[
+        "Kernel indicates VP is both halted and idle",
+        "the guest operating system requested an operation that is not supported by Hyper-V",
+        "an unrecoverable error occurred on a virtual processor that caused a triple fault",
+        "an unrecoverable error occurred while accessing a virtual processor register which caused a triple fault",
+        "failed to start worker process",
+        "Failed to create a new virtual machine",
+        "Not enough memory in the system to start the virtual machine",
+        "Test timed out",
+    ];
+
     /// How a test finished, for tests that did not pass.
-    #[derive(Clone, Copy, PartialEq, Eq)]
+    #[derive(Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
     enum Outcome {
         Failed,
         FailedUnstable,
@@ -518,6 +603,7 @@ mod failure_summary {
     }
 
     /// A failing test discovered by scanning the petri log directory.
+    #[derive(Serialize, Deserialize)]
     pub struct FailedTest {
         /// Full test name, e.g. `x86_64::openhcl_linux_direct_boot`.
         name: String,
@@ -529,6 +615,8 @@ mod failure_summary {
         error: Option<String>,
         /// ERROR / WARN entries from the tail of `petri.jsonl`.
         excerpt: Vec<String>,
+        /// Path to the test results on the local system
+        path: PathBuf,
     }
 
     /// Scans `log_dir` for the per-test marker files petri writes, returning
@@ -584,6 +672,7 @@ mod failure_summary {
                 outcome,
                 error: error.map(|e| one_line(&e)).filter(|e| !e.is_empty()),
                 excerpt,
+                path: entry.path(),
             });
         }
 
@@ -643,17 +732,12 @@ mod failure_summary {
     ///
     /// Returns `None` when the run ID is unknown (i.e. outside of GitHub
     /// Actions), since the viewer is keyed on it.
-    fn log_viewer_url(
-        run_id: Option<&str>,
-        log_artifact_name: &str,
-        test: &FailedTest,
-    ) -> Option<String> {
-        let run_id = run_id?;
-        Some(format!(
-            "{LOG_VIEWER_BASE_URL}/#/runs/{run_id}/{}/{}",
+    fn log_viewer_url(run_id_attempt: &str, log_artifact_name: &str, test: &FailedTest) -> String {
+        format!(
+            "{LOG_VIEWER_BASE_URL}/#/runs/{run_id_attempt}/{}/{}",
             percent_encode(log_artifact_name),
             percent_encode(&test.dir_name),
-        ))
+        )
     }
 
     /// Renders the per-failure detail written to the job log.
@@ -663,7 +747,7 @@ mod failure_summary {
     fn render_job_log(
         failures: &[FailedTest],
         is_github: bool,
-        run_id: Option<&str>,
+        run_id_attempt: Option<&str>,
         log_artifact_name: &str,
     ) -> String {
         use std::fmt::Write as _;
@@ -693,8 +777,12 @@ mod failure_summary {
                 }
             }
 
-            if let Some(url) = log_viewer_url(run_id, log_artifact_name, test) {
-                let _ = writeln!(out, "  full logs: {url}");
+            if let Some(run_id_attempt) = run_id_attempt {
+                let _ = writeln!(
+                    out,
+                    "  full logs: {}",
+                    log_viewer_url(run_id_attempt, log_artifact_name, test)
+                );
             }
 
             if is_github {
@@ -707,7 +795,7 @@ mod failure_summary {
     /// Renders the markdown table appended to the GitHub Actions job summary.
     fn render_job_summary(
         failures: &[FailedTest],
-        run_id: Option<&str>,
+        run_id_attempt: Option<&str>,
         log_artifact_name: &str,
     ) -> String {
         use std::fmt::Write as _;
@@ -718,8 +806,11 @@ mod failure_summary {
         let _ = writeln!(out, "| Test | Result | Reason | Logs |");
         let _ = writeln!(out, "| --- | --- | --- | --- |");
         for test in failures {
-            let logs = match log_viewer_url(run_id, log_artifact_name, test) {
-                Some(url) => format!("[view]({url})"),
+            let logs = match run_id_attempt {
+                Some(run_id_attempt) => format!(
+                    "[view]({})",
+                    log_viewer_url(run_id_attempt, log_artifact_name, test)
+                ),
                 None => format!("`{log_artifact_name}` artifact"),
             };
             // Escape pipes so a reason containing one can't break the table.
@@ -753,15 +844,24 @@ mod failure_summary {
         // log artifacts once the whole run completes, so these links only
         // become live after the run finishes.
         let run_id = std::env::var("GITHUB_RUN_ID").ok();
+        let run_attempt = std::env::var("GITHUB_RUN_ATTEMPT").ok();
+        let run_id_attempt = run_id
+            .zip(run_attempt)
+            .map(|(id, attempt)| format!("{id}_{attempt}"));
         print!(
             "{}",
-            render_job_log(failures, is_github, run_id.as_deref(), log_artifact_name)
+            render_job_log(
+                failures,
+                is_github,
+                run_id_attempt.as_deref(),
+                log_artifact_name
+            )
         );
 
         let Ok(summary_path) = std::env::var("GITHUB_STEP_SUMMARY") else {
             return;
         };
-        let summary = render_job_summary(failures, run_id.as_deref(), log_artifact_name);
+        let summary = render_job_summary(failures, run_id_attempt.as_deref(), log_artifact_name);
         // Other steps may have already appended to the summary file.
         let write_summary = || -> std::io::Result<()> {
             let mut file = fs_err::OpenOptions::new()
@@ -811,6 +911,105 @@ mod failure_summary {
         encoded
     }
 
+    pub fn bucketize_failures(
+        test_failures: &[FailedTest],
+    ) -> (
+        BTreeMap<String, BTreeMap<&'static str, Vec<PathBuf>>>,
+        BTreeMap<&'static str, BTreeMap<String, Vec<PathBuf>>>,
+    ) {
+        let mut failures_by_test: BTreeMap<String, BTreeMap<&'static str, Vec<PathBuf>>> =
+            BTreeMap::new();
+        let mut failures_by_mode: BTreeMap<&'static str, BTreeMap<String, Vec<PathBuf>>> =
+            BTreeMap::new();
+
+        for FailedTest {
+            name,
+            excerpt,
+            path,
+            ..
+        } in test_failures
+        {
+            let mut error = "Unknown";
+            for err in ERROR_BUCKETS {
+                for line in excerpt {
+                    if line.contains(err) {
+                        error = err;
+                    }
+                }
+            }
+
+            failures_by_test
+                .entry(name.clone())
+                .or_default()
+                .entry(error)
+                .or_default()
+                .push(path.clone());
+            failures_by_mode
+                .entry(error)
+                .or_default()
+                .entry(name.clone())
+                .or_default()
+                .push(path.clone());
+        }
+
+        (failures_by_test, failures_by_mode)
+    }
+
+    pub fn report_failure_buckets(
+        failures_by_test: BTreeMap<String, BTreeMap<&'static str, Vec<PathBuf>>>,
+        failures_by_mode: BTreeMap<&'static str, BTreeMap<String, Vec<PathBuf>>>,
+    ) {
+        println!("\nFailures by test\n");
+        if !failures_by_test.is_empty() {
+            for (name, failures) in failures_by_test {
+                let total_failures: usize = failures.values().map(|x| x.len()).sum();
+
+                println!(
+                    "test failed {} times in {} ways: {}",
+                    total_failures,
+                    failures.len(),
+                    name,
+                );
+                for (error, log_dirs) in failures {
+                    println!(
+                        "  error occured {} times in this test: {}",
+                        log_dirs.len(),
+                        error
+                    );
+                    for dir in log_dirs {
+                        println!("    {}", dir.to_string_lossy());
+                    }
+                }
+                println!();
+            }
+        }
+
+        println!("\nFailures by mode\n");
+        if !failures_by_mode.is_empty() {
+            for (error, tests) in failures_by_mode {
+                let total_failures: usize = tests.values().map(|x| x.len()).sum();
+
+                println!(
+                    "error occured {} times in {} tests: {}",
+                    total_failures,
+                    tests.len(),
+                    error
+                );
+                for (name, log_dirs) in tests {
+                    println!(
+                        "  test failed {} times in this way: {}",
+                        log_dirs.len(),
+                        name
+                    );
+                    for dir in log_dirs {
+                        println!("    {}", dir.to_string_lossy());
+                    }
+                }
+                println!();
+            }
+        }
+    }
+
     #[cfg(test)]
     mod tests {
         use super::*;
@@ -824,6 +1023,7 @@ mod failure_summary {
                 outcome,
                 error: None,
                 excerpt: excerpt.iter().map(|s| (*s).to_owned()).collect(),
+                path: PathBuf::new(),
             }
         }
 

--- a/flowey/flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs
@@ -252,7 +252,8 @@ impl SimpleFlowNode for Node {
             None
         };
 
-        let mut pre_run_deps = vec![ctx.reqv(crate::install_vmm_tests_deps::Request::Install)];
+        let installed_deps = ctx.reqv(crate::install_vmm_tests_deps::Request::Install);
+        let mut pre_run_deps = vec![installed_deps.clone()];
 
         let (test_log_path, get_test_log_path) = ctx.new_var();
 
@@ -345,7 +346,9 @@ impl SimpleFlowNode for Node {
         };
 
         if !prep_steps_variants.is_empty() {
-            let prep_steps = register_prep_steps.expect("Test run indicated prep_steps was needed but built prep_steps binary was not given");
+            let prep_steps = register_prep_steps
+                .expect("Prep steps variants requested but missing binary")
+                .depending_on(ctx, &installed_deps);
             for variant in &prep_steps_variants {
                 pre_run_deps.push(ctx.reqv(|done| crate::run_prep_steps::Request {
                     prep_steps: prep_steps.clone(),
@@ -439,6 +442,17 @@ impl SimpleFlowNode for Node {
             all_log_dirs.push(log_dir_archive);
         }
 
+        let test_label_for_iteration = {
+            let test_label = junit_test_label.clone();
+            move |i| {
+                if repetitions > 1 {
+                    format!("{test_label}-{i}")
+                } else {
+                    test_label.clone()
+                }
+            }
+        };
+
         // A failing VMM test dumps its entire captured stdout -- guest serial
         // console, OpenHCL kmsg, pipette, and petri tracing -- into the job
         // log, which makes it impractical to tell at a glance which tests
@@ -446,33 +460,38 @@ impl SimpleFlowNode for Node {
         let summarized = {
             let is_github = matches!(ctx.backend(), FlowBackend::Github);
             let all_log_dirs = all_log_dirs.clone();
-            let log_artifact_name = format!("{junit_test_label}-logs");
+            let test_label = junit_test_label.clone();
+            let test_label_for_iteration = test_label_for_iteration.clone();
             ctx.emit_rust_step("summarize failing vmm tests", |ctx| {
                 let all_log_dirs = all_log_dirs.claim(ctx);
                 move |rt| {
                     let all_log_dirs = rt.read(all_log_dirs);
 
-                    let mut test_failures = Vec::new();
+                    let mut test_failures = BTreeMap::new();
 
                     // Summarizing is ancillary to the test run. If it fails,
                     // warn rather than propagate: this step is ordered before
                     // the one that reports test failures, so returning an
                     // error here would replace "encountered test failures"
                     // with an unrelated error and hide what actually broke.
-                    for log_dir in all_log_dirs {
+                    for (i, log_dir) in all_log_dirs.iter().enumerate() {
                         match failure_summary::collect_failed_tests(&log_dir) {
-                            Ok(failures) => test_failures.extend(failures),
+                            Ok(failures) => {
+                                let log_artifact_name =
+                                    format!("{}-logs", test_label_for_iteration(i));
+                                if test_failures.insert(log_artifact_name, failures).is_some() {
+                                    anyhow::bail!("tests should not have the same label")
+                                }
+                            }
                             Err(err) => {
                                 failure_summary::warn_summary_unavailable(is_github, &err);
                             }
                         };
                     }
 
-                    failure_summary::report_failed_tests(
-                        &test_failures,
-                        is_github,
-                        &log_artifact_name,
-                    );
+                    failure_summary::report_failed_tests(&test_failures, is_github, &test_label);
+
+                    let test_failures = test_failures.into_values().flatten().collect::<Vec<_>>();
 
                     let (failures_by_test, failures_by_mode) =
                         failure_summary::bucketize_failures(&test_failures);
@@ -487,11 +506,7 @@ impl SimpleFlowNode for Node {
 
         for (i, (results, log_dir)) in all_results.iter().enumerate() {
             let junit_xml = results.map(ctx, |r| r.junit_xml);
-            let test_label = if repetitions > 1 {
-                format!("{junit_test_label}-{i}")
-            } else {
-                junit_test_label.clone()
-            };
+            let test_label = test_label_for_iteration(i);
             reported_results.push(
                 ctx.reqv(|v| flowey_lib_common::publish_test_results::Request {
                     junit_xml,
@@ -745,48 +760,49 @@ mod failure_summary {
     /// On GitHub the detail is wrapped in workflow-command groups so that it
     /// collapses by default and the list of failures stays scannable.
     fn render_job_log(
-        failures: &[FailedTest],
+        failures: &BTreeMap<String, Vec<FailedTest>>,
         is_github: bool,
         run_id_attempt: Option<&str>,
-        log_artifact_name: &str,
     ) -> String {
         use std::fmt::Write as _;
 
         let mut out = String::new();
-        for test in failures {
-            let label = match test.outcome {
-                Outcome::Failed => "FAIL",
-                Outcome::FailedUnstable => "FAIL (unstable)",
-                Outcome::Incomplete => "INCOMPLETE",
-            };
-            if is_github {
-                let _ = writeln!(out, "::group::{label} {}", test.name);
-            } else {
-                let _ = writeln!(out, "--- {label} {} ---", test.name);
-            }
-
-            if let Some(error) = &test.error {
-                let _ = writeln!(out, "  error: {error}");
-            }
-
-            if test.excerpt.is_empty() {
-                let _ = writeln!(out, "  (no ERROR or WARN entries found in petri.jsonl)");
-            } else {
-                for line in &test.excerpt {
-                    let _ = writeln!(out, "  {line}");
+        for (log_artifact_name, tests) in failures {
+            for test in tests {
+                let label = match test.outcome {
+                    Outcome::Failed => "FAIL",
+                    Outcome::FailedUnstable => "FAIL (unstable)",
+                    Outcome::Incomplete => "INCOMPLETE",
+                };
+                if is_github {
+                    let _ = writeln!(out, "::group::{label} {}", test.name);
+                } else {
+                    let _ = writeln!(out, "--- {label} {} ---", test.name);
                 }
-            }
 
-            if let Some(run_id_attempt) = run_id_attempt {
-                let _ = writeln!(
-                    out,
-                    "  full logs: {}",
-                    log_viewer_url(run_id_attempt, log_artifact_name, test)
-                );
-            }
+                if let Some(error) = &test.error {
+                    let _ = writeln!(out, "  error: {error}");
+                }
 
-            if is_github {
-                let _ = writeln!(out, "::endgroup::");
+                if test.excerpt.is_empty() {
+                    let _ = writeln!(out, "  (no ERROR or WARN entries found in petri.jsonl)");
+                } else {
+                    for line in &test.excerpt {
+                        let _ = writeln!(out, "  {line}");
+                    }
+                }
+
+                if let Some(run_id_attempt) = run_id_attempt {
+                    let _ = writeln!(
+                        out,
+                        "  full logs: {}",
+                        log_viewer_url(run_id_attempt, log_artifact_name, test)
+                    );
+                }
+
+                if is_github {
+                    let _ = writeln!(out, "::endgroup::");
+                }
             }
         }
         out
@@ -794,36 +810,38 @@ mod failure_summary {
 
     /// Renders the markdown table appended to the GitHub Actions job summary.
     fn render_job_summary(
-        failures: &[FailedTest],
+        failures: &BTreeMap<String, Vec<FailedTest>>,
         run_id_attempt: Option<&str>,
-        log_artifact_name: &str,
+        test_label: &str,
     ) -> String {
         use std::fmt::Write as _;
 
         let mut out = String::new();
-        let _ = writeln!(out, "### Failed VMM tests: {log_artifact_name}");
+        let _ = writeln!(out, "### Failed VMM tests: {test_label}");
         let _ = writeln!(out);
         let _ = writeln!(out, "| Test | Result | Reason | Logs |");
         let _ = writeln!(out, "| --- | --- | --- | --- |");
-        for test in failures {
-            let logs = match run_id_attempt {
-                Some(run_id_attempt) => format!(
-                    "[view]({})",
-                    log_viewer_url(run_id_attempt, log_artifact_name, test)
-                ),
-                None => format!("`{log_artifact_name}` artifact"),
-            };
-            // Escape pipes so a reason containing one can't break the table.
-            let reason = match &test.error {
-                Some(error) => error.replace('|', "\\|"),
-                None => String::new(),
-            };
-            let _ = writeln!(
-                out,
-                "| `{}` | {} | {reason} | {logs} |",
-                test.name,
-                test.outcome.describe(),
-            );
+        for (log_artifact_name, tests) in failures {
+            for test in tests {
+                let logs = match run_id_attempt {
+                    Some(run_id_attempt) => format!(
+                        "[view]({})",
+                        log_viewer_url(run_id_attempt, log_artifact_name, test)
+                    ),
+                    None => format!("`{log_artifact_name}` artifact"),
+                };
+                // Escape pipes so a reason containing one can't break the table.
+                let reason = match &test.error {
+                    Some(error) => error.replace('|', "\\|"),
+                    None => String::new(),
+                };
+                let _ = writeln!(
+                    out,
+                    "| `{}` | {} | {reason} | {logs} |",
+                    test.name,
+                    test.outcome.describe(),
+                );
+            }
         }
         let _ = writeln!(out);
         let _ = writeln!(
@@ -835,7 +853,11 @@ mod failure_summary {
 
     /// Writes the failure report to the job log and, on GitHub, to the job
     /// summary.
-    pub fn report_failed_tests(failures: &[FailedTest], is_github: bool, log_artifact_name: &str) {
+    pub fn report_failed_tests(
+        failures: &BTreeMap<String, Vec<FailedTest>>,
+        is_github: bool,
+        test_label: &str,
+    ) {
         if failures.is_empty() {
             return;
         }
@@ -850,18 +872,13 @@ mod failure_summary {
             .map(|(id, attempt)| format!("{id}_{attempt}"));
         print!(
             "{}",
-            render_job_log(
-                failures,
-                is_github,
-                run_id_attempt.as_deref(),
-                log_artifact_name
-            )
+            render_job_log(failures, is_github, run_id_attempt.as_deref())
         );
 
         let Ok(summary_path) = std::env::var("GITHUB_STEP_SUMMARY") else {
             return;
         };
-        let summary = render_job_summary(failures, run_id_attempt.as_deref(), log_artifact_name);
+        let summary = render_job_summary(failures, run_id_attempt.as_deref(), test_label);
         // Other steps may have already appended to the summary file.
         let write_summary = || -> std::io::Result<()> {
             let mut file = fs_err::OpenOptions::new()
@@ -972,7 +989,7 @@ mod failure_summary {
                 );
                 for (error, log_dirs) in failures {
                     println!(
-                        "  error occured {} times in this test: {}",
+                        "  error occurred {} times in this test: {}",
                         log_dirs.len(),
                         error
                     );
@@ -990,7 +1007,7 @@ mod failure_summary {
                 let total_failures: usize = tests.values().map(|x| x.len()).sum();
 
                 println!(
-                    "error occured {} times in {} tests: {}",
+                    "error occurred {} times in {} tests: {}",
                     total_failures,
                     tests.len(),
                     error
@@ -1014,18 +1031,6 @@ mod failure_summary {
     mod tests {
         use super::*;
         use std::path::PathBuf;
-
-        /// Builds a `FailedTest` with an excerpt, for the rendering tests.
-        fn failed_test(name: &str, outcome: Outcome, excerpt: &[&str]) -> FailedTest {
-            FailedTest {
-                name: name.to_owned(),
-                dir_name: name.replace("::", "__"),
-                outcome,
-                error: None,
-                excerpt: excerpt.iter().map(|s| (*s).to_owned()).collect(),
-                path: PathBuf::new(),
-            }
-        }
 
         /// Writes a test output directory of the shape petri produces.
         ///
@@ -1251,80 +1256,6 @@ mod failure_summary {
                 collect_failed_tests(&PathBuf::from("this/does/not/exist"))
                     .unwrap()
                     .is_empty()
-            );
-        }
-
-        #[test]
-        fn job_log_folds_detail_on_github() {
-            let failures = [failed_test(
-                "x86_64::boot",
-                Outcome::Failed,
-                &["[ERROR] boom"],
-            )];
-
-            let rendered = render_job_log(&failures, true, Some("123"), "x64-linux-vmm-tests-logs");
-
-            assert_eq!(
-                rendered,
-                "::group::FAIL x86_64::boot\n\
-                 \x20 [ERROR] boom\n\
-                 \x20 full logs: https://openvmm.dev/test-results/#/runs/123/x64-linux-vmm-tests-logs/x86_64__boot\n\
-                 ::endgroup::\n"
-            );
-        }
-
-        #[test]
-        fn job_log_omits_group_commands_off_github() {
-            let failures = [failed_test("x86_64::boot", Outcome::FailedUnstable, &[])];
-
-            let rendered = render_job_log(&failures, false, None, "x64-linux-vmm-tests-logs");
-
-            assert_eq!(
-                rendered,
-                "--- FAIL (unstable) x86_64::boot ---\n\
-                 \x20 (no ERROR or WARN entries found in petri.jsonl)\n"
-            );
-            // Without a run ID there is nothing to link to.
-            assert!(!rendered.contains("full logs"));
-        }
-
-        #[test]
-        fn job_summary_links_each_failure() {
-            let failures = [
-                failed_test("x86_64::boot", Outcome::Failed, &[]),
-                failed_test("x86_64::flaky", Outcome::FailedUnstable, &[]),
-            ];
-
-            let rendered = render_job_summary(&failures, Some("42"), "x64-linux-vmm-tests-logs");
-
-            assert!(rendered.contains("### Failed VMM tests: x64-linux-vmm-tests-logs"));
-            assert!(rendered.contains(
-                "| `x86_64::boot` | failed |  | [view](https://openvmm.dev/test-results/#/runs/42/x64-linux-vmm-tests-logs/x86_64__boot) |"
-            ));
-            assert!(rendered.contains("| `x86_64::flaky` | failed (unstable) |"));
-        }
-
-        #[test]
-        fn job_summary_shows_the_failure_reason() {
-            let mut test = failed_test("x86_64::boot", Outcome::Failed, &[]);
-            // A reason containing a pipe must not break the table.
-            test.error = Some("guest panicked | oops".to_owned());
-
-            let rendered = render_job_summary(&[test], None, "x64-linux-vmm-tests-logs");
-
-            assert!(rendered.contains("| guest panicked \\| oops |"));
-        }
-
-        #[test]
-        fn job_summary_falls_back_to_artifact_without_run_id() {
-            let failures = [failed_test("x86_64::boot", Outcome::Failed, &[])];
-
-            let rendered = render_job_summary(&failures, None, "x64-linux-vmm-tests-logs");
-
-            assert!(
-                rendered.contains(
-                    "| `x86_64::boot` | failed |  | `x64-linux-vmm-tests-logs` artifact |"
-                )
             );
         }
 

--- a/flowey/flowey_lib_hvlite/src/_jobs/local_build_and_run_nextest_vmm_tests.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/local_build_and_run_nextest_vmm_tests.rs
@@ -728,6 +728,7 @@ impl SimpleFlowNode for Node {
             use_relative_paths: build_only,
             disable_remote_artifacts: false,
             reuse_prepped_vhds,
+            require_2mb_hugetlb: false,
         });
 
         let mut side_effects = Vec::new();
@@ -912,6 +913,7 @@ impl SimpleFlowNode for Node {
                     crate::run_test_igvm_agent_rpc_server::Request {
                         env: extra_env.clone(),
                         done,
+                        previous_done: None,
                     }
                 }));
                 true
@@ -950,8 +952,6 @@ impl SimpleFlowNode for Node {
             target: nextest_target,
             extra_env,
             pre_run_deps: side_effects,
-            hugetlb_2mb_overcommit_pages: None,
-            prepare_vhost_vsock: false,
             results: v,
         });
 

--- a/flowey/flowey_lib_hvlite/src/init_vmm_tests_env.rs
+++ b/flowey/flowey_lib_hvlite/src/init_vmm_tests_env.rs
@@ -68,6 +68,8 @@ flowey_request! {
         pub disable_remote_artifacts: bool,
         /// Whether to reuse VHDs created with prep_steps
         pub reuse_prepped_vhds: bool,
+        /// Tell petri to expect 2mb hugetlb support
+        pub require_2mb_hugetlb: bool,
     }
 }
 
@@ -110,6 +112,7 @@ impl SimpleFlowNode for Node {
             use_relative_paths,
             disable_remote_artifacts,
             reuse_prepped_vhds,
+            require_2mb_hugetlb,
         } = request;
 
         let arch = CommonArch::from_architecture(vmm_tests_target.architecture)?;
@@ -264,17 +267,19 @@ impl SimpleFlowNode for Node {
                     make_portable_path(converted_content_dir)?,
                 );
 
-                if !test_log_dir.exists() {
-                    fs_err::create_dir(&test_log_dir)?
+                if test_log_dir.exists() {
+                    fs_err::remove_dir_all(&test_log_dir)?;
                 };
+                fs_err::create_dir(&test_log_dir)?;
                 env.insert(
                     "TEST_OUTPUT_PATH".into(),
                     make_portable_path(converted_log_dir)?,
                 );
 
-                if !temp_dir.exists() {
-                    fs_err::create_dir(&temp_dir)?
+                if temp_dir.exists() {
+                    fs_err::remove_dir_all(&temp_dir)?;
                 };
+                fs_err::create_dir(&temp_dir)?;
                 let portable_temp_dir = make_portable_path(converted_temp_dir)?;
                 if matches!(rt.platform().kind(), FlowPlatformKind::Windows) || windows_via_wsl2 {
                     env.insert("TEMP".into(), portable_temp_dir.clone());
@@ -301,6 +306,10 @@ impl SimpleFlowNode for Node {
 
                 if ignore_unstable_failures {
                     env.insert("PETRI_IGNORE_UNSTABLE_FAILURES".into(), "1".into());
+                }
+
+                if require_2mb_hugetlb {
+                    env.insert("OPENVMM_REQUIRE_2MB_HUGETLB".into(), "1".into());
                 }
 
                 if let Some(openvmm) = openvmm {

--- a/flowey/flowey_lib_hvlite/src/install_vmm_tests_deps.rs
+++ b/flowey/flowey_lib_hvlite/src/install_vmm_tests_deps.rs
@@ -22,7 +22,7 @@ const HYPERVISOR_REG_PATH: &str = r#"HKLM\System\CurrentControlSet\Control\Hyper
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 pub enum VmmTestsDepSelections {
     Windows(VmmTestsDepSelectionsWindows),
-    Linux,
+    Linux(VmmTestsDepSelectionsLinux),
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
@@ -30,6 +30,14 @@ pub struct VmmTestsDepSelectionsWindows {
     pub hyperv: bool,
     pub whp: bool,
     pub hardware_isolation: bool,
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+pub struct VmmTestsDepSelectionsLinux {
+    /// If set, configure this 2 MiB hugetlb surplus page overcommit limit before running tests.
+    pub hugetlb_2mb_overcommit_pages: Option<u64>,
+    /// Load vhost-vsock and make `/dev/vhost-vsock` accessible before tests.
+    pub prepare_vhost_vsock: bool,
 }
 
 flowey_config! {
@@ -88,7 +96,14 @@ impl FlowNodeWithConfig for Node {
         let selections = config
             .selections
             .ok_or(anyhow::anyhow!("missing config: selections"))?;
-        let auto_install = config.auto_install;
+        // Resolve auto_install for local backend
+        let auto_install = match ctx.backend() {
+            FlowBackend::Local => config
+                .auto_install
+                .ok_or_else(|| anyhow::anyhow!("Missing essential request: AutoInstall"))?,
+            // CI backends always auto-install
+            FlowBackend::Ado | FlowBackend::Github => true,
+        };
         let installing = !installed.is_empty();
 
         match selections {
@@ -108,17 +123,13 @@ impl FlowNodeWithConfig for Node {
                     }
                 });
             }
-            VmmTestsDepSelections::Linux => {
+            VmmTestsDepSelections::Linux(selections) => {
                 ctx.emit_rust_step("install vmm tests deps (linux)", |ctx| {
                     installed.claim(ctx);
                     let write_commands = write_commands.claim(ctx);
 
-                    |rt| {
-                        for write_cmds in write_commands {
-                            rt.write(write_cmds, &Vec::new());
-                        }
-
-                        Ok(())
+                    move |rt| {
+                        install_linux_deps(rt, installing, auto_install, selections, write_commands)
                     }
                 });
             }
@@ -131,7 +142,7 @@ impl FlowNodeWithConfig for Node {
 fn install_windows_deps(
     rt: &mut RustRuntimeServices<'_>,
     installing: bool,
-    auto_install: Option<bool>,
+    auto_install: bool,
     selections: VmmTestsDepSelectionsWindows,
     write_commands: Vec<WriteVar<Vec<String>, VarClaimed>>,
 ) -> anyhow::Result<()> {
@@ -148,15 +159,6 @@ fn install_windows_deps(
     {
         anyhow::bail!("Must be on Windows or WSL2 to install Windows deps.")
     }
-
-    // Resolve auto_install for local backend
-    let auto_install = match rt.backend() {
-        FlowBackend::Local => {
-            auto_install.ok_or_else(|| anyhow::anyhow!("Missing essential request: AutoInstall"))?
-        }
-        // CI backends always auto-install
-        FlowBackend::Ado | FlowBackend::Github => true,
-    };
 
     // TODO: add these features and reg keys to the initial CI image
 
@@ -382,6 +384,102 @@ Please re-run in an Administrator window with `--install-missing-deps`.
 
     for write_cmds in write_commands {
         rt.write(write_cmds, &commands);
+    }
+
+    Ok(())
+}
+
+fn install_linux_deps(
+    rt: &mut RustRuntimeServices<'_>,
+    installing: bool,
+    auto_install: bool,
+    selections: VmmTestsDepSelectionsLinux,
+    write_commands: Vec<WriteVar<Vec<String>, VarClaimed>>,
+) -> anyhow::Result<()> {
+    let VmmTestsDepSelectionsLinux {
+        hugetlb_2mb_overcommit_pages,
+        prepare_vhost_vsock,
+    } = selections;
+
+    // command output not currently supported
+    for write_cmds in write_commands {
+        rt.write(write_cmds, &Vec::new());
+    }
+
+    if !installing || !auto_install {
+        return Ok(());
+    }
+
+    // ensure hypervisor device is accessible
+    {
+        // Make whichever hypervisor device exists accessible.
+        // KVM machines have /dev/kvm, MSHV machines have /dev/mshv.
+        if Path::new("/dev/kvm").exists() {
+            flowey::shell_cmd!(rt, "sudo chmod a+rw /dev/kvm").run()?;
+        }
+        if Path::new("/dev/mshv").exists() {
+            flowey::shell_cmd!(rt, "sudo chmod a+rw /dev/mshv").run()?;
+        }
+    }
+
+    // ensure 2 MiB hugetlb pages are available
+    if let Some(overcommit_pages) = hugetlb_2mb_overcommit_pages {
+        let hugepages_dir = Path::new("/sys/kernel/mm/hugepages/hugepages-2048kB");
+
+        let read_counter = |name: &str| -> anyhow::Result<u64> {
+            let path = hugepages_dir.join(name);
+            let value = fs_err::read_to_string(&path)?;
+            Ok(value.trim().parse()?)
+        };
+
+        let write_overcommit_script = format!(
+            "echo {overcommit_pages} | sudo tee {path}",
+            path = hugepages_dir.join("nr_overcommit_hugepages").display(),
+        );
+        flowey::shell_cmd!(rt, "sh -c {write_overcommit_script}").run()?;
+
+        let nr_hugepages = read_counter("nr_hugepages")?;
+        let free_hugepages = read_counter("free_hugepages")?;
+        let nr_overcommit_hugepages = read_counter("nr_overcommit_hugepages")?;
+        let surplus_hugepages = read_counter("surplus_hugepages")?;
+
+        log::info!("2 MiB hugetlb nr_hugepages={nr_hugepages}");
+        log::info!("2 MiB hugetlb free_hugepages={free_hugepages}");
+        log::info!("2 MiB hugetlb nr_overcommit_hugepages={nr_overcommit_hugepages}");
+        log::info!("2 MiB hugetlb surplus_hugepages={surplus_hugepages}");
+
+        if nr_overcommit_hugepages < overcommit_pages {
+            anyhow::bail!(
+                "2 MiB hugetlb overcommit remains {}, below requested {}",
+                nr_overcommit_hugepages,
+                overcommit_pages
+            );
+        }
+    }
+
+    // prepare vhost-vsock
+    if prepare_vhost_vsock {
+        flowey::shell_cmd!(rt, "sudo modprobe vhost_vsock").run()?;
+        // The kernel creates /dev/vhost-vsock as part of
+        // loading the module, but udev then processes the
+        // corresponding uevent asynchronously and applies
+        // its own (root-only) permissions to the node.
+        // Without settling first, that races with - and
+        // frequently wins against - the chmod below,
+        // leaving the device inaccessible to the tests.
+        flowey::shell_cmd!(rt, "sudo udevadm settle").run()?;
+        if !Path::new("/dev/vhost-vsock").exists() {
+            anyhow::bail!("/dev/vhost-vsock did not appear after loading vhost_vsock");
+        }
+        flowey::shell_cmd!(rt, "sudo chmod a+rw /dev/vhost-vsock").run()?;
+        // Confirm the permissions actually stuck, so that a
+        // failure here is reported by this step instead of
+        // as an opaque test failure minutes later.
+        fs_err::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open("/dev/vhost-vsock")
+            .context("/dev/vhost-vsock is not accessible to the test user")?;
     }
 
     Ok(())

--- a/flowey/flowey_lib_hvlite/src/run_cargo_nextest_run.rs
+++ b/flowey/flowey_lib_hvlite/src/run_cargo_nextest_run.rs
@@ -65,11 +65,6 @@ impl FlowNode for Node {
     }
 
     fn emit(requests: Vec<Self::Request>, ctx: &mut NodeCtx<'_>) -> anyhow::Result<()> {
-        let openvmm_repo_path = ctx.reqv(crate::git_checkout_openvmm_repo::req::GetRepoDir);
-
-        let default_nextest_config_file =
-            openvmm_repo_path.map(ctx, |p| p.join(".config").join("nextest.toml"));
-
         let base_env = [
             // Used by the test_with_tracing macro in test runners
             ("RUST_LOG", "trace"),
@@ -86,7 +81,7 @@ impl FlowNode for Node {
             nextest_working_dir,
             nextest_config_file,
             run_ignored,
-            mut pre_run_deps,
+            pre_run_deps,
             results,
             extra_env,
         } in requests
@@ -103,19 +98,13 @@ impl FlowNode for Node {
                 ReadVar::from_static(base_env.clone())
             };
 
-            let working_dir = if let Some(nextest_working_dir) = nextest_working_dir {
-                pre_run_deps.push(openvmm_repo_path.clone().into_side_effect());
-                nextest_working_dir
-            } else {
-                openvmm_repo_path.clone()
-            };
+            let working_dir = nextest_working_dir
+                .unwrap_or_else(|| ctx.reqv(crate::git_checkout_openvmm_repo::req::GetRepoDir));
 
-            let config_file = if let Some(nextest_config_file) = nextest_config_file {
-                pre_run_deps.push(default_nextest_config_file.clone().into_side_effect());
-                nextest_config_file
-            } else {
-                default_nextest_config_file.clone()
-            };
+            let config_file = nextest_config_file.unwrap_or_else(|| {
+                ctx.reqv(crate::git_checkout_openvmm_repo::req::GetRepoDir)
+                    .map(ctx, |p| p.join(".config").join("nextest.toml"))
+            });
 
             ctx.req(flowey_lib_common::run_cargo_nextest_run::Request::Run(
                 flowey_lib_common::run_cargo_nextest_run::Run {

--- a/flowey/flowey_lib_hvlite/src/run_test_igvm_agent_rpc_server.rs
+++ b/flowey/flowey_lib_hvlite/src/run_test_igvm_agent_rpc_server.rs
@@ -24,6 +24,8 @@ flowey_request! {
         pub env: ReadVar<BTreeMap<String, String>>,
         /// Completion indicator - signals that the server is ready
         pub done: WriteVar<SideEffect>,
+        /// Used to ensure that the previous test run is complete, if any
+        pub previous_done: Option<ReadVar<SideEffect>>,
     }
 }
 
@@ -35,7 +37,11 @@ impl SimpleFlowNode for Node {
     fn imports(_ctx: &mut ImportCtx<'_>) {}
 
     fn process_request(request: Self::Request, ctx: &mut NodeCtx<'_>) -> anyhow::Result<()> {
-        let Request { env, done } = request;
+        let Request {
+            env,
+            done,
+            previous_done,
+        } = request;
 
         // This node only supports Windows - fail at flow-graph construction time
         // if someone mistakenly tries to use it on another platform.
@@ -49,7 +55,8 @@ impl SimpleFlowNode for Node {
         ctx.emit_rust_step("starting test_igvm_agent_rpc_server", |ctx| {
             let env = env.claim(ctx);
             done.claim(ctx);
-            move |rt| start_rpc_server(rt.read(env))
+            previous_done.claim(ctx);
+            move |rt| start_rpc_server(rt, env)
         });
 
         Ok(())
@@ -57,9 +64,14 @@ impl SimpleFlowNode for Node {
 }
 
 #[cfg(windows)]
-fn start_rpc_server(env: BTreeMap<String, String>) -> anyhow::Result<()> {
+fn start_rpc_server(
+    rt: &mut RustRuntimeServices<'_>,
+    env: ReadVar<BTreeMap<String, String>, VarClaimed>,
+) -> anyhow::Result<()> {
     use std::os::windows::process::CommandExt;
     use std::path::Path;
+
+    let env = rt.read(env);
 
     let test_content_dir = env
         .get("VMM_TESTS_CONTENT_DIR")
@@ -136,7 +148,10 @@ fn start_rpc_server(env: BTreeMap<String, String>) -> anyhow::Result<()> {
 }
 
 #[cfg(not(windows))]
-fn start_rpc_server(_env: BTreeMap<String, String>) -> anyhow::Result<()> {
+fn start_rpc_server(
+    _rt: &mut RustRuntimeServices<'_>,
+    _env: ReadVar<BTreeMap<String, String>, VarClaimed>,
+) -> anyhow::Result<()> {
     // This should never be called - the node rejects non-Windows at construction time.
     // But we need this for compilation on non-Windows hosts.
     anyhow::bail!("run_test_igvm_agent_rpc_server is only supported on Windows")

--- a/flowey/flowey_lib_hvlite/src/test_nextest_vmm_tests_archive.rs
+++ b/flowey/flowey_lib_hvlite/src/test_nextest_vmm_tests_archive.rs
@@ -35,10 +35,6 @@ flowey_request! {
         /// any tests. (e.g: to allow for some ambient packages / dependencies
         /// to get installed).
         pub pre_run_deps: Vec<ReadVar<SideEffect>>,
-        /// If set, configure this 2 MiB hugetlb surplus page overcommit limit before running tests.
-        pub hugetlb_2mb_overcommit_pages: Option<u64>,
-        /// Load vhost-vsock and make `/dev/vhost-vsock` accessible before tests.
-        pub prepare_vhost_vsock: bool,
         /// Results of running the tests
         pub results: WriteVar<TestResults>,
     }
@@ -62,117 +58,10 @@ impl SimpleFlowNode for Node {
             nextest_config_file,
             nextest_bin,
             target,
-            mut extra_env,
-            mut pre_run_deps,
-            hugetlb_2mb_overcommit_pages,
-            prepare_vhost_vsock,
+            extra_env,
+            pre_run_deps,
             results,
         } = request;
-
-        if hugetlb_2mb_overcommit_pages.is_some() {
-            extra_env = extra_env.map(ctx, |mut env| {
-                env.insert("OPENVMM_REQUIRE_2MB_HUGETLB".into(), "1".into());
-                env
-            });
-        }
-
-        if !matches!(ctx.backend(), FlowBackend::Local)
-            && matches!(ctx.platform(), FlowPlatform::Linux(_))
-        {
-            pre_run_deps.push({
-                ctx.emit_rust_step("ensure hypervisor device is accessible", |_| {
-                    |rt| {
-                        // Make whichever hypervisor device exists accessible.
-                        // KVM machines have /dev/kvm, MSHV machines have /dev/mshv.
-                        if Path::new("/dev/kvm").exists() {
-                            flowey::shell_cmd!(rt, "sudo chmod a+rw /dev/kvm").run()?;
-                        }
-                        if Path::new("/dev/mshv").exists() {
-                            flowey::shell_cmd!(rt, "sudo chmod a+rw /dev/mshv").run()?;
-                        }
-                        Ok(())
-                    }
-                })
-            });
-
-            if let Some(overcommit_pages) = hugetlb_2mb_overcommit_pages {
-                pre_run_deps.push({
-                    ctx.emit_rust_step("ensure 2 MiB hugetlb pages are available", move |_| {
-                        move |rt| {
-                            let hugepages_dir =
-                                Path::new("/sys/kernel/mm/hugepages/hugepages-2048kB");
-
-                            let read_counter = |name: &str| -> anyhow::Result<u64> {
-                                let path = hugepages_dir.join(name);
-                                let value = fs_err::read_to_string(&path)?;
-                                Ok(value.trim().parse()?)
-                            };
-
-                            let write_overcommit_script = format!(
-                                "echo {overcommit_pages} | sudo tee {path}",
-                                path = hugepages_dir.join("nr_overcommit_hugepages").display(),
-                            );
-                            flowey::shell_cmd!(rt, "sh -c {write_overcommit_script}").run()?;
-
-                            let nr_hugepages = read_counter("nr_hugepages")?;
-                            let free_hugepages = read_counter("free_hugepages")?;
-                            let nr_overcommit_hugepages = read_counter("nr_overcommit_hugepages")?;
-                            let surplus_hugepages = read_counter("surplus_hugepages")?;
-
-                            log::info!("2 MiB hugetlb nr_hugepages={nr_hugepages}");
-                            log::info!("2 MiB hugetlb free_hugepages={free_hugepages}");
-                            log::info!(
-                                "2 MiB hugetlb nr_overcommit_hugepages={nr_overcommit_hugepages}"
-                            );
-                            log::info!("2 MiB hugetlb surplus_hugepages={surplus_hugepages}");
-
-                            if nr_overcommit_hugepages < overcommit_pages {
-                                anyhow::bail!(
-                                    "2 MiB hugetlb overcommit remains {}, below requested {}",
-                                    nr_overcommit_hugepages,
-                                    overcommit_pages
-                                );
-                            }
-
-                            Ok(())
-                        }
-                    })
-                });
-            }
-
-            if prepare_vhost_vsock {
-                pre_run_deps.push({
-                    ctx.emit_rust_step("prepare vhost-vsock", |_| {
-                        |rt| {
-                            flowey::shell_cmd!(rt, "sudo modprobe vhost_vsock").run()?;
-                            // The kernel creates /dev/vhost-vsock as part of
-                            // loading the module, but udev then processes the
-                            // corresponding uevent asynchronously and applies
-                            // its own (root-only) permissions to the node.
-                            // Without settling first, that races with - and
-                            // frequently wins against - the chmod below,
-                            // leaving the device inaccessible to the tests.
-                            flowey::shell_cmd!(rt, "sudo udevadm settle").run()?;
-                            if !Path::new("/dev/vhost-vsock").exists() {
-                                anyhow::bail!(
-                                    "/dev/vhost-vsock did not appear after loading vhost_vsock"
-                                );
-                            }
-                            flowey::shell_cmd!(rt, "sudo chmod a+rw /dev/vhost-vsock").run()?;
-                            // Confirm the permissions actually stuck, so that a
-                            // failure here is reported by this step instead of
-                            // as an opaque test failure minutes later.
-                            fs_err::OpenOptions::new()
-                                .read(true)
-                                .write(true)
-                                .open("/dev/vhost-vsock")
-                                .context("/dev/vhost-vsock is not accessible to the test user")?;
-                            Ok(())
-                        }
-                    })
-                });
-            }
-        }
 
         let nextest_archive = nextest_archive_file.map(ctx, |x| x.archive_file);
 


### PR DESCRIPTION
First of several PRs refactoring different parts of our vmm_tests infrastructure.
- Add a basic bucketing system for test failures printed to summary in logs. In a future PR this will be uploaded and viewable on the petri test results website, along with statistics across all runs generated by a separate pipeline.
- Add the ability to repeat the tests a certain number of times without having to rerun all the setup or have to manually run cargo-nextest. For this PR this functionality is not used anywhere, but I have tested this locally with changes to vmm-tests-run that will come in a separate PR.
- Move logic for preparing the test environment out of test_nextest_vmm_tests_archive.rs and into install_vmm_tests_deps.rs and init_vmm_tests_env.rs where other similar logic lives. This is necessary to avoid duplicate work when repeating tests.
- Other minor refactors to improve readability and correctness.