### PR TITLE
snp: add standalone test IGVM generator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3876,6 +3876,7 @@ dependencies = [
  "product_policy",
  "serde",
  "serde_json",
+ "thiserror 2.0.16",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3862,6 +3862,8 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "underhill_confidentiality",
+ "vm_topology",
+ "vmm_core",
  "x509-cert",
  "x86defs",
  "zerocopy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3839,6 +3839,7 @@ dependencies = [
  "anyhow",
  "base64 0.22.1",
  "bitfield-struct 0.11.0",
+ "chipset_resources",
  "clap",
  "corim",
  "crypto",
@@ -3857,6 +3858,7 @@ dependencies = [
  "range_map_vec",
  "serde",
  "serde_json",
+ "serial_16550_resources",
  "signature",
  "test_with_tracing",
  "tracing",
@@ -3873,6 +3875,8 @@ dependencies = [
 name = "igvmfilegen_config"
 version = "0.0.0"
 dependencies = [
+ "igvm_defs",
+ "page_table",
  "product_policy",
  "serde",
  "serde_json",

--- a/vm/loader/igvmfilegen/Cargo.toml
+++ b/vm/loader/igvmfilegen/Cargo.toml
@@ -16,6 +16,8 @@ hvdef.workspace = true
 
 memory_range.workspace = true
 underhill_confidentiality.workspace = true
+vm_topology.workspace = true
+vmm_core.workspace = true
 x86defs.workspace = true
 
 anyhow.workspace = true

--- a/vm/loader/igvmfilegen/Cargo.toml
+++ b/vm/loader/igvmfilegen/Cargo.toml
@@ -7,10 +7,12 @@ name = "igvmfilegen"
 rust-version.workspace = true
 
 [dependencies]
+chipset_resources.workspace = true
 igvmfilegen_config.workspace = true
 loader.workspace = true
 loader_defs.workspace = true
 product_policy.workspace = true
+serial_16550_resources.workspace = true
 
 hvdef.workspace = true
 

--- a/vm/loader/igvmfilegen/src/file_loader.rs
+++ b/vm/loader/igvmfilegen/src/file_loader.rs
@@ -45,6 +45,7 @@ use memory_range::MemoryRange;
 use range_map_vec::Entry;
 use range_map_vec::RangeMap;
 use std::collections::BTreeMap;
+use std::collections::BTreeSet;
 use std::fmt::Debug;
 use std::fmt::Display;
 use zerocopy::FromBytes;
@@ -84,6 +85,18 @@ struct RangeInfo {
     acceptance: BootPageAcceptance,
 }
 
+/// Additional finalization needed by a self-contained SNP Linux-direct image.
+#[derive(Debug, Copy, Clone)]
+pub struct SnpLinuxDirectConfig {
+    pub policy: SnpPolicy,
+    pub c_bit_mask: u64,
+    pub ram_page_count: u64,
+    pub vp_context_count: u32,
+    pub vmsa_page: Option<u64>,
+    pub injection_type: InjectionType,
+    pub import_all_ram: bool,
+}
+
 pub struct IgvmLoader<R: VbsRegister + GuestArch> {
     accepted_ranges: RangeMap<u64, RangeInfo>,
     relocatable_regions: RangeMap<u64, RelocationType>,
@@ -100,6 +113,7 @@ pub struct IgvmLoader<R: VbsRegister + GuestArch> {
     paravisor_present: bool,
     imported_regions_config_page: Option<u64>,
     expected_page_hashes_config_page: Option<u64>,
+    snp_linux_direct: Option<SnpLinuxDirectConfig>,
 }
 
 pub struct IgvmVtlLoader<'a, R: VbsRegister + GuestArch> {
@@ -426,6 +440,53 @@ pub struct IgvmOutput {
     pub map: MapFile,
 }
 
+impl IgvmLoader<X86Register> {
+    /// Create a loader for a self-contained SNP Linux-direct image.
+    pub fn new_snp_linux_direct(config: SnpLinuxDirectConfig) -> Self {
+        let isolation_type = LoaderIsolationType::Snp {
+            shared_gpa_boundary_bits: None,
+            policy: config.policy,
+            injection_type: config.injection_type,
+            secure_avic: SecureAvic::Disabled,
+        };
+        let platform_header = IgvmPlatformHeader::SupportedPlatform(IGVM_VHS_SUPPORTED_PLATFORM {
+            compatibility_mask: DEFAULT_COMPATIBILITY_MASK,
+            highest_vtl: Vtl::Vtl0 as u8,
+            platform_type: IgvmPlatformType::SEV_SNP,
+            platform_version: igvm_defs::IGVM_SEV_SNP_PLATFORM_VERSION,
+            shared_gpa_boundary: 0,
+        });
+        let initialization_headers = vec![IgvmInitializationHeader::GuestPolicy {
+            policy: config.policy.into(),
+            compatibility_mask: DEFAULT_COMPATIBILITY_MASK,
+        }];
+        let mut vp_context =
+            SnpHardwareContext::new_linux_direct(config.c_bit_mask, config.injection_type);
+        if let Some(page) = config.vmsa_page {
+            vp_context.set_vp_context_memory(page);
+        }
+
+        Self {
+            accepted_ranges: RangeMap::new(),
+            relocatable_regions: RangeMap::new(),
+            required_memory: Vec::new(),
+            page_table_region: None,
+            platform_header,
+            initialization_headers,
+            directives: Vec::new(),
+            page_data_directives: Vec::new(),
+            vp_context: Some(Box::new(vp_context)),
+            max_vtl: Vtl::Vtl0,
+            parameter_areas: BTreeMap::new(),
+            isolation_type,
+            paravisor_present: false,
+            imported_regions_config_page: None,
+            expected_page_hashes_config_page: None,
+            snp_linux_direct: Some(config),
+        }
+    }
+}
+
 impl<R: IgvmLoaderRegister + GuestArch + 'static> IgvmLoader<R> {
     pub fn new(with_paravisor: bool, isolation_type: LoaderIsolationType) -> Self {
         let vp_context_builder: Option<Box<dyn VpContextBuilder<Register = R>>>;
@@ -474,7 +535,113 @@ impl<R: IgvmLoaderRegister + GuestArch + 'static> IgvmLoader<R> {
             paravisor_present: with_paravisor,
             imported_regions_config_page: None,
             expected_page_hashes_config_page: None,
+            snp_linux_direct: None,
         }
+    }
+
+    fn finalize_snp_linux_direct(&mut self, config: SnpLinuxDirectConfig) -> anyhow::Result<()> {
+        anyhow::ensure!(
+            self.required_memory.is_empty(),
+            "SNP Linux-direct image already contains a required-memory directive"
+        );
+        let ram_size = config
+            .ram_page_count
+            .checked_mul(PAGE_SIZE_4K)
+            .context("RAM size overflow")?;
+        let number_of_bytes = ram_size
+            .try_into()
+            .context("RAM size does not fit in an IGVM required-memory directive")?;
+        self.directives.insert(
+            0,
+            IgvmDirectiveHeader::RequiredMemory {
+                gpa: 0,
+                compatibility_mask: DEFAULT_COMPATIBILITY_MASK,
+                number_of_bytes,
+                vtl2_protectable: false,
+            },
+        );
+        self.required_memory.push(RequiredMemory {
+            range: MemoryRange::new(0..ram_size),
+            vtl2_protectable: false,
+        });
+
+        let mut page_data_pages = BTreeSet::new();
+        for directive in &self.page_data_directives {
+            let IgvmDirectiveHeader::PageData { gpa, .. } = directive else {
+                unreachable!("page_data_directives contains only PageData")
+            };
+            anyhow::ensure!(
+                gpa.is_multiple_of(PAGE_SIZE_4K),
+                "unaligned page-data GPA {gpa:#x}"
+            );
+            let page = gpa / PAGE_SIZE_4K;
+            anyhow::ensure!(
+                page < config.ram_page_count,
+                "page-data GPA {gpa:#x} lies outside configured RAM"
+            );
+            anyhow::ensure!(
+                page_data_pages.insert(page),
+                "duplicate page-data GPA {gpa:#x}"
+            );
+        }
+
+        if config.import_all_ram {
+            let mut missing_start = None;
+            for page in 0..config.ram_page_count {
+                let occupied = page_data_pages.contains(&page)
+                    || self
+                        .accepted_ranges
+                        .iter()
+                        .any(|(range, _)| range.contains(&page));
+                if occupied {
+                    if let Some(start) = missing_start.take() {
+                        self.accept_new_range(
+                            start,
+                            page - start,
+                            "accepted-zero-ram",
+                            BootPageAcceptance::Exclusive,
+                        )?;
+                    }
+                    continue;
+                }
+
+                missing_start.get_or_insert(page);
+                self.page_data_directives
+                    .push(IgvmDirectiveHeader::PageData {
+                        gpa: page * PAGE_SIZE_4K,
+                        compatibility_mask: DEFAULT_COMPATIBILITY_MASK,
+                        flags: IgvmPageDataFlags::new(),
+                        data_type: IgvmPageDataType::NORMAL,
+                        data: Vec::new(),
+                    });
+            }
+            if let Some(start) = missing_start {
+                self.accept_new_range(
+                    start,
+                    config.ram_page_count - start,
+                    "accepted-zero-ram",
+                    BootPageAcceptance::Exclusive,
+                )?;
+            }
+        }
+
+        self.page_data_directives
+            .sort_unstable_by_key(|directive| match directive {
+                IgvmDirectiveHeader::PageData { gpa, .. } => *gpa,
+                _ => unreachable!("page_data_directives contains only PageData"),
+            });
+
+        let vmsa_count = self
+            .directives
+            .iter()
+            .filter(|directive| matches!(directive, IgvmDirectiveHeader::SnpVpContext { .. }))
+            .count();
+        anyhow::ensure!(
+            vmsa_count == config.vp_context_count as usize,
+            "expected {} SNP VMSA contexts, found {vmsa_count}",
+            config.vp_context_count
+        );
+        Ok(())
     }
 
     /// Compute both the combined SHA-384 over all shared (unmeasured) pages
@@ -679,11 +846,25 @@ impl<R: IgvmLoaderRegister + GuestArch + 'static> IgvmLoader<R> {
             ));
         }
 
-        // Merge the page_data_directives into the others directives. This
-        // must be done before constructing the IGVM file so that subsequent
-        // measurement computation (in `IgvmSerializer`) sees the full set
-        // of directives.
-        self.directives.append(&mut self.page_data_directives);
+        if let Some(config) = self.snp_linux_direct {
+            self.finalize_snp_linux_direct(config)?;
+
+            let (mut vmsa_directives, mut other_directives): (Vec<_>, Vec<_>) =
+                std::mem::take(&mut self.directives)
+                    .into_iter()
+                    .partition(|directive| {
+                        matches!(directive, IgvmDirectiveHeader::SnpVpContext { .. })
+                    });
+            other_directives.append(&mut self.page_data_directives);
+            other_directives.append(&mut vmsa_directives);
+            self.directives = other_directives;
+        } else {
+            // Merge the page_data_directives into the others directives. This
+            // must be done before constructing the IGVM file so that subsequent
+            // measurement computation (in `IgvmSerializer`) sees the full set
+            // of directives.
+            self.directives.append(&mut self.page_data_directives);
+        }
 
         // Display a report about the build igvm file's layout.
         let map_file = MapFile {
@@ -808,6 +989,11 @@ impl<R: IgvmLoaderRegister + GuestArch + 'static> IgvmLoader<R> {
             "Importing page",
         );
 
+        anyhow::ensure!(page_count != 0, "cannot import an empty page range");
+        page_base
+            .checked_add(page_count)
+            .context("imported page range overflow")?;
+
         // Pages must not overlap already accepted ranges
         self.accept_new_range(page_base, page_count, debug_tag, acceptance)?;
 
@@ -860,14 +1046,31 @@ impl<R: IgvmLoaderRegister + GuestArch + 'static> IgvmLoader<R> {
             let mut padded = vec![0u8; size_of::<SevVmsa>()];
             padded[..data.len()].copy_from_slice(data);
 
-            self.directives.push(IgvmDirectiveHeader::SnpVpContext {
-                gpa: page_base * PAGE_SIZE_4K,
-                compatibility_mask: DEFAULT_COMPATIBILITY_MASK,
-                vp_index: 0,
-                vmsa: Box::new(
-                    SevVmsa::read_from_bytes(padded.as_slice()).expect("should be correct size"),
-                ), // TODO: zerocopy: map_err (https://github.com/microsoft/openvmm/issues/759)
-            });
+            let vmsa = SevVmsa::read_from_bytes(padded.as_slice()).expect("should be correct size");
+            let vp_context_count = if let Some(config) = self.snp_linux_direct {
+                anyhow::ensure!(vmsa.rip != 0, "Linux loader did not provide an entry point");
+                anyhow::ensure!(
+                    vmsa.cr3 & config.c_bit_mask != 0,
+                    "initial CR3 does not contain the configured SNP C-bit"
+                );
+                anyhow::ensure!(
+                    !vmsa.sev_features.vtom() && vmsa.virtual_tom == 0,
+                    "C-bit image must not enable vTOM"
+                );
+                config.vp_context_count
+            } else {
+                1
+            };
+            for vp_index in 0..vp_context_count {
+                self.directives.push(IgvmDirectiveHeader::SnpVpContext {
+                    gpa: page_base * PAGE_SIZE_4K,
+                    compatibility_mask: DEFAULT_COMPATIBILITY_MASK,
+                    vp_index: vp_index
+                        .try_into()
+                        .context("VP index does not fit in IGVM")?,
+                    vmsa: Box::new(vmsa),
+                });
+            }
         } else {
             for page in page_base..page_base + page_count {
                 let (data_type, flags) = match acceptance {
@@ -1110,6 +1313,16 @@ impl<R: IgvmLoaderRegister + GuestArch + 'static> ImageLoad<R> for IgvmVtlLoader
     }
 
     fn set_vp_context_page(&mut self, page_base: u64) -> anyhow::Result<()> {
+        if let Some(config) = &mut self.loader.snp_linux_direct {
+            anyhow::ensure!(
+                page_base < config.ram_page_count,
+                "Linux-selected VP context page lies outside RAM"
+            );
+            if config.vmsa_page.is_some() {
+                return Ok(());
+            }
+            config.vmsa_page = Some(page_base);
+        }
         self.loader
             .vp_context
             .as_mut()

--- a/vm/loader/igvmfilegen/src/file_loader.rs
+++ b/vm/loader/igvmfilegen/src/file_loader.rs
@@ -91,7 +91,6 @@ pub struct SnpLinuxDirectConfig {
     pub policy: SnpPolicy,
     pub c_bit_mask: u64,
     pub ram_page_count: u64,
-    pub vp_context_count: u32,
     pub vmsa_page: Option<u64>,
     pub injection_type: InjectionType,
     pub import_all_ram: bool,
@@ -637,9 +636,8 @@ impl<R: IgvmLoaderRegister + GuestArch + 'static> IgvmLoader<R> {
             .filter(|directive| matches!(directive, IgvmDirectiveHeader::SnpVpContext { .. }))
             .count();
         anyhow::ensure!(
-            vmsa_count == config.vp_context_count as usize,
-            "expected {} SNP VMSA contexts, found {vmsa_count}",
-            config.vp_context_count
+            vmsa_count == 1,
+            "expected one SNP BSP VMSA context, found {vmsa_count}"
         );
         Ok(())
     }
@@ -1047,7 +1045,7 @@ impl<R: IgvmLoaderRegister + GuestArch + 'static> IgvmLoader<R> {
             padded[..data.len()].copy_from_slice(data);
 
             let vmsa = SevVmsa::read_from_bytes(padded.as_slice()).expect("should be correct size");
-            let vp_context_count = if let Some(config) = self.snp_linux_direct {
+            if let Some(config) = self.snp_linux_direct {
                 anyhow::ensure!(vmsa.rip != 0, "Linux loader did not provide an entry point");
                 anyhow::ensure!(
                     vmsa.cr3 & config.c_bit_mask != 0,
@@ -1057,20 +1055,13 @@ impl<R: IgvmLoaderRegister + GuestArch + 'static> IgvmLoader<R> {
                     !vmsa.sev_features.vtom() && vmsa.virtual_tom == 0,
                     "C-bit image must not enable vTOM"
                 );
-                config.vp_context_count
-            } else {
-                1
-            };
-            for vp_index in 0..vp_context_count {
-                self.directives.push(IgvmDirectiveHeader::SnpVpContext {
-                    gpa: page_base * PAGE_SIZE_4K,
-                    compatibility_mask: DEFAULT_COMPATIBILITY_MASK,
-                    vp_index: vp_index
-                        .try_into()
-                        .context("VP index does not fit in IGVM")?,
-                    vmsa: Box::new(vmsa),
-                });
             }
+            self.directives.push(IgvmDirectiveHeader::SnpVpContext {
+                gpa: page_base * PAGE_SIZE_4K,
+                compatibility_mask: DEFAULT_COMPATIBILITY_MASK,
+                vp_index: 0,
+                vmsa: Box::new(vmsa),
+            });
         } else {
             for page in page_base..page_base + page_count {
                 let (data_type, flags) = match acceptance {

--- a/vm/loader/igvmfilegen/src/file_loader.rs
+++ b/vm/loader/igvmfilegen/src/file_loader.rs
@@ -855,27 +855,13 @@ impl<R: IgvmLoaderRegister + GuestArch + 'static> IgvmLoader<R> {
 
         if let Some(config) = self.snp_linux_direct {
             self.finalize_snp_linux_direct(config)?;
-
-            // Current KVM measures initial VMSAs during launch finish, after
-            // every userspace page update. Keep the file's BSP VMSA last so a
-            // single-VP launch measurement and ID block match that ordering.
-            // This remains necessary until KVM accepts userspace VMSA pages.
-            let (mut vmsa_directives, mut other_directives): (Vec<_>, Vec<_>) =
-                std::mem::take(&mut self.directives)
-                    .into_iter()
-                    .partition(|directive| {
-                        matches!(directive, IgvmDirectiveHeader::SnpVpContext { .. })
-                    });
-            other_directives.append(&mut self.page_data_directives);
-            other_directives.append(&mut vmsa_directives);
-            self.directives = other_directives;
-        } else {
-            // Merge the page_data_directives into the others directives. This
-            // must be done before constructing the IGVM file so that subsequent
-            // measurement computation (in `IgvmSerializer`) sees the full set
-            // of directives.
-            self.directives.append(&mut self.page_data_directives);
         }
+
+        // Merge the page_data_directives into the others directives. This
+        // must be done before constructing the IGVM file so that subsequent
+        // measurement computation (in `IgvmSerializer`) sees the full set
+        // of directives.
+        self.directives.append(&mut self.page_data_directives);
 
         // Display a report about the build igvm file's layout.
         let map_file = MapFile {

--- a/vm/loader/igvmfilegen/src/file_loader.rs
+++ b/vm/loader/igvmfilegen/src/file_loader.rs
@@ -538,6 +538,15 @@ impl<R: IgvmLoaderRegister + GuestArch + 'static> IgvmLoader<R> {
         }
     }
 
+    /// Adds the fixed-memory contract required by a self-contained
+    /// Linux-direct image.
+    ///
+    /// The generic Linux loader imports only the pages that contain boot data
+    /// and does not call `verify_startup_memory_available`. UEFI and paravisor
+    /// loaders use that callback to emit their required-memory directives, but
+    /// a direct Linux IGVM must describe its complete startup RAM here. When
+    /// requested, this also imports every otherwise-unused RAM page as measured
+    /// zero data. The caller then places the BSP VMSA after those page updates.
     fn finalize_snp_linux_direct(&mut self, config: SnpLinuxDirectConfig) -> anyhow::Result<()> {
         anyhow::ensure!(
             self.required_memory.is_empty(),
@@ -847,6 +856,10 @@ impl<R: IgvmLoaderRegister + GuestArch + 'static> IgvmLoader<R> {
         if let Some(config) = self.snp_linux_direct {
             self.finalize_snp_linux_direct(config)?;
 
+            // Current KVM measures initial VMSAs during launch finish, after
+            // every userspace page update. Keep the file's BSP VMSA last so a
+            // single-VP launch measurement and ID block match that ordering.
+            // This remains necessary until KVM accepts userspace VMSA pages.
             let (mut vmsa_directives, mut other_directives): (Vec<_>, Vec<_>) =
                 std::mem::take(&mut self.directives)
                     .into_iter()

--- a/vm/loader/igvmfilegen/src/main.rs
+++ b/vm/loader/igvmfilegen/src/main.rs
@@ -436,20 +436,6 @@ struct PlatformMeta {
     snp_identity: Option<snp_id_block::SnpImageIdentity>,
 }
 
-struct BuiltGuest {
-    guest: IgvmFile,
-    map: String,
-}
-
-impl From<file_loader::IgvmOutput> for BuiltGuest {
-    fn from(output: file_loader::IgvmOutput) -> Self {
-        Self {
-            guest: output.guest,
-            map: output.map.to_string(),
-        }
-    }
-}
-
 /// Build a sibling path of `output` named `<base>-<isolation><ext>`,
 /// where `base` is `output`'s stem, `<isolation>` is derived from
 /// `meta.platform`, and `ext` includes the leading dot
@@ -658,7 +644,7 @@ fn create_igvm_file<R: IgvmfilegenRegister + GuestArch + 'static>(
             LoaderIsolationType::None => {}
         }
 
-        let igvm_output: BuiltGuest = match &config.image {
+        let igvm_output: file_loader::IgvmOutput = match &config.image {
             Image::SnpLinuxDirect {
                 linux,
                 processor_count,
@@ -702,7 +688,7 @@ fn create_igvm_file<R: IgvmfilegenRegister + GuestArch + 'static>(
                 let with_paravisor = config.max_vtl == 2;
                 let mut loader = IgvmLoader::<R>::new(with_paravisor, loader_isolation_type);
                 load_image(&mut loader.loader(), &config.image, &resources)?;
-                loader.finalize().context("finalizing loader")?.into()
+                loader.finalize().context("finalizing loader")?
             }
         };
 
@@ -1265,7 +1251,7 @@ fn debug_validate_igvm_file(binary_file: &[u8]) {
 trait IgvmfilegenRegister: IgvmLoaderRegister + 'static {
     fn build_snp_linux_direct(
         params: snp_linux_direct::BuildParams<'_>,
-    ) -> anyhow::Result<BuiltGuest>;
+    ) -> anyhow::Result<file_loader::IgvmOutput>;
 
     fn load_uefi(
         importer: &mut dyn ImageLoad<Self>,
@@ -1303,12 +1289,8 @@ trait IgvmfilegenRegister: IgvmLoaderRegister + 'static {
 impl IgvmfilegenRegister for X86Register {
     fn build_snp_linux_direct(
         params: snp_linux_direct::BuildParams<'_>,
-    ) -> anyhow::Result<BuiltGuest> {
-        let output = snp_linux_direct::build(params)?;
-        Ok(BuiltGuest {
-            guest: output.guest,
-            map: output.map,
-        })
+    ) -> anyhow::Result<file_loader::IgvmOutput> {
+        snp_linux_direct::build(params)
     }
 
     fn load_uefi(
@@ -1370,7 +1352,7 @@ impl IgvmfilegenRegister for X86Register {
 impl IgvmfilegenRegister for Aarch64Register {
     fn build_snp_linux_direct(
         _params: snp_linux_direct::BuildParams<'_>,
-    ) -> anyhow::Result<BuiltGuest> {
+    ) -> anyhow::Result<file_loader::IgvmOutput> {
         bail!("snp_linux_direct is only supported for x64")
     }
 

--- a/vm/loader/igvmfilegen/src/main.rs
+++ b/vm/loader/igvmfilegen/src/main.rs
@@ -15,6 +15,7 @@ mod identity_mapping;
 mod measurement_diag;
 mod platform_mask;
 mod snp_id_block;
+mod snp_linux_direct;
 mod vp_context_builder;
 
 use crate::corim_signature::detach_payload;
@@ -432,6 +433,21 @@ struct PlatformMeta {
     platform: IgvmPlatformType,
     svn: u32,
     debug_enabled: bool,
+    snp_identity: Option<snp_id_block::SnpImageIdentity>,
+}
+
+struct BuiltGuest {
+    guest: IgvmFile,
+    map: String,
+}
+
+impl From<file_loader::IgvmOutput> for BuiltGuest {
+    fn from(output: file_loader::IgvmOutput) -> Self {
+        Self {
+            guest: output.guest,
+            map: output.map.to_string(),
+        }
+    }
 }
 
 /// Build a sibling path of `output` named `<base>-<isolation><ext>`,
@@ -533,15 +549,27 @@ fn create_igvm_file<R: IgvmfilegenRegister + GuestArch + 'static>(
     let mut map_files = Vec::new();
     let mut platform_metas: Vec<PlatformMeta> = Vec::new();
     let base_path = output.file_stem().unwrap();
+    let has_snp_linux_direct = igvm_config
+        .guest_configs
+        .iter()
+        .any(|config| matches!(config.image, Image::SnpLinuxDirect { .. }));
+    if has_snp_linux_direct && igvm_config.guest_configs.len() != 1 {
+        bail!("snp_linux_direct must be the only guest config in an IGVM file");
+    }
+
     for config in igvm_config.guest_configs {
         // Max VTL must be 2 or 0.
         if config.max_vtl != 2 && config.max_vtl != 0 {
             bail!("max_vtl must be 2 or 0");
         }
 
-        let loader_isolation_type = match config.isolation_type {
+        config.image.validate().context("invalid image config")?;
+
+        let loader_isolation_type = match &config.isolation_type {
             ConfigIsolationType::None => LoaderIsolationType::None,
-            ConfigIsolationType::Vbs { enable_debug } => LoaderIsolationType::Vbs { enable_debug },
+            ConfigIsolationType::Vbs { enable_debug } => LoaderIsolationType::Vbs {
+                enable_debug: *enable_debug,
+            },
             ConfigIsolationType::Snp {
                 shared_gpa_boundary_bits,
                 policy,
@@ -549,8 +577,8 @@ fn create_igvm_file<R: IgvmfilegenRegister + GuestArch + 'static>(
                 injection_type,
                 secure_avic,
             } => LoaderIsolationType::Snp {
-                shared_gpa_boundary_bits,
-                policy: SnpPolicy::from(policy).with_debug(enable_debug as u8),
+                shared_gpa_boundary_bits: *shared_gpa_boundary_bits,
+                policy: SnpPolicy::from(*policy).with_debug(*enable_debug as u8),
                 injection_type: match injection_type {
                     SnpInjectionType::Normal => vp_context_builder::snp::InjectionType::Normal,
                     SnpInjectionType::Restricted => {
@@ -567,8 +595,8 @@ fn create_igvm_file<R: IgvmfilegenRegister + GuestArch + 'static>(
                 sept_ve_disable,
             } => LoaderIsolationType::Tdx {
                 policy: TdxPolicy::new()
-                    .with_debug_allowed(enable_debug as u8)
-                    .with_sept_ve_disable(sept_ve_disable as u8),
+                    .with_debug_allowed(*enable_debug as u8)
+                    .with_sept_ve_disable(*sept_ve_disable as u8),
             },
         };
 
@@ -604,6 +632,11 @@ fn create_igvm_file<R: IgvmfilegenRegister + GuestArch + 'static>(
                     platform: IgvmPlatformType::SEV_SNP,
                     svn: config.guest_svn,
                     debug_enabled: policy.debug() == 1,
+                    snp_identity: Some(if matches!(config.image, Image::SnpLinuxDirect { .. }) {
+                        snp_id_block::SnpImageIdentity::LINUX_DIRECT
+                    } else {
+                        snp_id_block::SnpImageIdentity::OPENHCL
+                    }),
                 });
             }
             LoaderIsolationType::Tdx { policy } => {
@@ -611,6 +644,7 @@ fn create_igvm_file<R: IgvmfilegenRegister + GuestArch + 'static>(
                     platform: IgvmPlatformType::TDX,
                     svn: config.guest_svn,
                     debug_enabled: policy.debug_allowed() == 1,
+                    snp_identity: None,
                 });
             }
             LoaderIsolationType::Vbs { enable_debug } => {
@@ -618,19 +652,59 @@ fn create_igvm_file<R: IgvmfilegenRegister + GuestArch + 'static>(
                     platform: IgvmPlatformType::VSM_ISOLATION,
                     svn: config.guest_svn,
                     debug_enabled: *enable_debug,
+                    snp_identity: None,
                 });
             }
             LoaderIsolationType::None => {}
         }
 
-        // Max VTL of 2 implies paravisor.
-        let with_paravisor = config.max_vtl == 2;
+        let igvm_output: BuiltGuest = match &config.image {
+            Image::SnpLinuxDirect {
+                linux,
+                processor_count,
+                memory_page_count,
+                c_bit_position,
+            } => {
+                if config.max_vtl != 0 {
+                    bail!("snp_linux_direct requires max_vtl 0");
+                }
+                let ConfigIsolationType::Snp {
+                    shared_gpa_boundary_bits,
+                    policy,
+                    enable_debug,
+                    injection_type,
+                    secure_avic,
+                } = &config.isolation_type
+                else {
+                    bail!("snp_linux_direct requires SNP isolation");
+                };
+                if shared_gpa_boundary_bits.is_some() {
+                    bail!("snp_linux_direct does not support a shared GPA boundary");
+                }
+                if !matches!(injection_type, SnpInjectionType::Normal) {
+                    bail!("snp_linux_direct requires normal interrupt injection");
+                }
+                if !matches!(secure_avic, SecureAvicType::Disabled) {
+                    bail!("snp_linux_direct requires secure AVIC to be disabled");
+                }
 
-        let mut loader = IgvmLoader::<R>::new(with_paravisor, loader_isolation_type);
-
-        load_image(&mut loader.loader(), &config.image, &resources)?;
-
-        let igvm_output = loader.finalize().context("finalizing loader")?;
+                R::build_snp_linux_direct(snp_linux_direct::BuildParams {
+                    linux,
+                    processor_count: *processor_count,
+                    memory_page_count: *memory_page_count,
+                    c_bit_position: *c_bit_position,
+                    policy: SnpPolicy::from(*policy).with_debug(*enable_debug as u8),
+                    resources: &resources,
+                })?
+            }
+            _ => {
+                // Max VTL of 2 implies paravisor.
+                let with_paravisor = config.max_vtl == 2;
+                let mut loader = IgvmLoader::<R>::new(with_paravisor, loader_isolation_type);
+                load_image(&mut loader.loader(), &config.image, &resources)?;
+                loader.finalize().context("finalizing loader")?.into()
+            }
+        };
 
         // Merge the loaded guest into the overall IGVM file.
         match &mut igvm_file {
@@ -704,8 +778,16 @@ fn create_igvm_file<R: IgvmfilegenRegister + GuestArch + 'static>(
         if meta.platform == IgvmPlatformType::SEV_SNP {
             let policy = snp_id_block::guest_policy(serializer.file(), compatibility_mask)
                 .context("SNP GuestPolicy missing; cannot emit SNP ID block signing payload")?;
-            let signing_payload =
-                snp_id_block::id_block_signing_payload(&digest, meta.svn, policy)?;
+            let identity = meta
+                .snp_identity
+                .expect("SNP platform metadata includes an image identity");
+            let signing_payload = if identity == snp_id_block::SnpImageIdentity::OPENHCL {
+                snp_id_block::id_block_signing_payload(&digest, meta.svn, policy)?
+            } else {
+                snp_id_block::id_block_signing_payload_with_identity(
+                    &digest, meta.svn, policy, identity,
+                )?
+            };
             write_platform_sibling(base_path, &output, meta, ".idblock", &signing_payload)?;
         }
     }
@@ -1181,6 +1263,10 @@ fn debug_validate_igvm_file(binary_file: &[u8]) {
 /// register types for different architectures. Different methods may need to be
 /// called depending on the register type that represents the given architecture.
 trait IgvmfilegenRegister: IgvmLoaderRegister + 'static {
+    fn build_snp_linux_direct(
+        params: snp_linux_direct::BuildParams<'_>,
+    ) -> anyhow::Result<BuiltGuest>;
+
     fn load_uefi(
         importer: &mut dyn ImageLoad<Self>,
         image: &[u8],
@@ -1215,6 +1301,16 @@ trait IgvmfilegenRegister: IgvmLoaderRegister + 'static {
 }
 
 impl IgvmfilegenRegister for X86Register {
+    fn build_snp_linux_direct(
+        params: snp_linux_direct::BuildParams<'_>,
+    ) -> anyhow::Result<BuiltGuest> {
+        let output = snp_linux_direct::build(params)?;
+        Ok(BuiltGuest {
+            guest: output.guest,
+            map: output.map,
+        })
+    }
+
     fn load_uefi(
         importer: &mut dyn ImageLoad<Self>,
         image: &[u8],
@@ -1272,6 +1368,12 @@ impl IgvmfilegenRegister for X86Register {
 }
 
 impl IgvmfilegenRegister for Aarch64Register {
+    fn build_snp_linux_direct(
+        _params: snp_linux_direct::BuildParams<'_>,
+    ) -> anyhow::Result<BuiltGuest> {
+        bail!("snp_linux_direct is only supported for x64")
+    }
+
     fn load_uefi(
         importer: &mut dyn ImageLoad<Self>,
         image: &[u8],
@@ -1345,6 +1447,9 @@ fn load_image<'a, R: IgvmfilegenRegister + GuestArch + 'static>(
         }
         Image::Linux(ref linux) => {
             load_linux(loader, linux, resources)?;
+        }
+        Image::SnpLinuxDirect { .. } => {
+            unreachable!("snp_linux_direct is built by its dedicated strategy")
         }
         Image::Openhcl {
             ref command_line,

--- a/vm/loader/igvmfilegen/src/main.rs
+++ b/vm/loader/igvmfilegen/src/main.rs
@@ -552,7 +552,7 @@ fn create_igvm_file<R: IgvmfilegenRegister + GuestArch + 'static>(
     let has_snp_linux_direct = igvm_config
         .guest_configs
         .iter()
-        .any(|config| matches!(config.image, Image::SnpLinuxDirect { .. }));
+        .any(|config| matches!(&config.image, Image::SnpLinuxDirect { .. }));
     if has_snp_linux_direct && igvm_config.guest_configs.len() != 1 {
         bail!("snp_linux_direct must be the only guest config in an IGVM file");
     }
@@ -632,7 +632,7 @@ fn create_igvm_file<R: IgvmfilegenRegister + GuestArch + 'static>(
                     platform: IgvmPlatformType::SEV_SNP,
                     svn: config.guest_svn,
                     debug_enabled: policy.debug() == 1,
-                    snp_identity: Some(if matches!(config.image, Image::SnpLinuxDirect { .. }) {
+                    snp_identity: Some(if matches!(&config.image, Image::SnpLinuxDirect { .. }) {
                         snp_id_block::SnpImageIdentity::LINUX_DIRECT
                     } else {
                         snp_id_block::SnpImageIdentity::OPENHCL

--- a/vm/loader/igvmfilegen/src/main.rs
+++ b/vm/loader/igvmfilegen/src/main.rs
@@ -171,9 +171,10 @@ enum Options {
     ///   and `--id-public-key <key.pem>` (the signer's X.509 certificate or
     ///   SPKI public key, PEM or DER). No private key is held by this tool.
     ///   The guest SVN comes from the signing payload.
-    /// * Temporary key (development/test): pass `--guest-svn <N>` or
-    ///   `--manifest <config.json>` (to source the SVN from the SNP guest
-    ///   config). An ephemeral ECDSA P-384 key signs the block in-process.
+    /// * Temporary key (development/test): pass `--guest-svn <N>` to sign an
+    ///   OpenHCL identity, or `--manifest <config.json>` to source both the SVN
+    ///   and image identity from its SNP guest config. An ephemeral ECDSA P-384
+    ///   key signs the block in-process.
     AddSnpIdBlock {
         /// Input IGVM file path
         #[clap(short, long)]
@@ -181,12 +182,13 @@ enum Options {
         /// Output IGVM file path (can be the same as input to modify in place)
         #[clap(short, long)]
         output: PathBuf,
-        /// Temporary-key mode: guest security version number to embed.
+        /// Temporary-key mode: guest security version number to embed using
+        /// the OpenHCL image identity.
         /// Mutually exclusive with the out-of-band inputs and with `--manifest`.
         #[clap(long, conflicts_with_all = ["manifest", "id_block", "id_signature", "id_public_key"])]
         guest_svn: Option<u32>,
-        /// Temporary-key mode: source the guest SVN from the SNP guest config
-        /// in this manifest instead of `--guest-svn`.
+        /// Temporary-key mode: source the guest SVN and image identity from
+        /// the SNP guest config in this manifest instead of `--guest-svn`.
         #[clap(long, conflicts_with_all = ["guest_svn", "id_block", "id_signature", "id_public_key"])]
         manifest: Option<PathBuf>,
         /// Out-of-band mode: path to the SNP ID block signing payload
@@ -904,17 +906,17 @@ fn add_snp_id_block_command(
             &public_key,
         )?
     } else {
-        // Temporary-key (development/test) mode. The SVN comes from
-        // `--guest-svn` or is sourced from the SNP guest config in `--manifest`.
-        let svn = if let Some(svn) = guest_svn {
-            svn
+        // Temporary-key (development/test) mode. Raw `--guest-svn` preserves
+        // the original OpenHCL behavior; a manifest selects both fields.
+        let (svn, identity) = if let Some(svn) = guest_svn {
+            (svn, snp_id_block::SnpImageIdentity::OPENHCL)
         } else if let Some(manifest_path) = manifest {
             let config: Config = serde_json::from_str(
                 &fs_err::read_to_string(&manifest_path)
                     .with_context(|| format!("reading manifest at {}", manifest_path.display()))?,
             )
             .with_context(|| format!("parsing manifest at {}", manifest_path.display()))?;
-            snp_guest_svn_from_config(&config)?
+            snp_temporary_signing_metadata_from_config(&config)?
         } else {
             bail!(
                 "provide either --guest-svn/--manifest (temporary-key signing) \
@@ -926,30 +928,37 @@ fn add_snp_id_block_command(
             input = %input.display(),
             output = %output.display(),
             guest_svn = svn,
+            ?identity,
             "Adding SNP ID block (temporary key)"
         );
-        snp_id_block::add_snp_id_block_temp_key(&igvm_data, svn)?
+        snp_id_block::add_snp_id_block_temp_key(&igvm_data, svn, identity)?
     };
 
     write_igvm_file_atomic(&output, &new_igvm, "Writing IGVM file with SNP ID block")
 }
 
-/// Extract the guest SVN from the (single) SEV-SNP guest config in a manifest.
-fn snp_guest_svn_from_config(config: &Config) -> anyhow::Result<u32> {
-    let mut snp_svns = config
+/// Extract temporary-signing metadata from the single SNP guest config.
+fn snp_temporary_signing_metadata_from_config(
+    config: &Config,
+) -> anyhow::Result<(u32, snp_id_block::SnpImageIdentity)> {
+    let mut snp_guests = config
         .guest_configs
         .iter()
-        .filter(|c| matches!(c.isolation_type, ConfigIsolationType::Snp { .. }))
-        .map(|c| c.guest_svn);
-    let svn = snp_svns
-        .next()
-        .context("manifest has no SEV-SNP guest config to source --guest-svn from")?;
+        .filter(|c| matches!(&c.isolation_type, ConfigIsolationType::Snp { .. }));
+    let guest = snp_guests.next().context(
+        "manifest has no SEV-SNP guest config to source temporary-signing metadata from",
+    )?;
     anyhow::ensure!(
-        snp_svns.next().is_none(),
+        snp_guests.next().is_none(),
         "manifest has more than one SEV-SNP guest config; cannot unambiguously \
-         source --guest-svn (pass --guest-svn explicitly instead)"
+         source temporary-signing metadata"
     );
-    Ok(svn)
+    let identity = if matches!(&guest.image, Image::SnpLinuxDirect { .. }) {
+        snp_id_block::SnpImageIdentity::LINUX_DIRECT
+    } else {
+        snp_id_block::SnpImageIdentity::OPENHCL
+    };
+    Ok((guest.guest_svn, identity))
 }
 
 /// Dump CoRIM headers from an IGVM file.
@@ -1603,4 +1612,28 @@ fn load_linux<R: IgvmfilegenRegister + GuestArch + 'static>(
     let load_info = R::load_linux_kernel_and_initrd(loader, &mut kernel, 0, initrd, None)
         .context("loading linux kernel and initrd")?;
     Ok(load_info)
+}
+
+#[cfg(test)]
+mod temporary_signing_tests {
+    use super::*;
+
+    #[test]
+    fn linux_direct_manifest_selects_linux_direct_identity() {
+        let config: Config =
+            serde_json::from_str(include_str!("../../manifests/snp-linux-direct.json")).unwrap();
+
+        let (svn, identity) = snp_temporary_signing_metadata_from_config(&config).unwrap();
+        assert_eq!(svn, 1);
+        assert_eq!(identity, snp_id_block::SnpImageIdentity::LINUX_DIRECT);
+    }
+
+    #[test]
+    fn openhcl_manifest_selects_openhcl_identity() {
+        let config: Config =
+            serde_json::from_str(include_str!("../../manifests/openhcl-x64-cvm-dev.json")).unwrap();
+
+        let (_, identity) = snp_temporary_signing_metadata_from_config(&config).unwrap();
+        assert_eq!(identity, snp_id_block::SnpImageIdentity::OPENHCL);
+    }
 }

--- a/vm/loader/igvmfilegen/src/snp_id_block.rs
+++ b/vm/loader/igvmfilegen/src/snp_id_block.rs
@@ -138,11 +138,16 @@ pub fn guest_policy(igvm_file: &IgvmFile, compatibility_mask: u32) -> Option<u64
 /// * `igvm_data` - Input IGVM file; must contain an SEV-SNP platform header and
 ///   a matching [`IgvmInitializationHeader::GuestPolicy`].
 /// * `guest_svn` - Guest security version number to embed.
+/// * `identity` - Family and image identifiers to embed.
 ///
 /// # Errors
 /// Returns an error if the file has no SEV-SNP platform, already contains an
 /// SNP ID block, lacks an SNP measurement/guest policy, or if signing fails.
-pub fn add_snp_id_block_temp_key(igvm_data: &[u8], guest_svn: u32) -> anyhow::Result<Vec<u8>> {
+pub(crate) fn add_snp_id_block_temp_key(
+    igvm_data: &[u8],
+    guest_svn: u32,
+    identity: SnpImageIdentity,
+) -> anyhow::Result<Vec<u8>> {
     let igvm_file =
         IgvmFile::new_from_binary(igvm_data, None).context("parsing input IGVM file")?;
     let (compatibility_mask, policy) = snp_context(&igvm_file)?;
@@ -152,8 +157,8 @@ pub fn add_snp_id_block_temp_key(igvm_data: &[u8], guest_svn: u32) -> anyhow::Re
 
     let psp_id_block = SnpPspIdBlock {
         ld,
-        family_id: SNP_FAMILY_ID,
-        image_id: SNP_IMAGE_ID,
+        family_id: identity.family_id,
+        image_id: identity.image_id,
         version: 0x1,
         guest_svn,
         policy,
@@ -851,7 +856,8 @@ mod tests {
             .digest
             .clone();
 
-        let out = add_snp_id_block_temp_key(&igvm_data, 7).expect("add SNP ID block");
+        let out = add_snp_id_block_temp_key(&igvm_data, 7, SnpImageIdentity::LINUX_DIRECT)
+            .expect("add SNP ID block");
         assert_eq!(count_id_blocks(&out), 1);
 
         let parsed = IgvmFile::new_from_binary(&out, None).expect("valid output");
@@ -859,12 +865,20 @@ mod tests {
             .directives()
             .iter()
             .find_map(|h| match h {
-                IgvmDirectiveHeader::SnpIdBlock { ld, guest_svn, .. } => Some((*ld, *guest_svn)),
+                IgvmDirectiveHeader::SnpIdBlock {
+                    ld,
+                    family_id,
+                    image_id,
+                    guest_svn,
+                    ..
+                } => Some((*ld, *family_id, *image_id, *guest_svn)),
                 _ => None,
             })
             .expect("id block present");
         assert_eq!(id_block.0.as_slice(), ref_ld.as_slice());
-        assert_eq!(id_block.1, 7);
+        assert_eq!(id_block.1, SnpImageIdentity::LINUX_DIRECT.family_id);
+        assert_eq!(id_block.2, SnpImageIdentity::LINUX_DIRECT.image_id);
+        assert_eq!(id_block.3, 7);
 
         // The measurement of the patched file must be unchanged.
         let after_ld = IgvmSerializer::new(&parsed)
@@ -880,8 +894,9 @@ mod tests {
     #[test]
     fn add_snp_id_block_rejects_double_add() {
         let igvm_data = build_snp_igvm(0x1);
-        let once = add_snp_id_block_temp_key(&igvm_data, 1).expect("first add");
-        let err = add_snp_id_block_temp_key(&once, 1).unwrap_err();
+        let once =
+            add_snp_id_block_temp_key(&igvm_data, 1, SnpImageIdentity::OPENHCL).expect("first add");
+        let err = add_snp_id_block_temp_key(&once, 1, SnpImageIdentity::OPENHCL).unwrap_err();
         assert!(
             format!("{err:#}").contains("already contains an SNP ID block"),
             "unexpected error: {err:#}"
@@ -911,7 +926,7 @@ mod tests {
         let mut data = Vec::new();
         igvm.serialize(&mut data).unwrap();
 
-        let err = add_snp_id_block_temp_key(&data, 1).unwrap_err();
+        let err = add_snp_id_block_temp_key(&data, 1, SnpImageIdentity::OPENHCL).unwrap_err();
         assert!(format!("{err:#}").to_lowercase().contains("platform"));
     }
 

--- a/vm/loader/igvmfilegen/src/snp_id_block.rs
+++ b/vm/loader/igvmfilegen/src/snp_id_block.rs
@@ -59,6 +59,28 @@ const SNP_ECDSA_CURVE_P384: u32 = 2;
 const SNP_ECC_KEY_SIZE_BYTES: usize = 48;
 const SNP_ECC_COMPONENT_SIZE_BYTES: usize = 72;
 
+/// Identity fields included in an SNP ID block.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct SnpImageIdentity {
+    family_id: [u8; 16],
+    image_id: [u8; 16],
+}
+
+impl SnpImageIdentity {
+    /// The OpenHCL SNP image identity.
+    pub(crate) const OPENHCL: Self = Self::new(SNP_FAMILY_ID, SNP_IMAGE_ID);
+
+    /// The identity used by the direct-Linux SNP test image.
+    pub(crate) const LINUX_DIRECT: Self = Self::new(*b"OpenVMM SNP test", *b"linux-direct\0\0\0\0");
+
+    const fn new(family_id: [u8; 16], image_id: [u8; 16]) -> Self {
+        Self {
+            family_id,
+            image_id,
+        }
+    }
+}
+
 /// Build the SNP ID block signing payload for an IGVM file.
 ///
 /// Called by `manifest` to emit `<base>-snp.idblock`. The returned bytes are
@@ -69,12 +91,22 @@ const SNP_ECC_COMPONENT_SIZE_BYTES: usize = 72;
 /// measurement, `policy` comes from the file's `GuestPolicy`, and `guest_svn`
 /// from the manifest.
 pub fn id_block_signing_payload(ld: &[u8], guest_svn: u32, policy: u64) -> anyhow::Result<Vec<u8>> {
+    id_block_signing_payload_with_identity(ld, guest_svn, policy, SnpImageIdentity::OPENHCL)
+}
+
+/// Build an SNP ID block signing payload with an explicit image identity.
+pub(crate) fn id_block_signing_payload_with_identity(
+    ld: &[u8],
+    guest_svn: u32,
+    policy: u64,
+    identity: SnpImageIdentity,
+) -> anyhow::Result<Vec<u8>> {
     let ld: [u8; SHA_384_OUTPUT_SIZE_BYTES] =
         ld.try_into().context("SNP launch digest is not 48 bytes")?;
     let id_block = SnpPspIdBlock {
         ld,
-        family_id: SNP_FAMILY_ID,
-        image_id: SNP_IMAGE_ID,
+        family_id: identity.family_id,
+        image_id: identity.image_id,
         version: 0x1,
         guest_svn,
         policy,

--- a/vm/loader/igvmfilegen/src/snp_linux_direct.rs
+++ b/vm/loader/igvmfilegen/src/snp_linux_direct.rs
@@ -183,6 +183,13 @@ impl ImageLoad<X86Register> for TestIgvmImporter {
             page_end <= self.ram_page_count,
             "{debug_tag} lies outside the configured RAM layout"
         );
+        if let Some(page_number) = (page_base..page_end).find(|page| self.pages.contains_key(page))
+        {
+            bail!(
+                "{debug_tag} overlaps an existing import at GPA {:#x}",
+                page_number * PAGE_SIZE
+            );
+        }
 
         for page_offset in 0..page_count {
             let data_start = (page_offset * PAGE_SIZE) as usize;
@@ -195,18 +202,13 @@ impl ImageLoad<X86Register> for TestIgvmImporter {
                 Vec::new()
             };
             let page_number = page_base + page_offset;
-            let previous = self.pages.insert(
+            self.pages.insert(
                 page_number,
                 ImportedPage {
                     acceptance,
                     data: page_data,
                     tag: debug_tag,
                 },
-            );
-            ensure!(
-                previous.is_none(),
-                "{debug_tag} overlaps an existing import at GPA {:#x}",
-                page_number * PAGE_SIZE
             );
         }
         Ok(())
@@ -912,5 +914,30 @@ mod tests {
             })
             .collect::<Vec<_>>();
         assert_eq!(vp_indexes, [0, 1, 2, 3]);
+    }
+
+    #[test]
+    fn overlapping_import_does_not_mutate_existing_pages() {
+        let mut importer = TestIgvmImporter::new(4, 51);
+        importer
+            .import_pages(1, 1, "first", BootPageAcceptance::Exclusive, &[0xaa])
+            .unwrap();
+
+        let error = importer
+            .import_pages(
+                0,
+                2,
+                "overlap",
+                BootPageAcceptance::Exclusive,
+                &[0xbb; PAGE_SIZE as usize * 2],
+            )
+            .unwrap_err();
+
+        assert!(error.to_string().contains("overlaps an existing import"));
+        assert_eq!(importer.pages.len(), 1);
+        assert!(!importer.pages.contains_key(&0));
+        let existing = &importer.pages[&1];
+        assert_eq!(existing.tag, "first");
+        assert_eq!(existing.data, [0xaa]);
     }
 }

--- a/vm/loader/igvmfilegen/src/snp_linux_direct.rs
+++ b/vm/loader/igvmfilegen/src/snp_linux_direct.rs
@@ -3,16 +3,13 @@
 
 //! Generation strategy for a self-contained SNP Linux-direct IGVM.
 
+use crate::file_loader::IgvmLoader;
+use crate::file_loader::IgvmOutput;
+use crate::file_loader::SnpLinuxDirectConfig;
+use crate::vp_context_builder::snp::InjectionType;
 use anyhow::Context;
-use anyhow::bail;
-use anyhow::ensure;
-use igvm::IgvmDirectiveHeader;
-use igvm::IgvmFile;
-use igvm::IgvmInitializationHeader;
-use igvm::IgvmPlatformHeader;
-use igvm::IgvmSerializer;
-use igvm_defs::IgvmPageDataType;
-use igvm_defs::IgvmPlatformType;
+use chipset_resources::pm::DEFAULT_ACPI_IRQ;
+use chipset_resources::pm::DEFAULT_PM_PIO_BASE;
 use igvm_defs::SnpPolicy;
 use igvmfilegen_config::LinuxImage;
 use igvmfilegen_config::ResourceType;
@@ -20,72 +17,103 @@ use igvmfilegen_config::Resources;
 use loader::importer::X86Register;
 use loader::linux::InitrdAddressType;
 use loader::linux::InitrdConfig;
-use std::collections::BTreeSet;
+use serial_16550_resources::ComPort;
 use std::io::Seek;
 use vm_topology::memory::MemoryLayout;
+use vm_topology::pcie::PcieHostBridge;
+use vm_topology::processor::ProcessorTopology;
 use vm_topology::processor::TopologyBuilder;
+use vm_topology::processor::x86::X86Topology;
+use vmm_core::acpi_builder::AcpiArchConfig;
+use vmm_core::acpi_builder::AcpiTablesBuilder;
 
-const COMPATIBILITY_MASK: u32 = 1;
 const PAGE_SIZE: u64 = igvm_defs::PAGE_SIZE_4K;
 /// KVM hardcodes the initial VMSA at this GPA and measures it during launch
 /// finish, after all userspace-provided launch-update pages.
+///
+/// Keep the BSP context at this address until KVM supports userspace-supplied
+/// VMSA pages. MSHV can import the same context at this fixed address.
 const KVM_VMSA_GPA: u64 = 0xffff_ffff_f000;
-const PM_BASE: u16 = 0x400;
-const ACPI_IRQ: u32 = 9;
-const COM1_BASE: u16 = 0x3f8;
-const COM1_IRQ: u32 = 4;
 
+/// Inputs for the deterministic SNP Linux-direct guest layout.
 pub struct BuildParams<'a> {
+    /// The Linux payload configuration.
     pub linux: &'a LinuxImage,
+    /// The processor count described by the embedded topology and ACPI tables.
     pub processor_count: u32,
+    /// The number of measured 4-KiB RAM pages.
     pub memory_page_count: u64,
+    /// The page-table address bit used as the SNP encryption bit.
     pub c_bit_position: u8,
+    /// The SNP guest policy.
     pub policy: SnpPolicy,
+    /// The kernel and optional initrd resources.
     pub resources: &'a Resources,
 }
 
-pub fn build(params: BuildParams<'_>) -> anyhow::Result<crate::file_loader::IgvmOutput> {
-    let BuildParams {
-        linux,
-        processor_count,
-        memory_page_count,
-        c_bit_position,
-        policy,
-        resources,
-    } = params;
-    let memory_size = memory_page_count
-        .checked_mul(PAGE_SIZE)
-        .context("RAM size overflow")?;
-    let memory_layout =
-        MemoryLayout::new(memory_size, &[], &[], &[], None).context("building memory layout")?;
-    let processor_topology = TopologyBuilder::new_x86()
-        .build(processor_count)
-        .context("building processor topology")?;
-    let pcie_host_bridges = Vec::new();
-    let acpi_builder = vmm_core::acpi_builder::AcpiTablesBuilder {
-        processor_topology: &processor_topology,
-        mem_layout: &memory_layout,
-        cache_topology: None,
-        pcie_host_bridges: &pcie_host_bridges,
-        slit_info: None,
-        generic_initiators: &[],
-        arch: vmm_core::acpi_builder::AcpiArchConfig::X86 {
-            with_ioapic: true,
-            with_pic: true,
-            with_pit: true,
-            with_psp: false,
-            pm_base: PM_BASE,
-            acpi_irq: ACPI_IRQ,
-            iommu: None,
-        },
-    };
+/// The fixed platform layout embedded in the bring-up IGVM.
+struct FixedGuestLayout {
+    memory: MemoryLayout,
+    processors: ProcessorTopology<X86Topology>,
+    pcie_host_bridges: Vec<PcieHostBridge>,
+}
 
+impl FixedGuestLayout {
+    fn new(memory_page_count: u64, processor_count: u32) -> anyhow::Result<Self> {
+        let memory_size = memory_page_count
+            .checked_mul(PAGE_SIZE)
+            .context("RAM size overflow")?;
+        let memory = MemoryLayout::new(memory_size, &[], &[], &[], None)
+            .context("building memory layout")?;
+        let processors = TopologyBuilder::new_x86()
+            .build(processor_count)
+            .context("building processor topology")?;
+
+        Ok(Self {
+            memory,
+            processors,
+            pcie_host_bridges: Vec::new(),
+        })
+    }
+
+    fn acpi_builder(&self) -> AcpiTablesBuilder<'_, X86Topology> {
+        // This profile embeds OpenVMM's standard PC-compatible chipset
+        // contract. The ACPI values must match the devices supplied by the
+        // backend.
+        //
+        // TODO: Accept an external platform description when this bring-up
+        // profile needs layouts other than the fixed OpenVMM defaults.
+        AcpiTablesBuilder {
+            processor_topology: &self.processors,
+            mem_layout: &self.memory,
+            cache_topology: None,
+            pcie_host_bridges: &self.pcie_host_bridges,
+            slit_info: None,
+            generic_initiators: &[],
+            arch: AcpiArchConfig::X86 {
+                with_ioapic: true,
+                with_pic: true,
+                with_pit: true,
+                with_psp: false,
+                pm_base: DEFAULT_PM_PIO_BASE,
+                acpi_irq: DEFAULT_ACPI_IRQ,
+                iommu: None,
+            },
+        }
+    }
+}
+
+fn open_linux_resources(
+    linux: &LinuxImage,
+    resources: &Resources,
+) -> anyhow::Result<(fs_err::File, Option<fs_err::File>)> {
     let kernel_path = resources
         .get(ResourceType::LinuxKernel)
         .context("Linux kernel resource is missing")?;
-    let mut kernel = fs_err::File::open(kernel_path)
+    let kernel = fs_err::File::open(kernel_path)
         .with_context(|| format!("opening kernel {}", kernel_path.display()))?;
-    let mut initrd = if linux.use_initrd {
+
+    let initrd = if linux.use_initrd {
         let initrd_path = resources
             .get(ResourceType::LinuxInitrd)
             .context("Linux initrd resource is missing")?;
@@ -96,40 +124,69 @@ pub fn build(params: BuildParams<'_>) -> anyhow::Result<crate::file_loader::Igvm
     } else {
         None
     };
-    let initrd_config = if let Some(initrd) = &mut initrd {
-        let size = initrd
-            .seek(std::io::SeekFrom::End(0))
-            .context("measuring initrd")?;
-        initrd.rewind().context("rewinding initrd")?;
-        Some(InitrdConfig {
-            initrd_address: InitrdAddressType::AfterKernel,
-            initrd,
-            size,
-        })
-    } else {
-        None
-    };
 
-    let mut loader = crate::file_loader::IgvmLoader::<X86Register>::new_snp_linux_direct(
-        crate::file_loader::SnpLinuxDirectConfig {
-            policy,
-            c_bit_mask: 1u64 << c_bit_position,
-            ram_page_count: memory_page_count,
-            vmsa_page: Some(KVM_VMSA_GPA / PAGE_SIZE),
-            injection_type: crate::vp_context_builder::snp::InjectionType::Normal,
-            import_all_ram: true,
-        },
-    );
+    Ok((kernel, initrd))
+}
+
+fn initrd_config(initrd: &mut Option<fs_err::File>) -> anyhow::Result<Option<InitrdConfig<'_>>> {
+    let Some(initrd) = initrd else {
+        return Ok(None);
+    };
+    let size = initrd
+        .seek(std::io::SeekFrom::End(0))
+        .context("measuring initrd")?;
+    initrd.rewind().context("rewinding initrd")?;
+    Ok(Some(InitrdConfig {
+        initrd_address: InitrdAddressType::AfterKernel,
+        initrd,
+        size,
+    }))
+}
+
+fn new_loader(
+    policy: SnpPolicy,
+    c_bit_position: u8,
+    memory_page_count: u64,
+) -> IgvmLoader<X86Register> {
+    IgvmLoader::new_snp_linux_direct(SnpLinuxDirectConfig {
+        policy,
+        c_bit_mask: 1u64 << c_bit_position,
+        ram_page_count: memory_page_count,
+        vmsa_page: Some(KVM_VMSA_GPA / PAGE_SIZE),
+        injection_type: InjectionType::Normal,
+        import_all_ram: true,
+    })
+}
+
+/// Builds the deterministic topology, ACPI tables, Linux payload, and BSP
+/// launch context embedded in the standalone SNP IGVM.
+pub fn build(params: BuildParams<'_>) -> anyhow::Result<IgvmOutput> {
+    let BuildParams {
+        linux,
+        processor_count,
+        memory_page_count,
+        c_bit_position,
+        policy,
+        resources,
+    } = params;
+
+    let layout = FixedGuestLayout::new(memory_page_count, processor_count)?;
+    let acpi_builder = layout.acpi_builder();
+    let (mut kernel, mut initrd) = open_linux_resources(linux, resources)?;
+    let initrd_config = initrd_config(&mut initrd)?;
+    let mut loader = new_loader(policy, c_bit_position, memory_page_count);
+    let com1 = ComPort::Com1;
+
     loader::linux::load_x86(
         &mut loader.loader(),
         &mut kernel,
         initrd_config,
         &linux.command_line,
-        &memory_layout,
+        &layout.memory,
         |gpa| {
             let tables = acpi_builder.build_acpi_tables(gpa, |dsdt| {
                 dsdt.add_apic();
-                dsdt.add_uart(b"\\_SB.UAR1", b"COM1", 1, COM1_BASE, COM1_IRQ);
+                dsdt.add_uart(b"\\_SB.UAR1", b"COM1", 1, com1.io_port(), com1.irq().into());
                 dsdt.add_rtc();
             });
             loader::linux::AcpiTables {
@@ -144,205 +201,33 @@ pub fn build(params: BuildParams<'_>) -> anyhow::Result<crate::file_loader::Igvm
     )
     .context("loading direct-Linux image")?;
 
-    let policy: u64 = policy.into();
-    let output = loader.finalize().context("finalizing SNP IGVM")?;
-    let serializer = IgvmSerializer::new(&output.guest).context("measuring SNP IGVM")?;
-    let launch_digest: [u8; 48] = serializer
-        .measurement_for(IgvmPlatformType::SEV_SNP)
-        .context("missing SNP launch measurement")?
-        .digest
-        .as_slice()
-        .try_into()
-        .context("SNP launch digest is not 48 bytes")?;
-    let mut binary = Vec::new();
-    serializer
-        .serialize(&mut binary)
-        .context("serializing IGVM")?;
-    let reparsed = IgvmFile::new_from_binary(&binary, Some(igvm::IsolationType::Snp))
-        .context("validating serialized SNP IGVM")?;
-    validate_generated_igvm(
-        &reparsed,
-        launch_digest,
-        policy,
-        memory_page_count,
-        1u64 << c_bit_position,
-    )?;
-
-    Ok(output)
-}
-
-fn validate_generated_igvm(
-    igvm: &IgvmFile,
-    expected_launch_digest: [u8; 48],
-    expected_policy: u64,
-    ram_page_count: u64,
-    c_bit_mask: u64,
-) -> anyhow::Result<()> {
-    ensure!(igvm.platforms().len() == 1, "expected one platform header");
-    let IgvmPlatformHeader::SupportedPlatform(platform) = &igvm.platforms()[0];
-    ensure!(
-        platform.platform_type == IgvmPlatformType::SEV_SNP
-            && platform.highest_vtl == 0
-            && platform.shared_gpa_boundary == 0,
-        "unexpected SNP platform configuration"
-    );
-    ensure!(
-        igvm.initializations().iter().any(|header| matches!(
-            header,
-            IgvmInitializationHeader::GuestPolicy {
-                policy,
-                compatibility_mask: COMPATIBILITY_MASK,
-            } if *policy == expected_policy
-        )),
-        "serialized file lost its SNP guest policy"
-    );
-
-    let mut covered_pages = BTreeSet::new();
-    let mut required_memory_count = 0;
-    let mut next_vmsa_index = 0;
-    let mut secrets_count = 0;
-    let mut cpuid_count = 0;
-    let mut saw_vmsa = false;
-
-    for directive in igvm.directives() {
-        match directive {
-            IgvmDirectiveHeader::PageData {
-                gpa,
-                flags,
-                data_type,
-                data,
-                ..
-            } => {
-                ensure!(!saw_vmsa, "PageData appears after the VMSA directive");
-                ensure!(gpa.is_multiple_of(PAGE_SIZE), "unaligned PageData GPA");
-                let page = gpa / PAGE_SIZE;
-                ensure!(page < ram_page_count, "PageData lies outside RAM");
-                ensure!(
-                    covered_pages.insert(page),
-                    "duplicate page directive at GPA {gpa:#x}"
-                );
-                ensure!(
-                    !flags.shared() && !flags.unmeasured(),
-                    "fixed image unexpectedly contains shared or unmeasured PageData"
-                );
-                ensure!(
-                    data.len() <= PAGE_SIZE as usize,
-                    "PageData exceeds one page"
-                );
-                if *data_type == IgvmPageDataType::SECRETS {
-                    secrets_count += 1;
-                } else if *data_type == IgvmPageDataType::CPUID_DATA {
-                    cpuid_count += 1;
-                } else {
-                    ensure!(
-                        *data_type == IgvmPageDataType::NORMAL,
-                        "unexpected PageData type {data_type:?}"
-                    );
-                }
-            }
-            IgvmDirectiveHeader::SnpVpContext {
-                gpa,
-                vp_index,
-                vmsa,
-                ..
-            } => {
-                ensure!(*gpa == KVM_VMSA_GPA, "VMSA is not at KVM's fixed GPA");
-                ensure!(
-                    u32::from(*vp_index) == next_vmsa_index,
-                    "VMSA VP contexts are not ordered by VP index"
-                );
-                ensure!(vmsa.sev_features.snp(), "VMSA does not enable SNP");
-                ensure!(!vmsa.sev_features.vtom(), "VMSA unexpectedly enables vTOM");
-                ensure!(vmsa.virtual_tom == 0, "VMSA virtual TOM is not zero");
-                ensure!(
-                    vmsa.cr3 & c_bit_mask != 0,
-                    "VMSA CR3 does not contain the configured C-bit"
-                );
-                ensure!(
-                    vmsa.cr0 & x86defs::X64_CR0_ET != 0,
-                    "VMSA CR0 does not contain KVM's forced ET bit"
-                );
-                ensure!(
-                    vmsa.cr4 & x86defs::X64_CR4_MCE != 0,
-                    "VMSA CR4 does not contain KVM's forced MCE bit"
-                );
-                ensure!(
-                    vmsa.rflags == u64::from(x86defs::RFlags::at_reset()),
-                    "VMSA RFLAGS does not match KVM reset state"
-                );
-                ensure!(
-                    vmsa.dr6 == 0xffff_0ff0 && vmsa.dr7 == 0x400,
-                    "VMSA debug registers do not match KVM reset state"
-                );
-                ensure!(
-                    vmsa.x87_fcw == x86defs::xsave::INIT_FCW
-                        && vmsa.mxcsr == x86defs::xsave::DEFAULT_MXCSR,
-                    "VMSA FPU control state does not match KVM reset state"
-                );
-                next_vmsa_index += 1;
-                saw_vmsa = true;
-            }
-            IgvmDirectiveHeader::RequiredMemory {
-                gpa,
-                number_of_bytes,
-                vtl2_protectable,
-                ..
-            } => {
-                ensure!(
-                    *gpa == 0
-                        && u64::from(*number_of_bytes) == ram_page_count * PAGE_SIZE
-                        && !vtl2_protectable,
-                    "unexpected RequiredMemory directive"
-                );
-                required_memory_count += 1;
-            }
-            unexpected => bail!("unexpected directive in fixed SNP IGVM: {unexpected:?}"),
-        }
-    }
-
-    ensure!(
-        covered_pages.len() == ram_page_count as usize
-            && covered_pages.first() == Some(&0)
-            && covered_pages.last() == Some(&(ram_page_count - 1)),
-        "IGVM does not cover every page of the fixed RAM layout"
-    );
-    ensure!(required_memory_count == 1, "expected one RequiredMemory");
-    ensure!(next_vmsa_index == 1, "expected one SNP BSP VMSA");
-    ensure!(secrets_count == 1, "expected one SNP secrets page");
-    ensure!(cpuid_count == 1, "expected one SNP CPUID page");
-
-    let serializer = IgvmSerializer::new(igvm).context("remeasuring serialized SNP IGVM")?;
-    let measured_digest: [u8; 48] = serializer
-        .measurement_for(IgvmPlatformType::SEV_SNP)
-        .context("serialized IGVM has no SNP measurement")?
-        .digest
-        .as_slice()
-        .try_into()
-        .context("serialized SNP launch digest is not 48 bytes")?;
-    ensure!(
-        measured_digest == expected_launch_digest,
-        "serialized IGVM launch digest changed"
-    );
-    Ok(())
+    loader.finalize().context("finalizing SNP IGVM")
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::file_loader::IgvmLoader;
-    use crate::file_loader::SnpLinuxDirectConfig;
     use crate::vp_context_builder::VpContextBuilder;
-    use crate::vp_context_builder::snp::InjectionType;
     use crate::vp_context_builder::snp::SnpHardwareContext;
+    use igvm::IgvmDirectiveHeader;
+    use igvm::IgvmFile;
+    use igvm::IgvmInitializationHeader;
+    use igvm::IgvmPlatformHeader;
+    use igvm::IgvmSerializer;
+    use igvm_defs::IgvmPageDataType;
+    use igvm_defs::IgvmPlatformType;
     use loader::importer::BootPageAcceptance;
     use loader::importer::ImageLoad;
+    use std::collections::BTreeSet;
     use test_with_tracing::test;
 
+    const COMPATIBILITY_MASK: u32 = 1;
+    const TEST_POLICY: u64 = 0x30000;
     const TEST_C_BIT_MASK: u64 = 1 << 51;
 
     fn test_loader(ram_page_count: u64) -> IgvmLoader<X86Register> {
         IgvmLoader::new_snp_linux_direct(SnpLinuxDirectConfig {
-            policy: SnpPolicy::from(0x30000),
+            policy: SnpPolicy::from(TEST_POLICY),
             c_bit_mask: TEST_C_BIT_MASK,
             ram_page_count,
             vmsa_page: Some(KVM_VMSA_GPA / PAGE_SIZE),
@@ -369,6 +254,117 @@ mod tests {
                 x86defs::X64_EFER_LME | x86defs::X64_EFER_LMA,
             ))
             .unwrap();
+    }
+
+    fn assert_serialized_igvm_shape(igvm: &IgvmFile, ram_page_count: u64) {
+        let serializer = IgvmSerializer::new(igvm).unwrap();
+        let expected_launch_digest = serializer
+            .measurement_for(IgvmPlatformType::SEV_SNP)
+            .unwrap()
+            .digest
+            .clone();
+        let mut binary = Vec::new();
+        serializer.serialize(&mut binary).unwrap();
+        let reparsed = IgvmFile::new_from_binary(&binary, Some(igvm::IsolationType::Snp)).unwrap();
+
+        assert_eq!(reparsed.platforms().len(), 1);
+        let IgvmPlatformHeader::SupportedPlatform(platform) = &reparsed.platforms()[0];
+        assert_eq!(platform.platform_type, IgvmPlatformType::SEV_SNP);
+        assert_eq!(platform.highest_vtl, 0);
+        assert_eq!(platform.shared_gpa_boundary, 0);
+        assert!(reparsed.initializations().iter().any(|header| matches!(
+            header,
+            IgvmInitializationHeader::GuestPolicy {
+                policy: TEST_POLICY,
+                compatibility_mask: COMPATIBILITY_MASK,
+            }
+        )));
+
+        let mut covered_pages = BTreeSet::new();
+        let mut required_memory_count = 0;
+        let mut next_vmsa_index = 0;
+        let mut secrets_count = 0;
+        let mut cpuid_count = 0;
+        let mut saw_vmsa = false;
+
+        for directive in reparsed.directives() {
+            match directive {
+                IgvmDirectiveHeader::PageData {
+                    gpa,
+                    flags,
+                    data_type,
+                    data,
+                    ..
+                } => {
+                    // Current KVM measures its VMSA during launch finish, after
+                    // userspace page updates. A suffix VMSA keeps the serialized
+                    // single-VP measurement identical to KVM's measurement.
+                    assert!(!saw_vmsa, "PageData appears after the VMSA directive");
+                    assert!(gpa.is_multiple_of(PAGE_SIZE));
+                    let page = gpa / PAGE_SIZE;
+                    assert!(page < ram_page_count);
+                    assert!(covered_pages.insert(page));
+                    assert!(!flags.shared() && !flags.unmeasured());
+                    assert!(data.len() <= PAGE_SIZE as usize);
+                    match *data_type {
+                        IgvmPageDataType::SECRETS => secrets_count += 1,
+                        IgvmPageDataType::CPUID_DATA => cpuid_count += 1,
+                        IgvmPageDataType::NORMAL => {}
+                        unexpected => panic!("unexpected PageData type {unexpected:?}"),
+                    }
+                }
+                IgvmDirectiveHeader::SnpVpContext {
+                    gpa,
+                    vp_index,
+                    vmsa,
+                    ..
+                } => {
+                    assert_eq!(*gpa, KVM_VMSA_GPA);
+                    assert_eq!(u32::from(*vp_index), next_vmsa_index);
+                    assert!(vmsa.sev_features.snp());
+                    assert!(!vmsa.sev_features.vtom());
+                    assert_eq!(vmsa.virtual_tom, 0);
+                    assert_ne!(vmsa.cr3 & TEST_C_BIT_MASK, 0);
+                    assert_ne!(vmsa.cr0 & x86defs::X64_CR0_ET, 0);
+                    assert_ne!(vmsa.cr4 & x86defs::X64_CR4_MCE, 0);
+                    assert_eq!(vmsa.rflags, u64::from(x86defs::RFlags::at_reset()));
+                    assert_eq!(vmsa.dr6, 0xffff_0ff0);
+                    assert_eq!(vmsa.dr7, 0x400);
+                    assert_eq!(vmsa.x87_fcw, x86defs::xsave::INIT_FCW);
+                    assert_eq!(vmsa.mxcsr, x86defs::xsave::DEFAULT_MXCSR);
+                    next_vmsa_index += 1;
+                    saw_vmsa = true;
+                }
+                IgvmDirectiveHeader::RequiredMemory {
+                    gpa,
+                    number_of_bytes,
+                    vtl2_protectable,
+                    ..
+                } => {
+                    assert_eq!(*gpa, 0);
+                    assert_eq!(u64::from(*number_of_bytes), ram_page_count * PAGE_SIZE);
+                    assert!(!vtl2_protectable);
+                    required_memory_count += 1;
+                }
+                unexpected => panic!("unexpected directive in fixed SNP IGVM: {unexpected:?}"),
+            }
+        }
+
+        assert_eq!(covered_pages.len(), ram_page_count as usize);
+        assert_eq!(covered_pages.first(), Some(&0));
+        assert_eq!(covered_pages.last(), Some(&(ram_page_count - 1)));
+        assert_eq!(required_memory_count, 1);
+        assert_eq!(next_vmsa_index, 1);
+        assert_eq!(secrets_count, 1);
+        assert_eq!(cpuid_count, 1);
+
+        let measured_digest = IgvmSerializer::new(&reparsed)
+            .unwrap()
+            .measurement_for(IgvmPlatformType::SEV_SNP)
+            .unwrap()
+            .digest
+            .clone();
+        assert_eq!(measured_digest, expected_launch_digest);
     }
 
     #[test]
@@ -413,6 +409,9 @@ mod tests {
             importer
                 .import_pages(1, 1, "secret", BootPageAcceptance::SecretsPage, &[])
                 .unwrap();
+            importer
+                .import_pages(2, 1, "cpuid", BootPageAcceptance::CpuidPage, &[])
+                .unwrap();
             import_test_registers(&mut importer);
         }
         let output = loader.finalize().unwrap();
@@ -441,6 +440,13 @@ mod tests {
         assert!(matches!(
             directives[3],
             IgvmDirectiveHeader::PageData {
+                data_type: IgvmPageDataType::CPUID_DATA,
+                ..
+            }
+        ));
+        assert!(matches!(
+            directives[4],
+            IgvmDirectiveHeader::PageData {
                 data_type: IgvmPageDataType::NORMAL,
                 ..
             }
@@ -452,6 +458,7 @@ mod tests {
                 ..
             }
         ));
+        assert_serialized_igvm_shape(&output.guest, 4);
     }
 
     #[test]

--- a/vm/loader/igvmfilegen/src/snp_linux_direct.rs
+++ b/vm/loader/igvmfilegen/src/snp_linux_direct.rs
@@ -285,7 +285,6 @@ mod tests {
         let mut next_vmsa_index = 0;
         let mut secrets_count = 0;
         let mut cpuid_count = 0;
-        let mut saw_vmsa = false;
 
         for directive in reparsed.directives() {
             match directive {
@@ -296,10 +295,6 @@ mod tests {
                     data,
                     ..
                 } => {
-                    // Current KVM measures its VMSA during launch finish, after
-                    // userspace page updates. A suffix VMSA keeps the serialized
-                    // single-VP measurement identical to KVM's measurement.
-                    assert!(!saw_vmsa, "PageData appears after the VMSA directive");
                     assert!(gpa.is_multiple_of(PAGE_SIZE));
                     let page = gpa / PAGE_SIZE;
                     assert!(page < ram_page_count);
@@ -333,7 +328,6 @@ mod tests {
                     assert_eq!(vmsa.x87_fcw, x86defs::xsave::INIT_FCW);
                     assert_eq!(vmsa.mxcsr, x86defs::xsave::DEFAULT_MXCSR);
                     next_vmsa_index += 1;
-                    saw_vmsa = true;
                 }
                 IgvmDirectiveHeader::RequiredMemory {
                     gpa,
@@ -423,7 +417,7 @@ mod tests {
             IgvmDirectiveHeader::RequiredMemory { .. }
         ));
         assert!(matches!(
-            directives[1],
+            directives[2],
             IgvmDirectiveHeader::PageData {
                 data_type: IgvmPageDataType::NORMAL,
                 ref data,
@@ -431,28 +425,28 @@ mod tests {
             } if data.is_empty()
         ));
         assert!(matches!(
-            directives[2],
+            directives[3],
             IgvmDirectiveHeader::PageData {
                 data_type: IgvmPageDataType::SECRETS,
                 ..
             }
         ));
         assert!(matches!(
-            directives[3],
+            directives[4],
             IgvmDirectiveHeader::PageData {
                 data_type: IgvmPageDataType::CPUID_DATA,
                 ..
             }
         ));
         assert!(matches!(
-            directives[4],
+            directives[5],
             IgvmDirectiveHeader::PageData {
                 data_type: IgvmPageDataType::NORMAL,
                 ..
             }
         ));
         assert!(matches!(
-            directives[5],
+            directives[1],
             IgvmDirectiveHeader::SnpVpContext {
                 gpa: KVM_VMSA_GPA,
                 ..

--- a/vm/loader/igvmfilegen/src/snp_linux_direct.rs
+++ b/vm/loader/igvmfilegen/src/snp_linux_direct.rs
@@ -680,7 +680,7 @@ fn build_complete_ram_directives(
     processor_count: u32,
     ram_page_count: u64,
 ) -> anyhow::Result<(Vec<IgvmDirectiveHeader>, String)> {
-    let mut directives = Vec::with_capacity(ram_page_count as usize + processor_count as usize);
+    let mut directives = Vec::with_capacity(ram_page_count as usize + processor_count as usize + 1);
     let mut map_entries = Vec::new();
 
     for page in 0..ram_page_count {

--- a/vm/loader/igvmfilegen/src/snp_linux_direct.rs
+++ b/vm/loader/igvmfilegen/src/snp_linux_direct.rs
@@ -115,7 +115,6 @@ pub fn build(params: BuildParams<'_>) -> anyhow::Result<crate::file_loader::Igvm
             policy,
             c_bit_mask: 1u64 << c_bit_position,
             ram_page_count: memory_page_count,
-            vp_context_count: processor_count,
             vmsa_page: Some(KVM_VMSA_GPA / PAGE_SIZE),
             injection_type: crate::vp_context_builder::snp::InjectionType::Normal,
             import_all_ram: true,
@@ -165,7 +164,6 @@ pub fn build(params: BuildParams<'_>) -> anyhow::Result<crate::file_loader::Igvm
         &reparsed,
         launch_digest,
         policy,
-        processor_count,
         memory_page_count,
         1u64 << c_bit_position,
     )?;
@@ -177,7 +175,6 @@ fn validate_generated_igvm(
     igvm: &IgvmFile,
     expected_launch_digest: [u8; 48],
     expected_policy: u64,
-    processor_count: u32,
     ram_page_count: u64,
     c_bit_mask: u64,
 ) -> anyhow::Result<()> {
@@ -310,10 +307,7 @@ fn validate_generated_igvm(
         "IGVM does not cover every page of the fixed RAM layout"
     );
     ensure!(required_memory_count == 1, "expected one RequiredMemory");
-    ensure!(
-        next_vmsa_index == processor_count,
-        "expected one SNP VMSA per processor"
-    );
+    ensure!(next_vmsa_index == 1, "expected one SNP BSP VMSA");
     ensure!(secrets_count == 1, "expected one SNP secrets page");
     ensure!(cpuid_count == 1, "expected one SNP CPUID page");
 
@@ -346,12 +340,11 @@ mod tests {
 
     const TEST_C_BIT_MASK: u64 = 1 << 51;
 
-    fn test_loader(ram_page_count: u64, vp_context_count: u32) -> IgvmLoader<X86Register> {
+    fn test_loader(ram_page_count: u64) -> IgvmLoader<X86Register> {
         IgvmLoader::new_snp_linux_direct(SnpLinuxDirectConfig {
             policy: SnpPolicy::from(0x30000),
             c_bit_mask: TEST_C_BIT_MASK,
             ram_page_count,
-            vp_context_count,
             vmsa_page: Some(KVM_VMSA_GPA / PAGE_SIZE),
             injection_type: InjectionType::Normal,
             import_all_ram: true,
@@ -414,7 +407,7 @@ mod tests {
 
     #[test]
     fn complete_ram_has_one_directive_per_page() {
-        let mut loader = test_loader(4, 1);
+        let mut loader = test_loader(4);
         {
             let mut importer = loader.loader();
             importer
@@ -462,8 +455,8 @@ mod tests {
     }
 
     #[test]
-    fn complete_ram_emits_one_vmsa_per_processor() {
-        let mut loader = test_loader(1, 4);
+    fn complete_ram_emits_only_the_bsp_vmsa() {
+        let mut loader = test_loader(1);
         import_test_registers(&mut loader.loader());
         let output = loader.finalize().unwrap();
         let vp_indexes = output
@@ -475,12 +468,12 @@ mod tests {
                 _ => None,
             })
             .collect::<Vec<_>>();
-        assert_eq!(vp_indexes, [0, 1, 2, 3]);
+        assert_eq!(vp_indexes, [0]);
     }
 
     #[test]
     fn overlapping_import_does_not_mutate_existing_pages() {
-        let mut loader = test_loader(4, 1);
+        let mut loader = test_loader(4);
         {
             let mut importer = loader.loader();
             importer

--- a/vm/loader/igvmfilegen/src/snp_linux_direct.rs
+++ b/vm/loader/igvmfilegen/src/snp_linux_direct.rs
@@ -10,39 +10,20 @@ use igvm::IgvmDirectiveHeader;
 use igvm::IgvmFile;
 use igvm::IgvmInitializationHeader;
 use igvm::IgvmPlatformHeader;
-use igvm::IgvmRevision;
 use igvm::IgvmSerializer;
-use igvm::snp_defs::SevFeatures;
-use igvm::snp_defs::SevSelector;
-use igvm::snp_defs::SevVmsa;
-use igvm_defs::IGVM_VHS_SUPPORTED_PLATFORM;
-use igvm_defs::IgvmPageDataFlags;
 use igvm_defs::IgvmPageDataType;
 use igvm_defs::IgvmPlatformType;
 use igvm_defs::SnpPolicy;
 use igvmfilegen_config::LinuxImage;
 use igvmfilegen_config::ResourceType;
 use igvmfilegen_config::Resources;
-use loader::importer::BootPageAcceptance;
-use loader::importer::IgvmParameterType;
-use loader::importer::ImageLoad;
-use loader::importer::IsolationConfig;
-use loader::importer::IsolationType;
-use loader::importer::ParameterAreaIndex;
-use loader::importer::SegmentRegister;
-use loader::importer::StartupMemoryType;
-use loader::importer::TableRegister;
 use loader::importer::X86Register;
 use loader::linux::InitrdAddressType;
 use loader::linux::InitrdConfig;
-use std::collections::BTreeMap;
 use std::collections::BTreeSet;
-use std::fmt::Write as _;
 use std::io::Seek;
-use std::mem::discriminant;
 use vm_topology::memory::MemoryLayout;
 use vm_topology::processor::TopologyBuilder;
-use zerocopy::FromZeros;
 
 const COMPATIBILITY_MASK: u32 = 1;
 const PAGE_SIZE: u64 = igvm_defs::PAGE_SIZE_4K;
@@ -63,217 +44,7 @@ pub struct BuildParams<'a> {
     pub resources: &'a Resources,
 }
 
-pub struct BuildOutput {
-    pub guest: IgvmFile,
-    pub map: String,
-}
-
-#[derive(Debug, Clone)]
-struct ImportedPage {
-    acceptance: BootPageAcceptance,
-    data: Vec<u8>,
-    tag: &'static str,
-}
-
-#[derive(Debug)]
-struct TestIgvmImporter {
-    pages: BTreeMap<u64, ImportedPage>,
-    registers: Vec<X86Register>,
-    ram_page_count: u64,
-    c_bit_mask: u64,
-}
-
-impl TestIgvmImporter {
-    fn new(ram_page_count: u64, c_bit_position: u8) -> Self {
-        Self {
-            pages: BTreeMap::new(),
-            registers: Vec::new(),
-            ram_page_count,
-            c_bit_mask: 1u64 << c_bit_position,
-        }
-    }
-
-    fn finish(
-        self,
-        processor_count: u32,
-    ) -> anyhow::Result<(Vec<IgvmDirectiveHeader>, SevVmsa, String)> {
-        let vmsa = build_vmsa(&self.registers, self.c_bit_mask)?;
-        let (mut directives, map) = build_complete_ram_directives(
-            &self.pages,
-            &vmsa,
-            processor_count,
-            self.ram_page_count,
-        )?;
-        let ram_size = self
-            .ram_page_count
-            .checked_mul(PAGE_SIZE)
-            .context("RAM size overflow")?;
-        directives.insert(
-            0,
-            IgvmDirectiveHeader::RequiredMemory {
-                gpa: 0,
-                compatibility_mask: COMPATIBILITY_MASK,
-                number_of_bytes: ram_size
-                    .try_into()
-                    .context("RAM size does not fit in an IGVM required-memory directive")?,
-                vtl2_protectable: false,
-            },
-        );
-        Ok((directives, vmsa, map))
-    }
-}
-
-impl ImageLoad<X86Register> for TestIgvmImporter {
-    fn isolation_config(&self) -> IsolationConfig {
-        IsolationConfig {
-            paravisor_present: false,
-            isolation_type: IsolationType::Snp,
-            shared_gpa_boundary_bits: None,
-        }
-    }
-
-    fn create_parameter_area(
-        &mut self,
-        _page_base: u64,
-        _page_count: u32,
-        _debug_tag: &str,
-    ) -> anyhow::Result<ParameterAreaIndex> {
-        bail!("IGVM parameter areas are not supported by this fixed image")
-    }
-
-    fn create_parameter_area_with_data(
-        &mut self,
-        _page_base: u64,
-        _page_count: u32,
-        _debug_tag: &str,
-        _initial_data: &[u8],
-    ) -> anyhow::Result<ParameterAreaIndex> {
-        bail!("IGVM parameter areas are not supported by this fixed image")
-    }
-
-    fn import_parameter(
-        &mut self,
-        _parameter_area: ParameterAreaIndex,
-        _byte_offset: u32,
-        _parameter_type: IgvmParameterType,
-    ) -> anyhow::Result<()> {
-        bail!("IGVM parameters are not supported by this fixed image")
-    }
-
-    fn import_pages(
-        &mut self,
-        page_base: u64,
-        page_count: u64,
-        debug_tag: &'static str,
-        acceptance: BootPageAcceptance,
-        data: &[u8],
-    ) -> anyhow::Result<()> {
-        ensure!(page_count != 0, "cannot import an empty page range");
-        let byte_capacity = page_count
-            .checked_mul(PAGE_SIZE)
-            .context("imported page range size overflow")?;
-        ensure!(
-            data.len() as u64 <= byte_capacity,
-            "data for {debug_tag} exceeds its imported page range"
-        );
-        let page_end = page_base
-            .checked_add(page_count)
-            .context("imported page range overflow")?;
-        ensure!(
-            page_end <= self.ram_page_count,
-            "{debug_tag} lies outside the configured RAM layout"
-        );
-        if let Some(page_number) = (page_base..page_end).find(|page| self.pages.contains_key(page))
-        {
-            bail!(
-                "{debug_tag} overlaps an existing import at GPA {:#x}",
-                page_number * PAGE_SIZE
-            );
-        }
-
-        for page_offset in 0..page_count {
-            let data_start = (page_offset * PAGE_SIZE) as usize;
-            let data_end = data
-                .len()
-                .min(data_start.saturating_add(PAGE_SIZE as usize));
-            let page_data = if data_start < data.len() {
-                data[data_start..data_end].to_vec()
-            } else {
-                Vec::new()
-            };
-            let page_number = page_base + page_offset;
-            self.pages.insert(
-                page_number,
-                ImportedPage {
-                    acceptance,
-                    data: page_data,
-                    tag: debug_tag,
-                },
-            );
-        }
-        Ok(())
-    }
-
-    fn import_vp_register(&mut self, register: X86Register) -> anyhow::Result<()> {
-        ensure!(
-            !self
-                .registers
-                .iter()
-                .any(|existing| discriminant(existing) == discriminant(&register)),
-            "duplicate initial register {register:?}"
-        );
-        self.registers.push(register);
-        Ok(())
-    }
-
-    fn verify_startup_memory_available(
-        &mut self,
-        page_base: u64,
-        page_count: u64,
-        _memory_type: StartupMemoryType,
-    ) -> anyhow::Result<()> {
-        let page_end = page_base
-            .checked_add(page_count)
-            .context("required memory range overflow")?;
-        ensure!(
-            page_end <= self.ram_page_count,
-            "required memory lies outside the configured RAM layout"
-        );
-        Ok(())
-    }
-
-    fn set_vp_context_page(&mut self, _page_base: u64) -> anyhow::Result<()> {
-        bail!("the direct-Linux path must not select a guest-RAM VMSA page")
-    }
-
-    fn relocation_region(
-        &mut self,
-        _gpa: u64,
-        _size_bytes: u64,
-        _relocation_alignment: u64,
-        _minimum_relocation_gpa: u64,
-        _maximum_relocation_gpa: u64,
-        _apply_rip_offset: bool,
-        _apply_gdtr_offset: bool,
-        _vp_index: u16,
-    ) -> anyhow::Result<()> {
-        bail!("relocations are not supported by this fixed image")
-    }
-
-    fn page_table_relocation(
-        &mut self,
-        _page_table_gpa: u64,
-        _size_pages: u64,
-        _used_pages: u64,
-        _vp_index: u16,
-    ) -> anyhow::Result<()> {
-        bail!("page-table relocations are not supported by this fixed image")
-    }
-
-    fn set_imported_regions_config_page(&mut self, _page_base: u64) {}
-}
-
-pub fn build(params: BuildParams<'_>) -> anyhow::Result<BuildOutput> {
+pub fn build(params: BuildParams<'_>) -> anyhow::Result<crate::file_loader::IgvmOutput> {
     let BuildParams {
         linux,
         processor_count,
@@ -339,9 +110,19 @@ pub fn build(params: BuildParams<'_>) -> anyhow::Result<BuildOutput> {
         None
     };
 
-    let mut importer = TestIgvmImporter::new(memory_page_count, c_bit_position);
+    let mut loader = crate::file_loader::IgvmLoader::<X86Register>::new_snp_linux_direct(
+        crate::file_loader::SnpLinuxDirectConfig {
+            policy,
+            c_bit_mask: 1u64 << c_bit_position,
+            ram_page_count: memory_page_count,
+            vp_context_count: processor_count,
+            vmsa_page: Some(KVM_VMSA_GPA / PAGE_SIZE),
+            injection_type: crate::vp_context_builder::snp::InjectionType::Normal,
+            import_all_ram: true,
+        },
+    );
     loader::linux::load_x86(
-        &mut importer,
+        &mut loader.loader(),
         &mut kernel,
         initrd_config,
         &linux.command_line,
@@ -364,30 +145,9 @@ pub fn build(params: BuildParams<'_>) -> anyhow::Result<BuildOutput> {
     )
     .context("loading direct-Linux image")?;
 
-    let (directives, _vmsa, map) = importer.finish(processor_count)?;
     let policy: u64 = policy.into();
-    let platform_headers = vec![IgvmPlatformHeader::SupportedPlatform(
-        IGVM_VHS_SUPPORTED_PLATFORM {
-            compatibility_mask: COMPATIBILITY_MASK,
-            highest_vtl: 0,
-            platform_type: IgvmPlatformType::SEV_SNP,
-            platform_version: igvm_defs::IGVM_SEV_SNP_PLATFORM_VERSION,
-            shared_gpa_boundary: 0,
-        },
-    )];
-    let initialization_headers = vec![IgvmInitializationHeader::GuestPolicy {
-        policy,
-        compatibility_mask: COMPATIBILITY_MASK,
-    }];
-
-    let igvm = IgvmFile::new(
-        IgvmRevision::V1,
-        platform_headers,
-        initialization_headers,
-        directives,
-    )
-    .context("constructing IGVM")?;
-    let serializer = IgvmSerializer::new(&igvm).context("measuring SNP IGVM")?;
+    let output = loader.finalize().context("finalizing SNP IGVM")?;
+    let serializer = IgvmSerializer::new(&output.guest).context("measuring SNP IGVM")?;
     let launch_digest: [u8; 48] = serializer
         .measurement_for(IgvmPlatformType::SEV_SNP)
         .context("missing SNP launch measurement")?
@@ -410,7 +170,7 @@ pub fn build(params: BuildParams<'_>) -> anyhow::Result<BuildOutput> {
         1u64 << c_bit_position,
     )?;
 
-    Ok(BuildOutput { guest: igvm, map })
+    Ok(output)
 }
 
 fn validate_generated_igvm(
@@ -572,257 +332,66 @@ fn validate_generated_igvm(
     Ok(())
 }
 
-fn build_vmsa(registers: &[X86Register], c_bit_mask: u64) -> anyhow::Result<SevVmsa> {
-    let mut vmsa = SevVmsa::new_zeroed();
-    vmsa.efer = x86defs::X64_EFER_SVME;
-    vmsa.sev_features = SevFeatures::new().with_snp(true);
-    vmsa.virtual_tom = 0;
-    vmsa.xcr0 = 1;
-    vmsa.rflags = u64::from(x86defs::RFlags::at_reset());
-    vmsa.dr6 = 0xffff_0ff0;
-    vmsa.dr7 = 0x400;
-    vmsa.tr = segment_selector(SegmentRegister {
-        base: 0,
-        limit: 0xffff,
-        selector: 0,
-        attributes: 0x8b,
-    });
-    vmsa.ldtr = segment_selector(SegmentRegister {
-        base: 0,
-        limit: 0xffff,
-        selector: 0,
-        attributes: 0x82,
-    });
-    vmsa.idtr = table_selector(TableRegister {
-        base: 0,
-        limit: 0xffff,
-    });
-    vmsa.x87_fcw = x86defs::xsave::INIT_FCW;
-    vmsa.mxcsr = x86defs::xsave::DEFAULT_MXCSR;
-
-    for &register in registers {
-        match register {
-            X86Register::Gdtr(value) => vmsa.gdtr = table_selector(value),
-            X86Register::Idtr(value) => vmsa.idtr = table_selector(value),
-            X86Register::Ds(value) => vmsa.ds = segment_selector(value),
-            X86Register::Es(value) => vmsa.es = segment_selector(value),
-            X86Register::Fs(value) => vmsa.fs = segment_selector(value),
-            X86Register::Gs(value) => vmsa.gs = segment_selector(value),
-            X86Register::Ss(value) => vmsa.ss = segment_selector(value),
-            X86Register::Cs(value) => vmsa.cs = segment_selector(value),
-            X86Register::Tr(value) => vmsa.tr = segment_selector(value),
-            X86Register::Cr0(value) => vmsa.cr0 = value | x86defs::X64_CR0_ET,
-            X86Register::Cr3(value) => vmsa.cr3 = value | c_bit_mask,
-            X86Register::Cr4(value) => vmsa.cr4 = value | x86defs::X64_CR4_MCE,
-            X86Register::Efer(value) => vmsa.efer = value | x86defs::X64_EFER_SVME,
-            X86Register::Pat(value) => vmsa.pat = value,
-            X86Register::Rbp(value) => vmsa.rbp = value,
-            X86Register::Rip(value) => vmsa.rip = value,
-            X86Register::Rsi(value) => vmsa.rsi = value,
-            X86Register::Rsp(value) => vmsa.rsp = value,
-            X86Register::R8(value) => vmsa.r8 = value,
-            X86Register::R9(value) => vmsa.r9 = value,
-            X86Register::R10(value) => vmsa.r10 = value,
-            X86Register::R11(value) => vmsa.r11 = value,
-            X86Register::R12(value) => vmsa.r12 = value,
-            X86Register::Rflags(value) => vmsa.rflags = value,
-            X86Register::MtrrDefType(_)
-            | X86Register::MtrrPhysBase0(_)
-            | X86Register::MtrrPhysMask0(_)
-            | X86Register::MtrrPhysBase1(_)
-            | X86Register::MtrrPhysMask1(_)
-            | X86Register::MtrrPhysBase2(_)
-            | X86Register::MtrrPhysMask2(_)
-            | X86Register::MtrrPhysBase3(_)
-            | X86Register::MtrrPhysMask3(_)
-            | X86Register::MtrrPhysBase4(_)
-            | X86Register::MtrrPhysMask4(_)
-            | X86Register::MtrrFix64k00000(_)
-            | X86Register::MtrrFix16k80000(_)
-            | X86Register::MtrrFix4kE0000(_)
-            | X86Register::MtrrFix4kE8000(_)
-            | X86Register::MtrrFix4kF0000(_)
-            | X86Register::MtrrFix4kF8000(_) => {}
-        }
-    }
-
-    ensure!(vmsa.rip != 0, "Linux loader did not provide an entry point");
-    ensure!(
-        vmsa.cr3 & c_bit_mask != 0,
-        "initial CR3 does not contain the fixed SNP C-bit"
-    );
-    ensure!(
-        !vmsa.sev_features.vtom(),
-        "C-bit image must not enable vTOM"
-    );
-    Ok(vmsa)
-}
-
-fn table_selector(value: TableRegister) -> SevSelector {
-    SevSelector {
-        selector: 0,
-        attrib: 0,
-        limit: value.limit.into(),
-        base: value.base,
-    }
-}
-
-fn segment_selector(value: SegmentRegister) -> SevSelector {
-    SevSelector {
-        selector: value.selector,
-        attrib: (value.attributes & 0xff) | ((value.attributes >> 4) & 0xf00),
-        limit: value.limit,
-        base: value.base,
-    }
-}
-
-fn build_complete_ram_directives(
-    imported: &BTreeMap<u64, ImportedPage>,
-    vmsa: &SevVmsa,
-    processor_count: u32,
-    ram_page_count: u64,
-) -> anyhow::Result<(Vec<IgvmDirectiveHeader>, String)> {
-    let mut directives = Vec::with_capacity(ram_page_count as usize + processor_count as usize + 1);
-    let mut map_entries = Vec::new();
-
-    for page in 0..ram_page_count {
-        let (directive, tag, kind) = match imported.get(&page) {
-            Some(imported) => {
-                let (data_type, flags, kind) = page_data_shape(imported.acceptance)?;
-                (
-                    IgvmDirectiveHeader::PageData {
-                        gpa: page * PAGE_SIZE,
-                        compatibility_mask: COMPATIBILITY_MASK,
-                        flags,
-                        data_type,
-                        data: imported.data.clone(),
-                    },
-                    imported.tag.to_owned(),
-                    kind,
-                )
-            }
-            None => (
-                IgvmDirectiveHeader::PageData {
-                    gpa: page * PAGE_SIZE,
-                    compatibility_mask: COMPATIBILITY_MASK,
-                    flags: IgvmPageDataFlags::new(),
-                    data_type: IgvmPageDataType::NORMAL,
-                    data: Vec::new(),
-                },
-                "accepted-zero-ram".to_owned(),
-                "NORMAL",
-            ),
-        };
-        directives.push(directive);
-        map_entries.push((page, tag, kind));
-    }
-    for vp_index in 0..processor_count {
-        directives.push(IgvmDirectiveHeader::SnpVpContext {
-            gpa: KVM_VMSA_GPA,
-            compatibility_mask: COMPATIBILITY_MASK,
-            vp_index: vp_index
-                .try_into()
-                .context("VP index does not fit in IGVM")?,
-            vmsa: Box::new(*vmsa),
-        });
-        map_entries.push((
-            KVM_VMSA_GPA / PAGE_SIZE,
-            format!("snp-vmsa-vp{vp_index}"),
-            "VMSA",
-        ));
-    }
-
-    ensure!(
-        imported.keys().all(|page| *page < ram_page_count),
-        "an imported page lies outside RAM"
-    );
-    Ok((directives, format_map(&map_entries, ram_page_count)))
-}
-
-fn page_data_shape(
-    acceptance: BootPageAcceptance,
-) -> anyhow::Result<(IgvmPageDataType, IgvmPageDataFlags, &'static str)> {
-    Ok(match acceptance {
-        BootPageAcceptance::Exclusive => {
-            (IgvmPageDataType::NORMAL, IgvmPageDataFlags::new(), "NORMAL")
-        }
-        BootPageAcceptance::ExclusiveUnmeasured => (
-            IgvmPageDataType::NORMAL,
-            IgvmPageDataFlags::new().with_unmeasured(true),
-            "UNMEASURED",
-        ),
-        BootPageAcceptance::SecretsPage => (
-            IgvmPageDataType::SECRETS,
-            IgvmPageDataFlags::new(),
-            "SECRETS",
-        ),
-        BootPageAcceptance::CpuidPage => (
-            IgvmPageDataType::CPUID_DATA,
-            IgvmPageDataFlags::new(),
-            "CPUID",
-        ),
-        BootPageAcceptance::CpuidExtendedStatePage => (
-            IgvmPageDataType::CPUID_XF,
-            IgvmPageDataFlags::new(),
-            "CPUID_XF",
-        ),
-        BootPageAcceptance::Shared => (
-            IgvmPageDataType::NORMAL,
-            IgvmPageDataFlags::new().with_shared(true),
-            "SHARED",
-        ),
-        BootPageAcceptance::VpContext => {
-            bail!("VP context must be emitted as SnpVpContext")
-        }
-    })
-}
-
-fn format_map(entries: &[(u64, String, &'static str)], ram_page_count: u64) -> String {
-    let ram_size = ram_page_count * PAGE_SIZE;
-    let mut output = format!(
-        "IGVM file isolation: SNP (C-bit model)\n\
-         Required memory: 0000000000000000 - {ram_size:016x} ({ram_size:#x} bytes)\n\
-         IGVM file layout:\n"
-    );
-    let mut index = 0;
-    while index < entries.len() {
-        let (start_page, tag, kind) = &entries[index];
-        let mut end = index + 1;
-        while end < entries.len() && entries[end].1 == *tag && entries[end].2 == *kind {
-            end += 1;
-        }
-        let end_page = entries[end - 1].0 + 1;
-        let _ = writeln!(
-            output,
-            "  {:016x} - {:016x} ({:#x} bytes) {} [{}]",
-            start_page * PAGE_SIZE,
-            end_page * PAGE_SIZE,
-            (end_page - start_page) * PAGE_SIZE,
-            tag,
-            kind
-        );
-        index = end;
-    }
-    output
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::file_loader::IgvmLoader;
+    use crate::file_loader::SnpLinuxDirectConfig;
+    use crate::vp_context_builder::VpContextBuilder;
+    use crate::vp_context_builder::snp::InjectionType;
+    use crate::vp_context_builder::snp::SnpHardwareContext;
+    use loader::importer::BootPageAcceptance;
+    use loader::importer::ImageLoad;
     use test_with_tracing::test;
 
     const TEST_C_BIT_MASK: u64 = 1 << 51;
 
+    fn test_loader(ram_page_count: u64, vp_context_count: u32) -> IgvmLoader<X86Register> {
+        IgvmLoader::new_snp_linux_direct(SnpLinuxDirectConfig {
+            policy: SnpPolicy::from(0x30000),
+            c_bit_mask: TEST_C_BIT_MASK,
+            ram_page_count,
+            vp_context_count,
+            vmsa_page: Some(KVM_VMSA_GPA / PAGE_SIZE),
+            injection_type: InjectionType::Normal,
+            import_all_ram: true,
+        })
+    }
+
+    fn import_test_registers(importer: &mut dyn ImageLoad<X86Register>) {
+        importer
+            .import_vp_register(X86Register::Rip(0x100000))
+            .unwrap();
+        importer
+            .import_vp_register(X86Register::Cr3(0x4000 | TEST_C_BIT_MASK))
+            .unwrap();
+        importer
+            .import_vp_register(X86Register::Cr0(x86defs::X64_CR0_PE | x86defs::X64_CR0_PG))
+            .unwrap();
+        importer
+            .import_vp_register(X86Register::Cr4(x86defs::X64_CR4_PAE))
+            .unwrap();
+        importer
+            .import_vp_register(X86Register::Efer(
+                x86defs::X64_EFER_LME | x86defs::X64_EFER_LMA,
+            ))
+            .unwrap();
+    }
+
     #[test]
     fn vmsa_uses_c_bit_model() {
-        let registers = [
+        let mut context =
+            SnpHardwareContext::new_linux_direct(TEST_C_BIT_MASK, InjectionType::Normal);
+        for register in [
             X86Register::Rip(0x100000),
             X86Register::Cr3(0x4000 | TEST_C_BIT_MASK),
             X86Register::Cr0(x86defs::X64_CR0_PE | x86defs::X64_CR0_PG),
             X86Register::Cr4(x86defs::X64_CR4_PAE),
             X86Register::Efer(x86defs::X64_EFER_LME | x86defs::X64_EFER_LMA),
-        ];
-        let vmsa = build_vmsa(&registers, TEST_C_BIT_MASK).unwrap();
+        ] {
+            context.import_vp_register(register);
+        }
+        let vmsa = context.vmsa();
         assert_eq!(vmsa.rip, 0x100000);
         assert_ne!(vmsa.cr3 & TEST_C_BIT_MASK, 0);
         assert_ne!(vmsa.cr0 & x86defs::X64_CR0_ET, 0);
@@ -845,27 +414,24 @@ mod tests {
 
     #[test]
     fn complete_ram_has_one_directive_per_page() {
-        let mut imported = BTreeMap::new();
-        imported.insert(
-            1,
-            ImportedPage {
-                acceptance: BootPageAcceptance::SecretsPage,
-                data: Vec::new(),
-                tag: "secret",
-            },
-        );
-        let vmsa = build_vmsa(
-            &[
-                X86Register::Rip(0x100000),
-                X86Register::Cr3(0x4000 | TEST_C_BIT_MASK),
-            ],
-            TEST_C_BIT_MASK,
-        )
-        .unwrap();
-        let (directives, _) = build_complete_ram_directives(&imported, &vmsa, 1, 4).unwrap();
-        assert_eq!(directives.len(), 5);
+        let mut loader = test_loader(4, 1);
+        {
+            let mut importer = loader.loader();
+            importer
+                .import_pages(1, 1, "secret", BootPageAcceptance::SecretsPage, &[])
+                .unwrap();
+            import_test_registers(&mut importer);
+        }
+        let output = loader.finalize().unwrap();
+        let directives = output.guest.directives();
+
+        assert_eq!(directives.len(), 6);
         assert!(matches!(
             directives[0],
+            IgvmDirectiveHeader::RequiredMemory { .. }
+        ));
+        assert!(matches!(
+            directives[1],
             IgvmDirectiveHeader::PageData {
                 data_type: IgvmPageDataType::NORMAL,
                 ref data,
@@ -873,21 +439,21 @@ mod tests {
             } if data.is_empty()
         ));
         assert!(matches!(
-            directives[1],
+            directives[2],
             IgvmDirectiveHeader::PageData {
                 data_type: IgvmPageDataType::SECRETS,
                 ..
             }
         ));
         assert!(matches!(
-            directives[2],
+            directives[3],
             IgvmDirectiveHeader::PageData {
                 data_type: IgvmPageDataType::NORMAL,
                 ..
             }
         ));
         assert!(matches!(
-            directives[4],
+            directives[5],
             IgvmDirectiveHeader::SnpVpContext {
                 gpa: KVM_VMSA_GPA,
                 ..
@@ -897,16 +463,12 @@ mod tests {
 
     #[test]
     fn complete_ram_emits_one_vmsa_per_processor() {
-        let vmsa = build_vmsa(
-            &[
-                X86Register::Rip(0x100000),
-                X86Register::Cr3(0x4000 | TEST_C_BIT_MASK),
-            ],
-            TEST_C_BIT_MASK,
-        )
-        .unwrap();
-        let (directives, _) = build_complete_ram_directives(&BTreeMap::new(), &vmsa, 4, 1).unwrap();
-        let vp_indexes = directives
+        let mut loader = test_loader(1, 4);
+        import_test_registers(&mut loader.loader());
+        let output = loader.finalize().unwrap();
+        let vp_indexes = output
+            .guest
+            .directives()
             .iter()
             .filter_map(|directive| match directive {
                 IgvmDirectiveHeader::SnpVpContext { vp_index, .. } => Some(*vp_index),
@@ -918,26 +480,35 @@ mod tests {
 
     #[test]
     fn overlapping_import_does_not_mutate_existing_pages() {
-        let mut importer = TestIgvmImporter::new(4, 51);
-        importer
-            .import_pages(1, 1, "first", BootPageAcceptance::Exclusive, &[0xaa])
+        let mut loader = test_loader(4, 1);
+        {
+            let mut importer = loader.loader();
+            importer
+                .import_pages(1, 1, "first", BootPageAcceptance::Exclusive, &[0xaa])
+                .unwrap();
+            let error = importer
+                .import_pages(
+                    0,
+                    2,
+                    "overlap",
+                    BootPageAcceptance::Exclusive,
+                    &[0xbb; PAGE_SIZE as usize * 2],
+                )
+                .unwrap_err();
+            assert!(error.to_string().contains("overlaps"));
+            import_test_registers(&mut importer);
+        }
+
+        let output = loader.finalize().unwrap();
+        let page = output
+            .guest
+            .directives()
+            .iter()
+            .find_map(|directive| match directive {
+                IgvmDirectiveHeader::PageData { gpa, data, .. } if *gpa == PAGE_SIZE => Some(data),
+                _ => None,
+            })
             .unwrap();
-
-        let error = importer
-            .import_pages(
-                0,
-                2,
-                "overlap",
-                BootPageAcceptance::Exclusive,
-                &[0xbb; PAGE_SIZE as usize * 2],
-            )
-            .unwrap_err();
-
-        assert!(error.to_string().contains("overlaps an existing import"));
-        assert_eq!(importer.pages.len(), 1);
-        assert!(!importer.pages.contains_key(&0));
-        let existing = &importer.pages[&1];
-        assert_eq!(existing.tag, "first");
-        assert_eq!(existing.data, [0xaa]);
+        assert_eq!(page, &[0xaa]);
     }
 }

--- a/vm/loader/igvmfilegen/src/snp_linux_direct.rs
+++ b/vm/loader/igvmfilegen/src/snp_linux_direct.rs
@@ -1,0 +1,916 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Generation strategy for a self-contained SNP Linux-direct IGVM.
+
+use anyhow::Context;
+use anyhow::bail;
+use anyhow::ensure;
+use igvm::IgvmDirectiveHeader;
+use igvm::IgvmFile;
+use igvm::IgvmInitializationHeader;
+use igvm::IgvmPlatformHeader;
+use igvm::IgvmRevision;
+use igvm::IgvmSerializer;
+use igvm::snp_defs::SevFeatures;
+use igvm::snp_defs::SevSelector;
+use igvm::snp_defs::SevVmsa;
+use igvm_defs::IGVM_VHS_SUPPORTED_PLATFORM;
+use igvm_defs::IgvmPageDataFlags;
+use igvm_defs::IgvmPageDataType;
+use igvm_defs::IgvmPlatformType;
+use igvm_defs::SnpPolicy;
+use igvmfilegen_config::LinuxImage;
+use igvmfilegen_config::ResourceType;
+use igvmfilegen_config::Resources;
+use loader::importer::BootPageAcceptance;
+use loader::importer::IgvmParameterType;
+use loader::importer::ImageLoad;
+use loader::importer::IsolationConfig;
+use loader::importer::IsolationType;
+use loader::importer::ParameterAreaIndex;
+use loader::importer::SegmentRegister;
+use loader::importer::StartupMemoryType;
+use loader::importer::TableRegister;
+use loader::importer::X86Register;
+use loader::linux::InitrdAddressType;
+use loader::linux::InitrdConfig;
+use std::collections::BTreeMap;
+use std::collections::BTreeSet;
+use std::fmt::Write as _;
+use std::io::Seek;
+use std::mem::discriminant;
+use vm_topology::memory::MemoryLayout;
+use vm_topology::processor::TopologyBuilder;
+use zerocopy::FromZeros;
+
+const COMPATIBILITY_MASK: u32 = 1;
+const PAGE_SIZE: u64 = igvm_defs::PAGE_SIZE_4K;
+/// KVM hardcodes the initial VMSA at this GPA and measures it during launch
+/// finish, after all userspace-provided launch-update pages.
+const KVM_VMSA_GPA: u64 = 0xffff_ffff_f000;
+const PM_BASE: u16 = 0x400;
+const ACPI_IRQ: u32 = 9;
+const COM1_BASE: u16 = 0x3f8;
+const COM1_IRQ: u32 = 4;
+
+pub struct BuildParams<'a> {
+    pub linux: &'a LinuxImage,
+    pub processor_count: u32,
+    pub memory_page_count: u64,
+    pub c_bit_position: u8,
+    pub policy: SnpPolicy,
+    pub resources: &'a Resources,
+}
+
+pub struct BuildOutput {
+    pub guest: IgvmFile,
+    pub map: String,
+}
+
+#[derive(Debug, Clone)]
+struct ImportedPage {
+    acceptance: BootPageAcceptance,
+    data: Vec<u8>,
+    tag: &'static str,
+}
+
+#[derive(Debug)]
+struct TestIgvmImporter {
+    pages: BTreeMap<u64, ImportedPage>,
+    registers: Vec<X86Register>,
+    ram_page_count: u64,
+    c_bit_mask: u64,
+}
+
+impl TestIgvmImporter {
+    fn new(ram_page_count: u64, c_bit_position: u8) -> Self {
+        Self {
+            pages: BTreeMap::new(),
+            registers: Vec::new(),
+            ram_page_count,
+            c_bit_mask: 1u64 << c_bit_position,
+        }
+    }
+
+    fn finish(
+        self,
+        processor_count: u32,
+    ) -> anyhow::Result<(Vec<IgvmDirectiveHeader>, SevVmsa, String)> {
+        let vmsa = build_vmsa(&self.registers, self.c_bit_mask)?;
+        let (mut directives, map) = build_complete_ram_directives(
+            &self.pages,
+            &vmsa,
+            processor_count,
+            self.ram_page_count,
+        )?;
+        let ram_size = self
+            .ram_page_count
+            .checked_mul(PAGE_SIZE)
+            .context("RAM size overflow")?;
+        directives.insert(
+            0,
+            IgvmDirectiveHeader::RequiredMemory {
+                gpa: 0,
+                compatibility_mask: COMPATIBILITY_MASK,
+                number_of_bytes: ram_size
+                    .try_into()
+                    .context("RAM size does not fit in an IGVM required-memory directive")?,
+                vtl2_protectable: false,
+            },
+        );
+        Ok((directives, vmsa, map))
+    }
+}
+
+impl ImageLoad<X86Register> for TestIgvmImporter {
+    fn isolation_config(&self) -> IsolationConfig {
+        IsolationConfig {
+            paravisor_present: false,
+            isolation_type: IsolationType::Snp,
+            shared_gpa_boundary_bits: None,
+        }
+    }
+
+    fn create_parameter_area(
+        &mut self,
+        _page_base: u64,
+        _page_count: u32,
+        _debug_tag: &str,
+    ) -> anyhow::Result<ParameterAreaIndex> {
+        bail!("IGVM parameter areas are not supported by this fixed image")
+    }
+
+    fn create_parameter_area_with_data(
+        &mut self,
+        _page_base: u64,
+        _page_count: u32,
+        _debug_tag: &str,
+        _initial_data: &[u8],
+    ) -> anyhow::Result<ParameterAreaIndex> {
+        bail!("IGVM parameter areas are not supported by this fixed image")
+    }
+
+    fn import_parameter(
+        &mut self,
+        _parameter_area: ParameterAreaIndex,
+        _byte_offset: u32,
+        _parameter_type: IgvmParameterType,
+    ) -> anyhow::Result<()> {
+        bail!("IGVM parameters are not supported by this fixed image")
+    }
+
+    fn import_pages(
+        &mut self,
+        page_base: u64,
+        page_count: u64,
+        debug_tag: &'static str,
+        acceptance: BootPageAcceptance,
+        data: &[u8],
+    ) -> anyhow::Result<()> {
+        ensure!(page_count != 0, "cannot import an empty page range");
+        let byte_capacity = page_count
+            .checked_mul(PAGE_SIZE)
+            .context("imported page range size overflow")?;
+        ensure!(
+            data.len() as u64 <= byte_capacity,
+            "data for {debug_tag} exceeds its imported page range"
+        );
+        let page_end = page_base
+            .checked_add(page_count)
+            .context("imported page range overflow")?;
+        ensure!(
+            page_end <= self.ram_page_count,
+            "{debug_tag} lies outside the configured RAM layout"
+        );
+
+        for page_offset in 0..page_count {
+            let data_start = (page_offset * PAGE_SIZE) as usize;
+            let data_end = data
+                .len()
+                .min(data_start.saturating_add(PAGE_SIZE as usize));
+            let page_data = if data_start < data.len() {
+                data[data_start..data_end].to_vec()
+            } else {
+                Vec::new()
+            };
+            let page_number = page_base + page_offset;
+            let previous = self.pages.insert(
+                page_number,
+                ImportedPage {
+                    acceptance,
+                    data: page_data,
+                    tag: debug_tag,
+                },
+            );
+            ensure!(
+                previous.is_none(),
+                "{debug_tag} overlaps an existing import at GPA {:#x}",
+                page_number * PAGE_SIZE
+            );
+        }
+        Ok(())
+    }
+
+    fn import_vp_register(&mut self, register: X86Register) -> anyhow::Result<()> {
+        ensure!(
+            !self
+                .registers
+                .iter()
+                .any(|existing| discriminant(existing) == discriminant(&register)),
+            "duplicate initial register {register:?}"
+        );
+        self.registers.push(register);
+        Ok(())
+    }
+
+    fn verify_startup_memory_available(
+        &mut self,
+        page_base: u64,
+        page_count: u64,
+        _memory_type: StartupMemoryType,
+    ) -> anyhow::Result<()> {
+        let page_end = page_base
+            .checked_add(page_count)
+            .context("required memory range overflow")?;
+        ensure!(
+            page_end <= self.ram_page_count,
+            "required memory lies outside the configured RAM layout"
+        );
+        Ok(())
+    }
+
+    fn set_vp_context_page(&mut self, _page_base: u64) -> anyhow::Result<()> {
+        bail!("the direct-Linux path must not select a guest-RAM VMSA page")
+    }
+
+    fn relocation_region(
+        &mut self,
+        _gpa: u64,
+        _size_bytes: u64,
+        _relocation_alignment: u64,
+        _minimum_relocation_gpa: u64,
+        _maximum_relocation_gpa: u64,
+        _apply_rip_offset: bool,
+        _apply_gdtr_offset: bool,
+        _vp_index: u16,
+    ) -> anyhow::Result<()> {
+        bail!("relocations are not supported by this fixed image")
+    }
+
+    fn page_table_relocation(
+        &mut self,
+        _page_table_gpa: u64,
+        _size_pages: u64,
+        _used_pages: u64,
+        _vp_index: u16,
+    ) -> anyhow::Result<()> {
+        bail!("page-table relocations are not supported by this fixed image")
+    }
+
+    fn set_imported_regions_config_page(&mut self, _page_base: u64) {}
+}
+
+pub fn build(params: BuildParams<'_>) -> anyhow::Result<BuildOutput> {
+    let BuildParams {
+        linux,
+        processor_count,
+        memory_page_count,
+        c_bit_position,
+        policy,
+        resources,
+    } = params;
+    let memory_size = memory_page_count
+        .checked_mul(PAGE_SIZE)
+        .context("RAM size overflow")?;
+    let memory_layout =
+        MemoryLayout::new(memory_size, &[], &[], &[], None).context("building memory layout")?;
+    let processor_topology = TopologyBuilder::new_x86()
+        .build(processor_count)
+        .context("building processor topology")?;
+    let pcie_host_bridges = Vec::new();
+    let acpi_builder = vmm_core::acpi_builder::AcpiTablesBuilder {
+        processor_topology: &processor_topology,
+        mem_layout: &memory_layout,
+        cache_topology: None,
+        pcie_host_bridges: &pcie_host_bridges,
+        slit_info: None,
+        generic_initiators: &[],
+        arch: vmm_core::acpi_builder::AcpiArchConfig::X86 {
+            with_ioapic: true,
+            with_pic: true,
+            with_pit: true,
+            with_psp: false,
+            pm_base: PM_BASE,
+            acpi_irq: ACPI_IRQ,
+            iommu: None,
+        },
+    };
+
+    let kernel_path = resources
+        .get(ResourceType::LinuxKernel)
+        .context("Linux kernel resource is missing")?;
+    let mut kernel = fs_err::File::open(kernel_path)
+        .with_context(|| format!("opening kernel {}", kernel_path.display()))?;
+    let mut initrd = if linux.use_initrd {
+        let initrd_path = resources
+            .get(ResourceType::LinuxInitrd)
+            .context("Linux initrd resource is missing")?;
+        Some(
+            fs_err::File::open(initrd_path)
+                .with_context(|| format!("opening initrd {}", initrd_path.display()))?,
+        )
+    } else {
+        None
+    };
+    let initrd_config = if let Some(initrd) = &mut initrd {
+        let size = initrd
+            .seek(std::io::SeekFrom::End(0))
+            .context("measuring initrd")?;
+        initrd.rewind().context("rewinding initrd")?;
+        Some(InitrdConfig {
+            initrd_address: InitrdAddressType::AfterKernel,
+            initrd,
+            size,
+        })
+    } else {
+        None
+    };
+
+    let mut importer = TestIgvmImporter::new(memory_page_count, c_bit_position);
+    loader::linux::load_x86(
+        &mut importer,
+        &mut kernel,
+        initrd_config,
+        &linux.command_line,
+        &memory_layout,
+        |gpa| {
+            let tables = acpi_builder.build_acpi_tables(gpa, |dsdt| {
+                dsdt.add_apic();
+                dsdt.add_uart(b"\\_SB.UAR1", b"COM1", 1, COM1_BASE, COM1_IRQ);
+                dsdt.add_rtc();
+            });
+            loader::linux::AcpiTables {
+                rsdp: tables.rsdp,
+                tables: tables.tables,
+            }
+        },
+        None,
+        Some(loader::linux::SnpBootConfig {
+            c_bit: c_bit_position,
+        }),
+    )
+    .context("loading direct-Linux image")?;
+
+    let (directives, _vmsa, map) = importer.finish(processor_count)?;
+    let policy: u64 = policy.into();
+    let platform_headers = vec![IgvmPlatformHeader::SupportedPlatform(
+        IGVM_VHS_SUPPORTED_PLATFORM {
+            compatibility_mask: COMPATIBILITY_MASK,
+            highest_vtl: 0,
+            platform_type: IgvmPlatformType::SEV_SNP,
+            platform_version: igvm_defs::IGVM_SEV_SNP_PLATFORM_VERSION,
+            shared_gpa_boundary: 0,
+        },
+    )];
+    let initialization_headers = vec![IgvmInitializationHeader::GuestPolicy {
+        policy,
+        compatibility_mask: COMPATIBILITY_MASK,
+    }];
+
+    let igvm = IgvmFile::new(
+        IgvmRevision::V1,
+        platform_headers,
+        initialization_headers,
+        directives,
+    )
+    .context("constructing IGVM")?;
+    let serializer = IgvmSerializer::new(&igvm).context("measuring SNP IGVM")?;
+    let launch_digest: [u8; 48] = serializer
+        .measurement_for(IgvmPlatformType::SEV_SNP)
+        .context("missing SNP launch measurement")?
+        .digest
+        .as_slice()
+        .try_into()
+        .context("SNP launch digest is not 48 bytes")?;
+    let mut binary = Vec::new();
+    serializer
+        .serialize(&mut binary)
+        .context("serializing IGVM")?;
+    let reparsed = IgvmFile::new_from_binary(&binary, Some(igvm::IsolationType::Snp))
+        .context("validating serialized SNP IGVM")?;
+    validate_generated_igvm(
+        &reparsed,
+        launch_digest,
+        policy,
+        processor_count,
+        memory_page_count,
+        1u64 << c_bit_position,
+    )?;
+
+    Ok(BuildOutput { guest: igvm, map })
+}
+
+fn validate_generated_igvm(
+    igvm: &IgvmFile,
+    expected_launch_digest: [u8; 48],
+    expected_policy: u64,
+    processor_count: u32,
+    ram_page_count: u64,
+    c_bit_mask: u64,
+) -> anyhow::Result<()> {
+    ensure!(igvm.platforms().len() == 1, "expected one platform header");
+    let IgvmPlatformHeader::SupportedPlatform(platform) = &igvm.platforms()[0];
+    ensure!(
+        platform.platform_type == IgvmPlatformType::SEV_SNP
+            && platform.highest_vtl == 0
+            && platform.shared_gpa_boundary == 0,
+        "unexpected SNP platform configuration"
+    );
+    ensure!(
+        igvm.initializations().iter().any(|header| matches!(
+            header,
+            IgvmInitializationHeader::GuestPolicy {
+                policy,
+                compatibility_mask: COMPATIBILITY_MASK,
+            } if *policy == expected_policy
+        )),
+        "serialized file lost its SNP guest policy"
+    );
+
+    let mut covered_pages = BTreeSet::new();
+    let mut required_memory_count = 0;
+    let mut next_vmsa_index = 0;
+    let mut secrets_count = 0;
+    let mut cpuid_count = 0;
+    let mut saw_vmsa = false;
+
+    for directive in igvm.directives() {
+        match directive {
+            IgvmDirectiveHeader::PageData {
+                gpa,
+                flags,
+                data_type,
+                data,
+                ..
+            } => {
+                ensure!(!saw_vmsa, "PageData appears after the VMSA directive");
+                ensure!(gpa.is_multiple_of(PAGE_SIZE), "unaligned PageData GPA");
+                let page = gpa / PAGE_SIZE;
+                ensure!(page < ram_page_count, "PageData lies outside RAM");
+                ensure!(
+                    covered_pages.insert(page),
+                    "duplicate page directive at GPA {gpa:#x}"
+                );
+                ensure!(
+                    !flags.shared() && !flags.unmeasured(),
+                    "fixed image unexpectedly contains shared or unmeasured PageData"
+                );
+                ensure!(
+                    data.len() <= PAGE_SIZE as usize,
+                    "PageData exceeds one page"
+                );
+                if *data_type == IgvmPageDataType::SECRETS {
+                    secrets_count += 1;
+                } else if *data_type == IgvmPageDataType::CPUID_DATA {
+                    cpuid_count += 1;
+                } else {
+                    ensure!(
+                        *data_type == IgvmPageDataType::NORMAL,
+                        "unexpected PageData type {data_type:?}"
+                    );
+                }
+            }
+            IgvmDirectiveHeader::SnpVpContext {
+                gpa,
+                vp_index,
+                vmsa,
+                ..
+            } => {
+                ensure!(*gpa == KVM_VMSA_GPA, "VMSA is not at KVM's fixed GPA");
+                ensure!(
+                    u32::from(*vp_index) == next_vmsa_index,
+                    "VMSA VP contexts are not ordered by VP index"
+                );
+                ensure!(vmsa.sev_features.snp(), "VMSA does not enable SNP");
+                ensure!(!vmsa.sev_features.vtom(), "VMSA unexpectedly enables vTOM");
+                ensure!(vmsa.virtual_tom == 0, "VMSA virtual TOM is not zero");
+                ensure!(
+                    vmsa.cr3 & c_bit_mask != 0,
+                    "VMSA CR3 does not contain the configured C-bit"
+                );
+                ensure!(
+                    vmsa.cr0 & x86defs::X64_CR0_ET != 0,
+                    "VMSA CR0 does not contain KVM's forced ET bit"
+                );
+                ensure!(
+                    vmsa.cr4 & x86defs::X64_CR4_MCE != 0,
+                    "VMSA CR4 does not contain KVM's forced MCE bit"
+                );
+                ensure!(
+                    vmsa.rflags == u64::from(x86defs::RFlags::at_reset()),
+                    "VMSA RFLAGS does not match KVM reset state"
+                );
+                ensure!(
+                    vmsa.dr6 == 0xffff_0ff0 && vmsa.dr7 == 0x400,
+                    "VMSA debug registers do not match KVM reset state"
+                );
+                ensure!(
+                    vmsa.x87_fcw == x86defs::xsave::INIT_FCW
+                        && vmsa.mxcsr == x86defs::xsave::DEFAULT_MXCSR,
+                    "VMSA FPU control state does not match KVM reset state"
+                );
+                next_vmsa_index += 1;
+                saw_vmsa = true;
+            }
+            IgvmDirectiveHeader::RequiredMemory {
+                gpa,
+                number_of_bytes,
+                vtl2_protectable,
+                ..
+            } => {
+                ensure!(
+                    *gpa == 0
+                        && u64::from(*number_of_bytes) == ram_page_count * PAGE_SIZE
+                        && !vtl2_protectable,
+                    "unexpected RequiredMemory directive"
+                );
+                required_memory_count += 1;
+            }
+            unexpected => bail!("unexpected directive in fixed SNP IGVM: {unexpected:?}"),
+        }
+    }
+
+    ensure!(
+        covered_pages.len() == ram_page_count as usize
+            && covered_pages.first() == Some(&0)
+            && covered_pages.last() == Some(&(ram_page_count - 1)),
+        "IGVM does not cover every page of the fixed RAM layout"
+    );
+    ensure!(required_memory_count == 1, "expected one RequiredMemory");
+    ensure!(
+        next_vmsa_index == processor_count,
+        "expected one SNP VMSA per processor"
+    );
+    ensure!(secrets_count == 1, "expected one SNP secrets page");
+    ensure!(cpuid_count == 1, "expected one SNP CPUID page");
+
+    let serializer = IgvmSerializer::new(igvm).context("remeasuring serialized SNP IGVM")?;
+    let measured_digest: [u8; 48] = serializer
+        .measurement_for(IgvmPlatformType::SEV_SNP)
+        .context("serialized IGVM has no SNP measurement")?
+        .digest
+        .as_slice()
+        .try_into()
+        .context("serialized SNP launch digest is not 48 bytes")?;
+    ensure!(
+        measured_digest == expected_launch_digest,
+        "serialized IGVM launch digest changed"
+    );
+    Ok(())
+}
+
+fn build_vmsa(registers: &[X86Register], c_bit_mask: u64) -> anyhow::Result<SevVmsa> {
+    let mut vmsa = SevVmsa::new_zeroed();
+    vmsa.efer = x86defs::X64_EFER_SVME;
+    vmsa.sev_features = SevFeatures::new().with_snp(true);
+    vmsa.virtual_tom = 0;
+    vmsa.xcr0 = 1;
+    vmsa.rflags = u64::from(x86defs::RFlags::at_reset());
+    vmsa.dr6 = 0xffff_0ff0;
+    vmsa.dr7 = 0x400;
+    vmsa.tr = segment_selector(SegmentRegister {
+        base: 0,
+        limit: 0xffff,
+        selector: 0,
+        attributes: 0x8b,
+    });
+    vmsa.ldtr = segment_selector(SegmentRegister {
+        base: 0,
+        limit: 0xffff,
+        selector: 0,
+        attributes: 0x82,
+    });
+    vmsa.idtr = table_selector(TableRegister {
+        base: 0,
+        limit: 0xffff,
+    });
+    vmsa.x87_fcw = x86defs::xsave::INIT_FCW;
+    vmsa.mxcsr = x86defs::xsave::DEFAULT_MXCSR;
+
+    for &register in registers {
+        match register {
+            X86Register::Gdtr(value) => vmsa.gdtr = table_selector(value),
+            X86Register::Idtr(value) => vmsa.idtr = table_selector(value),
+            X86Register::Ds(value) => vmsa.ds = segment_selector(value),
+            X86Register::Es(value) => vmsa.es = segment_selector(value),
+            X86Register::Fs(value) => vmsa.fs = segment_selector(value),
+            X86Register::Gs(value) => vmsa.gs = segment_selector(value),
+            X86Register::Ss(value) => vmsa.ss = segment_selector(value),
+            X86Register::Cs(value) => vmsa.cs = segment_selector(value),
+            X86Register::Tr(value) => vmsa.tr = segment_selector(value),
+            X86Register::Cr0(value) => vmsa.cr0 = value | x86defs::X64_CR0_ET,
+            X86Register::Cr3(value) => vmsa.cr3 = value | c_bit_mask,
+            X86Register::Cr4(value) => vmsa.cr4 = value | x86defs::X64_CR4_MCE,
+            X86Register::Efer(value) => vmsa.efer = value | x86defs::X64_EFER_SVME,
+            X86Register::Pat(value) => vmsa.pat = value,
+            X86Register::Rbp(value) => vmsa.rbp = value,
+            X86Register::Rip(value) => vmsa.rip = value,
+            X86Register::Rsi(value) => vmsa.rsi = value,
+            X86Register::Rsp(value) => vmsa.rsp = value,
+            X86Register::R8(value) => vmsa.r8 = value,
+            X86Register::R9(value) => vmsa.r9 = value,
+            X86Register::R10(value) => vmsa.r10 = value,
+            X86Register::R11(value) => vmsa.r11 = value,
+            X86Register::R12(value) => vmsa.r12 = value,
+            X86Register::Rflags(value) => vmsa.rflags = value,
+            X86Register::MtrrDefType(_)
+            | X86Register::MtrrPhysBase0(_)
+            | X86Register::MtrrPhysMask0(_)
+            | X86Register::MtrrPhysBase1(_)
+            | X86Register::MtrrPhysMask1(_)
+            | X86Register::MtrrPhysBase2(_)
+            | X86Register::MtrrPhysMask2(_)
+            | X86Register::MtrrPhysBase3(_)
+            | X86Register::MtrrPhysMask3(_)
+            | X86Register::MtrrPhysBase4(_)
+            | X86Register::MtrrPhysMask4(_)
+            | X86Register::MtrrFix64k00000(_)
+            | X86Register::MtrrFix16k80000(_)
+            | X86Register::MtrrFix4kE0000(_)
+            | X86Register::MtrrFix4kE8000(_)
+            | X86Register::MtrrFix4kF0000(_)
+            | X86Register::MtrrFix4kF8000(_) => {}
+        }
+    }
+
+    ensure!(vmsa.rip != 0, "Linux loader did not provide an entry point");
+    ensure!(
+        vmsa.cr3 & c_bit_mask != 0,
+        "initial CR3 does not contain the fixed SNP C-bit"
+    );
+    ensure!(
+        !vmsa.sev_features.vtom(),
+        "C-bit image must not enable vTOM"
+    );
+    Ok(vmsa)
+}
+
+fn table_selector(value: TableRegister) -> SevSelector {
+    SevSelector {
+        selector: 0,
+        attrib: 0,
+        limit: value.limit.into(),
+        base: value.base,
+    }
+}
+
+fn segment_selector(value: SegmentRegister) -> SevSelector {
+    SevSelector {
+        selector: value.selector,
+        attrib: (value.attributes & 0xff) | ((value.attributes >> 4) & 0xf00),
+        limit: value.limit,
+        base: value.base,
+    }
+}
+
+fn build_complete_ram_directives(
+    imported: &BTreeMap<u64, ImportedPage>,
+    vmsa: &SevVmsa,
+    processor_count: u32,
+    ram_page_count: u64,
+) -> anyhow::Result<(Vec<IgvmDirectiveHeader>, String)> {
+    let mut directives = Vec::with_capacity(ram_page_count as usize + processor_count as usize);
+    let mut map_entries = Vec::new();
+
+    for page in 0..ram_page_count {
+        let (directive, tag, kind) = match imported.get(&page) {
+            Some(imported) => {
+                let (data_type, flags, kind) = page_data_shape(imported.acceptance)?;
+                (
+                    IgvmDirectiveHeader::PageData {
+                        gpa: page * PAGE_SIZE,
+                        compatibility_mask: COMPATIBILITY_MASK,
+                        flags,
+                        data_type,
+                        data: imported.data.clone(),
+                    },
+                    imported.tag.to_owned(),
+                    kind,
+                )
+            }
+            None => (
+                IgvmDirectiveHeader::PageData {
+                    gpa: page * PAGE_SIZE,
+                    compatibility_mask: COMPATIBILITY_MASK,
+                    flags: IgvmPageDataFlags::new(),
+                    data_type: IgvmPageDataType::NORMAL,
+                    data: Vec::new(),
+                },
+                "accepted-zero-ram".to_owned(),
+                "NORMAL",
+            ),
+        };
+        directives.push(directive);
+        map_entries.push((page, tag, kind));
+    }
+    for vp_index in 0..processor_count {
+        directives.push(IgvmDirectiveHeader::SnpVpContext {
+            gpa: KVM_VMSA_GPA,
+            compatibility_mask: COMPATIBILITY_MASK,
+            vp_index: vp_index
+                .try_into()
+                .context("VP index does not fit in IGVM")?,
+            vmsa: Box::new(*vmsa),
+        });
+        map_entries.push((
+            KVM_VMSA_GPA / PAGE_SIZE,
+            format!("snp-vmsa-vp{vp_index}"),
+            "VMSA",
+        ));
+    }
+
+    ensure!(
+        imported.keys().all(|page| *page < ram_page_count),
+        "an imported page lies outside RAM"
+    );
+    Ok((directives, format_map(&map_entries, ram_page_count)))
+}
+
+fn page_data_shape(
+    acceptance: BootPageAcceptance,
+) -> anyhow::Result<(IgvmPageDataType, IgvmPageDataFlags, &'static str)> {
+    Ok(match acceptance {
+        BootPageAcceptance::Exclusive => {
+            (IgvmPageDataType::NORMAL, IgvmPageDataFlags::new(), "NORMAL")
+        }
+        BootPageAcceptance::ExclusiveUnmeasured => (
+            IgvmPageDataType::NORMAL,
+            IgvmPageDataFlags::new().with_unmeasured(true),
+            "UNMEASURED",
+        ),
+        BootPageAcceptance::SecretsPage => (
+            IgvmPageDataType::SECRETS,
+            IgvmPageDataFlags::new(),
+            "SECRETS",
+        ),
+        BootPageAcceptance::CpuidPage => (
+            IgvmPageDataType::CPUID_DATA,
+            IgvmPageDataFlags::new(),
+            "CPUID",
+        ),
+        BootPageAcceptance::CpuidExtendedStatePage => (
+            IgvmPageDataType::CPUID_XF,
+            IgvmPageDataFlags::new(),
+            "CPUID_XF",
+        ),
+        BootPageAcceptance::Shared => (
+            IgvmPageDataType::NORMAL,
+            IgvmPageDataFlags::new().with_shared(true),
+            "SHARED",
+        ),
+        BootPageAcceptance::VpContext => {
+            bail!("VP context must be emitted as SnpVpContext")
+        }
+    })
+}
+
+fn format_map(entries: &[(u64, String, &'static str)], ram_page_count: u64) -> String {
+    let ram_size = ram_page_count * PAGE_SIZE;
+    let mut output = format!(
+        "IGVM file isolation: SNP (C-bit model)\n\
+         Required memory: 0000000000000000 - {ram_size:016x} ({ram_size:#x} bytes)\n\
+         IGVM file layout:\n"
+    );
+    let mut index = 0;
+    while index < entries.len() {
+        let (start_page, tag, kind) = &entries[index];
+        let mut end = index + 1;
+        while end < entries.len() && entries[end].1 == *tag && entries[end].2 == *kind {
+            end += 1;
+        }
+        let end_page = entries[end - 1].0 + 1;
+        let _ = writeln!(
+            output,
+            "  {:016x} - {:016x} ({:#x} bytes) {} [{}]",
+            start_page * PAGE_SIZE,
+            end_page * PAGE_SIZE,
+            (end_page - start_page) * PAGE_SIZE,
+            tag,
+            kind
+        );
+        index = end;
+    }
+    output
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use test_with_tracing::test;
+
+    const TEST_C_BIT_MASK: u64 = 1 << 51;
+
+    #[test]
+    fn vmsa_uses_c_bit_model() {
+        let registers = [
+            X86Register::Rip(0x100000),
+            X86Register::Cr3(0x4000 | TEST_C_BIT_MASK),
+            X86Register::Cr0(x86defs::X64_CR0_PE | x86defs::X64_CR0_PG),
+            X86Register::Cr4(x86defs::X64_CR4_PAE),
+            X86Register::Efer(x86defs::X64_EFER_LME | x86defs::X64_EFER_LMA),
+        ];
+        let vmsa = build_vmsa(&registers, TEST_C_BIT_MASK).unwrap();
+        assert_eq!(vmsa.rip, 0x100000);
+        assert_ne!(vmsa.cr3 & TEST_C_BIT_MASK, 0);
+        assert_ne!(vmsa.cr0 & x86defs::X64_CR0_ET, 0);
+        assert_ne!(vmsa.cr4 & x86defs::X64_CR4_MCE, 0);
+        assert!(vmsa.sev_features.snp());
+        assert!(!vmsa.sev_features.vtom());
+        assert!(!vmsa.sev_features.debug_swap());
+        assert_eq!(vmsa.virtual_tom, 0);
+        assert_eq!(vmsa.rflags, 2);
+        assert_eq!(vmsa.dr6, 0xffff_0ff0);
+        assert_eq!(vmsa.dr7, 0x400);
+        assert_eq!(vmsa.tr.limit, 0xffff);
+        assert_eq!(vmsa.tr.attrib, 0x8b);
+        assert_eq!(vmsa.ldtr.limit, 0xffff);
+        assert_eq!(vmsa.ldtr.attrib, 0x82);
+        assert_eq!(vmsa.idtr.limit, 0xffff);
+        assert_eq!(vmsa.x87_fcw, x86defs::xsave::INIT_FCW);
+        assert_eq!(vmsa.mxcsr, x86defs::xsave::DEFAULT_MXCSR);
+    }
+
+    #[test]
+    fn complete_ram_has_one_directive_per_page() {
+        let mut imported = BTreeMap::new();
+        imported.insert(
+            1,
+            ImportedPage {
+                acceptance: BootPageAcceptance::SecretsPage,
+                data: Vec::new(),
+                tag: "secret",
+            },
+        );
+        let vmsa = build_vmsa(
+            &[
+                X86Register::Rip(0x100000),
+                X86Register::Cr3(0x4000 | TEST_C_BIT_MASK),
+            ],
+            TEST_C_BIT_MASK,
+        )
+        .unwrap();
+        let (directives, _) = build_complete_ram_directives(&imported, &vmsa, 1, 4).unwrap();
+        assert_eq!(directives.len(), 5);
+        assert!(matches!(
+            directives[0],
+            IgvmDirectiveHeader::PageData {
+                data_type: IgvmPageDataType::NORMAL,
+                ref data,
+                ..
+            } if data.is_empty()
+        ));
+        assert!(matches!(
+            directives[1],
+            IgvmDirectiveHeader::PageData {
+                data_type: IgvmPageDataType::SECRETS,
+                ..
+            }
+        ));
+        assert!(matches!(
+            directives[2],
+            IgvmDirectiveHeader::PageData {
+                data_type: IgvmPageDataType::NORMAL,
+                ..
+            }
+        ));
+        assert!(matches!(
+            directives[4],
+            IgvmDirectiveHeader::SnpVpContext {
+                gpa: KVM_VMSA_GPA,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn complete_ram_emits_one_vmsa_per_processor() {
+        let vmsa = build_vmsa(
+            &[
+                X86Register::Rip(0x100000),
+                X86Register::Cr3(0x4000 | TEST_C_BIT_MASK),
+            ],
+            TEST_C_BIT_MASK,
+        )
+        .unwrap();
+        let (directives, _) = build_complete_ram_directives(&BTreeMap::new(), &vmsa, 4, 1).unwrap();
+        let vp_indexes = directives
+            .iter()
+            .filter_map(|directive| match directive {
+                IgvmDirectiveHeader::SnpVpContext { vp_index, .. } => Some(*vp_index),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(vp_indexes, [0, 1, 2, 3]);
+    }
+}

--- a/vm/loader/igvmfilegen/src/vp_context_builder/snp.rs
+++ b/vm/loader/igvmfilegen/src/vp_context_builder/snp.rs
@@ -38,6 +38,29 @@ pub enum SecureAvic {
     Disabled,
 }
 
+#[derive(Debug, Copy, Clone)]
+enum SnpContextKind {
+    Standard,
+    LinuxDirect { c_bit_mask: u64 },
+}
+
+fn table_register(reg: TableRegister) -> SevSelector {
+    SevSelector {
+        limit: reg.limit.into(),
+        base: reg.base,
+        ..FromZeros::new_zeroed()
+    }
+}
+
+fn segment_register(reg: SegmentRegister) -> SevSelector {
+    SevSelector {
+        limit: reg.limit,
+        base: reg.base,
+        selector: reg.selector,
+        attrib: (reg.attributes & 0xff) | ((reg.attributes >> 4) & 0xf00),
+    }
+}
+
 /// A hardware SNP VP context, that is imported as a VMSA.
 #[derive(Debug)]
 pub struct SnpHardwareContext {
@@ -48,6 +71,7 @@ pub struct SnpHardwareContext {
     page_number: Option<u64>,
     /// The VMSA for this VP.
     vmsa: SevVmsa,
+    kind: SnpContextKind,
 }
 
 impl SnpHardwareContext {
@@ -123,7 +147,52 @@ impl SnpHardwareContext {
             accept_lower_1mb: enlightened_uefi,
             page_number: None,
             vmsa,
+            kind: SnpContextKind::Standard,
         }
+    }
+
+    /// Create a VMSA builder for a Linux-direct guest using the C-bit model.
+    pub fn new_linux_direct(c_bit_mask: u64, injection_type: InjectionType) -> Self {
+        let mut vmsa: SevVmsa = FromZeros::new_zeroed();
+        vmsa.efer = X64_EFER_SVME;
+        vmsa.sev_features.set_snp(true);
+        vmsa.sev_features
+            .set_restrict_injection(injection_type == InjectionType::Restricted);
+        vmsa.xcr0 = x86defs::xsave::XFEATURE_X87;
+        vmsa.rflags = u64::from(x86defs::RFlags::at_reset());
+        vmsa.dr6 = 0xffff_0ff0;
+        vmsa.dr7 = 0x400;
+        vmsa.tr = segment_register(SegmentRegister {
+            base: 0,
+            limit: 0xffff,
+            selector: 0,
+            attributes: 0x8b,
+        });
+        vmsa.ldtr = segment_register(SegmentRegister {
+            base: 0,
+            limit: 0xffff,
+            selector: 0,
+            attributes: 0x82,
+        });
+        vmsa.idtr = table_register(TableRegister {
+            base: 0,
+            limit: 0xffff,
+        });
+        vmsa.x87_fcw = x86defs::xsave::INIT_FCW;
+        vmsa.mxcsr = x86defs::xsave::DEFAULT_MXCSR;
+
+        Self {
+            accept_lower_1mb: false,
+            page_number: None,
+            vmsa,
+            kind: SnpContextKind::LinuxDirect { c_bit_mask },
+        }
+    }
+
+    /// Returns the VMSA under construction.
+    #[cfg(test)]
+    pub fn vmsa(&self) -> &SevVmsa {
+        &self.vmsa
     }
 }
 
@@ -131,36 +200,37 @@ impl VpContextBuilder for SnpHardwareContext {
     type Register = X86Register;
 
     fn import_vp_register(&mut self, register: X86Register) {
-        let create_vmsa_table_register = |reg: TableRegister| -> SevSelector {
-            SevSelector {
-                limit: reg.limit as u32,
-                base: reg.base,
-                ..FromZeros::new_zeroed()
-            }
-        };
-
-        let create_vmsa_segment_register = |reg: SegmentRegister| -> SevSelector {
-            SevSelector {
-                limit: reg.limit,
-                base: reg.base,
-                selector: reg.selector,
-                attrib: (reg.attributes & 0xFF) | ((reg.attributes >> 4) & 0xF00),
-            }
-        };
-
         match register {
-            X86Register::Gdtr(reg) => self.vmsa.gdtr = create_vmsa_table_register(reg),
-            X86Register::Idtr(_) => panic!("Idtr not allowed for SNP"),
-            X86Register::Ds(reg) => self.vmsa.ds = create_vmsa_segment_register(reg),
-            X86Register::Es(reg) => self.vmsa.es = create_vmsa_segment_register(reg),
-            X86Register::Fs(reg) => self.vmsa.fs = create_vmsa_segment_register(reg),
-            X86Register::Gs(reg) => self.vmsa.gs = create_vmsa_segment_register(reg),
-            X86Register::Ss(reg) => self.vmsa.ss = create_vmsa_segment_register(reg),
-            X86Register::Cs(reg) => self.vmsa.cs = create_vmsa_segment_register(reg),
-            X86Register::Tr(reg) => self.vmsa.tr = create_vmsa_segment_register(reg),
-            X86Register::Cr0(reg) => self.vmsa.cr0 = reg,
-            X86Register::Cr3(reg) => self.vmsa.cr3 = reg,
-            X86Register::Cr4(reg) => self.vmsa.cr4 = reg,
+            X86Register::Gdtr(reg) => self.vmsa.gdtr = table_register(reg),
+            X86Register::Idtr(reg) => match self.kind {
+                SnpContextKind::Standard => panic!("Idtr not allowed for SNP"),
+                SnpContextKind::LinuxDirect { .. } => self.vmsa.idtr = table_register(reg),
+            },
+            X86Register::Ds(reg) => self.vmsa.ds = segment_register(reg),
+            X86Register::Es(reg) => self.vmsa.es = segment_register(reg),
+            X86Register::Fs(reg) => self.vmsa.fs = segment_register(reg),
+            X86Register::Gs(reg) => self.vmsa.gs = segment_register(reg),
+            X86Register::Ss(reg) => self.vmsa.ss = segment_register(reg),
+            X86Register::Cs(reg) => self.vmsa.cs = segment_register(reg),
+            X86Register::Tr(reg) => self.vmsa.tr = segment_register(reg),
+            X86Register::Cr0(reg) => {
+                self.vmsa.cr0 = match self.kind {
+                    SnpContextKind::Standard => reg,
+                    SnpContextKind::LinuxDirect { .. } => reg | x86defs::X64_CR0_ET,
+                }
+            }
+            X86Register::Cr3(reg) => {
+                self.vmsa.cr3 = match self.kind {
+                    SnpContextKind::Standard => reg,
+                    SnpContextKind::LinuxDirect { c_bit_mask } => reg | c_bit_mask,
+                }
+            }
+            X86Register::Cr4(reg) => {
+                self.vmsa.cr4 = match self.kind {
+                    SnpContextKind::Standard => reg,
+                    SnpContextKind::LinuxDirect { .. } => reg | x86defs::X64_CR4_MCE,
+                }
+            }
             X86Register::Efer(reg) => {
                 // All SEV guests require EFER.SVME for the VMSA to be valid.
                 self.vmsa.efer = reg | X64_EFER_SVME;
@@ -169,13 +239,19 @@ impl VpContextBuilder for SnpHardwareContext {
             X86Register::Rbp(reg) => self.vmsa.rbp = reg,
             X86Register::Rip(reg) => self.vmsa.rip = reg,
             X86Register::Rsi(reg) => self.vmsa.rsi = reg,
-            X86Register::Rsp(_) => panic!("rsp not allowed for SNP"),
+            X86Register::Rsp(reg) => match self.kind {
+                SnpContextKind::Standard => panic!("rsp not allowed for SNP"),
+                SnpContextKind::LinuxDirect { .. } => self.vmsa.rsp = reg,
+            },
             X86Register::R8(reg) => self.vmsa.r8 = reg,
             X86Register::R9(reg) => self.vmsa.r9 = reg,
             X86Register::R10(reg) => self.vmsa.r10 = reg,
             X86Register::R11(reg) => self.vmsa.r11 = reg,
             X86Register::R12(reg) => self.vmsa.r12 = reg,
-            X86Register::Rflags(_) => panic!("rflags not allowed for SNP"),
+            X86Register::Rflags(reg) => match self.kind {
+                SnpContextKind::Standard => panic!("rflags not allowed for SNP"),
+                SnpContextKind::LinuxDirect { .. } => self.vmsa.rflags = reg,
+            },
 
             X86Register::MtrrDefType(_)
             | X86Register::MtrrPhysBase0(_)

--- a/vm/loader/igvmfilegen_config/Cargo.toml
+++ b/vm/loader/igvmfilegen_config/Cargo.toml
@@ -7,6 +7,8 @@ edition.workspace = true
 rust-version.workspace = true
 
 [dependencies]
+igvm_defs.workspace = true
+page_table.workspace = true
 product_policy = { workspace = true, features = ["manifest"] }
 serde = { workspace = true, features = ["std", "derive"] }
 thiserror.workspace = true

--- a/vm/loader/igvmfilegen_config/Cargo.toml
+++ b/vm/loader/igvmfilegen_config/Cargo.toml
@@ -9,6 +9,7 @@ rust-version.workspace = true
 [dependencies]
 product_policy = { workspace = true, features = ["manifest"] }
 serde = { workspace = true, features = ["std", "derive"] }
+thiserror.workspace = true
 
 [dev-dependencies]
 serde_json = { workspace = true, features = ["std"] }

--- a/vm/loader/igvmfilegen_config/src/lib.rs
+++ b/vm/loader/igvmfilegen_config/src/lib.rs
@@ -129,7 +129,6 @@ pub enum Image {
         /// The Linux image to load.
         linux: LinuxImage,
         /// The number of virtual processors in the guest.
-        #[serde(default = "default_processor_count")]
         processor_count: u32,
         /// The number of pages in the guest.
         memory_page_count: u64,
@@ -203,46 +202,27 @@ impl Image {
 }
 
 /// Error returned when an image configuration contains invalid intrinsic fields.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, thiserror::Error, Clone, Copy, PartialEq, Eq)]
 pub enum ImageValidationError {
     /// The image requests no virtual processors.
+    #[error("processor_count must be nonzero")]
     ZeroProcessorCount,
     /// The image requests no guest memory.
+    #[error("memory_page_count must be nonzero")]
     ZeroMemoryPageCount,
     /// The requested memory byte count cannot be represented by an IGVM
     /// required-memory directive.
+    #[error("memory_page_count {memory_page_count} has a byte count that does not fit in u32")]
     MemoryByteCountTooLarge {
         /// The invalid number of 4-KiB pages.
         memory_page_count: u64,
     },
     /// The SNP C-bit is outside the address bits available in x64 page tables.
+    #[error("c_bit_position {c_bit_position} is outside the supported range 12..=51")]
     InvalidCBitPosition {
         /// The invalid C-bit position.
         c_bit_position: u8,
     },
-}
-
-impl std::fmt::Display for ImageValidationError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match *self {
-            Self::ZeroProcessorCount => write!(f, "processor_count must be nonzero"),
-            Self::ZeroMemoryPageCount => write!(f, "memory_page_count must be nonzero"),
-            Self::MemoryByteCountTooLarge { memory_page_count } => write!(
-                f,
-                "memory_page_count {memory_page_count} has a byte count that does not fit in u32"
-            ),
-            Self::InvalidCBitPosition { c_bit_position } => write!(
-                f,
-                "c_bit_position {c_bit_position} is outside the supported range 12..=51"
-            ),
-        }
-    }
-}
-
-impl std::error::Error for ImageValidationError {}
-
-const fn default_processor_count() -> u32 {
-    1
 }
 
 impl LinuxImage {

--- a/vm/loader/igvmfilegen_config/src/lib.rs
+++ b/vm/loader/igvmfilegen_config/src/lib.rs
@@ -14,6 +14,9 @@ use std::collections::HashMap;
 use std::ffi::CString;
 use std::path::PathBuf;
 
+const IGVM_PAGE_SIZE_BYTES: u64 = 4096;
+const X64_PAGE_TABLE_ADDRESS_BIT_RANGE: std::ops::RangeInclusive<u8> = 32..=51;
+
 /// The UEFI config type to pass to the UEFI loader.
 #[derive(Serialize, Deserialize, Debug, Copy, Clone)]
 #[serde(rename_all = "snake_case")]
@@ -121,6 +124,18 @@ pub enum Image {
     /// Load the Linux kernel.
     /// TODO: Currently, this only works with underhill.
     Linux(LinuxImage),
+    /// Load Linux directly into a self-contained SNP guest.
+    SnpLinuxDirect {
+        /// The Linux image to load.
+        linux: LinuxImage,
+        /// The number of virtual processors in the guest.
+        #[serde(default = "default_processor_count")]
+        processor_count: u32,
+        /// The number of pages in the guest.
+        memory_page_count: u64,
+        /// The page-table address bit used as the SNP encryption bit.
+        c_bit_position: u8,
+    },
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -149,9 +164,85 @@ impl Image {
             .chain(if uefi { Some(ResourceType::Uefi) } else { None })
             .chain(linux.iter().flat_map(|linux| linux.required_resources()))
             .collect(),
-            Image::Linux(ref linux) => linux.required_resources(),
+            Image::Linux(ref linux) | Image::SnpLinuxDirect { ref linux, .. } => {
+                linux.required_resources()
+            }
         }
     }
+
+    /// Validate constraints intrinsic to this image configuration.
+    pub fn validate(&self) -> Result<(), ImageValidationError> {
+        if let Image::SnpLinuxDirect {
+            processor_count,
+            memory_page_count,
+            c_bit_position,
+            ..
+        } = *self
+        {
+            if processor_count == 0 {
+                return Err(ImageValidationError::ZeroProcessorCount);
+            }
+            if memory_page_count == 0 {
+                return Err(ImageValidationError::ZeroMemoryPageCount);
+            }
+
+            let memory_byte_count = memory_page_count
+                .checked_mul(IGVM_PAGE_SIZE_BYTES)
+                .ok_or(ImageValidationError::MemoryByteCountTooLarge { memory_page_count })?;
+            if u32::try_from(memory_byte_count).is_err() {
+                return Err(ImageValidationError::MemoryByteCountTooLarge { memory_page_count });
+            }
+
+            if !X64_PAGE_TABLE_ADDRESS_BIT_RANGE.contains(&c_bit_position) {
+                return Err(ImageValidationError::InvalidCBitPosition { c_bit_position });
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// Error returned when an image configuration contains invalid intrinsic fields.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ImageValidationError {
+    /// The image requests no virtual processors.
+    ZeroProcessorCount,
+    /// The image requests no guest memory.
+    ZeroMemoryPageCount,
+    /// The requested memory byte count cannot be represented by an IGVM
+    /// required-memory directive.
+    MemoryByteCountTooLarge {
+        /// The invalid number of 4-KiB pages.
+        memory_page_count: u64,
+    },
+    /// The SNP C-bit is outside the address bits available in x64 page tables.
+    InvalidCBitPosition {
+        /// The invalid C-bit position.
+        c_bit_position: u8,
+    },
+}
+
+impl std::fmt::Display for ImageValidationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match *self {
+            Self::ZeroProcessorCount => write!(f, "processor_count must be nonzero"),
+            Self::ZeroMemoryPageCount => write!(f, "memory_page_count must be nonzero"),
+            Self::MemoryByteCountTooLarge { memory_page_count } => write!(
+                f,
+                "memory_page_count {memory_page_count} has a byte count that does not fit in u32"
+            ),
+            Self::InvalidCBitPosition { c_bit_position } => write!(
+                f,
+                "c_bit_position {c_bit_position} is outside the supported range 32..=51"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for ImageValidationError {}
+
+const fn default_processor_count() -> u32 {
+    1
 }
 
 impl LinuxImage {
@@ -332,6 +423,151 @@ impl Resources {
 #[cfg(test)]
 mod test {
     use super::*;
+
+    fn snp_linux_direct_image(
+        use_initrd: bool,
+        processor_count: u32,
+        memory_page_count: u64,
+        c_bit_position: u8,
+    ) -> Image {
+        Image::SnpLinuxDirect {
+            linux: LinuxImage {
+                use_initrd,
+                command_line: CString::new("console=ttyS0").unwrap(),
+            },
+            processor_count,
+            memory_page_count,
+            c_bit_position,
+        }
+    }
+
+    #[test]
+    fn parse_snp_linux_direct_manifest() {
+        let config: Config =
+            serde_json::from_str(include_str!("../../manifests/snp-linux-direct.json")).unwrap();
+
+        assert!(matches!(config.guest_arch, GuestArch::X64));
+        let [guest] = config.guest_configs.as_slice() else {
+            panic!("expected one guest config");
+        };
+        assert_eq!(guest.guest_svn, 1);
+        assert_eq!(guest.max_vtl, 0);
+        match &guest.isolation_type {
+            ConfigIsolationType::Snp {
+                shared_gpa_boundary_bits,
+                policy,
+                enable_debug,
+                injection_type,
+                secure_avic,
+            } => {
+                assert_eq!(*shared_gpa_boundary_bits, None);
+                assert_eq!(*policy, 196608);
+                assert!(*enable_debug);
+                assert!(matches!(injection_type, SnpInjectionType::Normal));
+                assert!(matches!(secure_avic, SecureAvicType::Disabled));
+            }
+
+            isolation_type => panic!("unexpected isolation type: {isolation_type:?}"),
+        }
+        match &guest.image {
+            Image::SnpLinuxDirect {
+                linux,
+                processor_count,
+                memory_page_count,
+                c_bit_position,
+            } => {
+                assert!(linux.use_initrd);
+                assert_eq!(
+                    linux.command_line.as_bytes(),
+                    b"console=ttyS0 earlyprintk=serial earlycon panic=-1"
+                );
+                assert_eq!(*processor_count, 1);
+                assert_eq!(*memory_page_count, 40960);
+                assert_eq!(*c_bit_position, 51);
+                guest.image.validate().unwrap();
+            }
+            image => panic!("unexpected image: {image:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_multi_vp_snp_linux_direct_manifest() {
+        let config: Config = serde_json::from_str(include_str!(
+            "../../manifests/snp-linux-direct-multi-vp.json"
+        ))
+        .unwrap();
+        let [guest] = config.guest_configs.as_slice() else {
+            panic!("expected one guest config");
+        };
+        let Image::SnpLinuxDirect {
+            processor_count, ..
+        } = &guest.image
+        else {
+            panic!("expected SNP Linux-direct image");
+        };
+        assert_eq!(*processor_count, 2);
+        guest.image.validate().unwrap();
+    }
+
+    #[test]
+    fn snp_linux_direct_required_resources_with_initrd() {
+        let image = snp_linux_direct_image(true, 1, 40960, 51);
+
+        assert_eq!(
+            image.required_resources(),
+            vec![ResourceType::LinuxKernel, ResourceType::LinuxInitrd]
+        );
+    }
+
+    #[test]
+    fn snp_linux_direct_required_resources_without_initrd() {
+        let image = snp_linux_direct_image(false, 1, 40960, 51);
+
+        assert_eq!(image.required_resources(), vec![ResourceType::LinuxKernel]);
+    }
+
+    #[test]
+    fn snp_linux_direct_rejects_zero_memory() {
+        let image = snp_linux_direct_image(false, 1, 0, 51);
+
+        assert_eq!(
+            image.validate(),
+            Err(ImageValidationError::ZeroMemoryPageCount)
+        );
+    }
+
+    #[test]
+    fn snp_linux_direct_rejects_oversized_memory() {
+        let memory_page_count = u64::from(u32::MAX) / IGVM_PAGE_SIZE_BYTES + 1;
+        let image = snp_linux_direct_image(false, 1, memory_page_count, 51);
+
+        assert_eq!(
+            image.validate(),
+            Err(ImageValidationError::MemoryByteCountTooLarge { memory_page_count })
+        );
+    }
+
+    #[test]
+    fn snp_linux_direct_rejects_invalid_c_bit_positions() {
+        for c_bit_position in [31, 52] {
+            let image = snp_linux_direct_image(false, 1, 40960, c_bit_position);
+
+            assert_eq!(
+                image.validate(),
+                Err(ImageValidationError::InvalidCBitPosition { c_bit_position })
+            );
+        }
+    }
+
+    #[test]
+    fn snp_linux_direct_rejects_zero_processors() {
+        let image = snp_linux_direct_image(false, 0, 40960, 51);
+
+        assert_eq!(
+            image.validate(),
+            Err(ImageValidationError::ZeroProcessorCount)
+        );
+    }
 
     #[test]
     fn non_absolute_path_new() {

--- a/vm/loader/igvmfilegen_config/src/lib.rs
+++ b/vm/loader/igvmfilegen_config/src/lib.rs
@@ -7,15 +7,14 @@
 #![expect(missing_docs)]
 #![forbid(unsafe_code)]
 
+use igvm_defs::PAGE_SIZE_4K;
+use page_table::x64::X64_PTE_ADDRESS_BIT_RANGE;
 use product_policy::ProductPolicy;
 use serde::Deserialize;
 use serde::Serialize;
 use std::collections::HashMap;
 use std::ffi::CString;
 use std::path::PathBuf;
-
-const IGVM_PAGE_SIZE_BYTES: u64 = 4096;
-const X64_PAGE_TABLE_ADDRESS_BIT_RANGE: std::ops::RangeInclusive<u8> = 12..=51;
 
 /// The UEFI config type to pass to the UEFI loader.
 #[derive(Serialize, Deserialize, Debug, Copy, Clone)]
@@ -186,13 +185,15 @@ impl Image {
             }
 
             let memory_byte_count = memory_page_count
-                .checked_mul(IGVM_PAGE_SIZE_BYTES)
+                .checked_mul(PAGE_SIZE_4K)
                 .ok_or(ImageValidationError::MemoryByteCountTooLarge { memory_page_count })?;
             if u32::try_from(memory_byte_count).is_err() {
                 return Err(ImageValidationError::MemoryByteCountTooLarge { memory_page_count });
             }
 
-            if !X64_PAGE_TABLE_ADDRESS_BIT_RANGE.contains(&c_bit_position) {
+            // Encrypted PTEs store the C-bit in the physical-address field.
+            // Page-offset and control bits cannot carry it.
+            if !X64_PTE_ADDRESS_BIT_RANGE.contains(&c_bit_position) {
                 return Err(ImageValidationError::InvalidCBitPosition { c_bit_position });
             }
         }
@@ -218,7 +219,7 @@ pub enum ImageValidationError {
         memory_page_count: u64,
     },
     /// The SNP C-bit is outside the address bits available in x64 page tables.
-    #[error("c_bit_position {c_bit_position} is outside the supported range 12..=51")]
+    #[error("c_bit_position {c_bit_position} is outside the x64 PTE address field")]
     InvalidCBitPosition {
         /// The invalid C-bit position.
         c_bit_position: u8,
@@ -518,7 +519,7 @@ mod test {
 
     #[test]
     fn snp_linux_direct_rejects_oversized_memory() {
-        let memory_page_count = u64::from(u32::MAX) / IGVM_PAGE_SIZE_BYTES + 1;
+        let memory_page_count = u64::from(u32::MAX) / PAGE_SIZE_4K + 1;
         let image = snp_linux_direct_image(false, 1, memory_page_count, 51);
 
         assert_eq!(

--- a/vm/loader/igvmfilegen_config/src/lib.rs
+++ b/vm/loader/igvmfilegen_config/src/lib.rs
@@ -15,7 +15,7 @@ use std::ffi::CString;
 use std::path::PathBuf;
 
 const IGVM_PAGE_SIZE_BYTES: u64 = 4096;
-const X64_PAGE_TABLE_ADDRESS_BIT_RANGE: std::ops::RangeInclusive<u8> = 32..=51;
+const X64_PAGE_TABLE_ADDRESS_BIT_RANGE: std::ops::RangeInclusive<u8> = 12..=51;
 
 /// The UEFI config type to pass to the UEFI loader.
 #[derive(Serialize, Deserialize, Debug, Copy, Clone)]
@@ -233,7 +233,7 @@ impl std::fmt::Display for ImageValidationError {
             ),
             Self::InvalidCBitPosition { c_bit_position } => write!(
                 f,
-                "c_bit_position {c_bit_position} is outside the supported range 32..=51"
+                "c_bit_position {c_bit_position} is outside the supported range 12..=51"
             ),
         }
     }
@@ -549,7 +549,7 @@ mod test {
 
     #[test]
     fn snp_linux_direct_rejects_invalid_c_bit_positions() {
-        for c_bit_position in [31, 52] {
+        for c_bit_position in [11, 52] {
             let image = snp_linux_direct_image(false, 1, 40960, c_bit_position);
 
             assert_eq!(

--- a/vm/loader/igvmfilegen_config/src/lib.rs
+++ b/vm/loader/igvmfilegen_config/src/lib.rs
@@ -8,6 +8,7 @@
 #![forbid(unsafe_code)]
 
 use igvm_defs::PAGE_SIZE_4K;
+use page_table::IdentityMapSize;
 use page_table::x64::X64_PTE_ADDRESS_BIT_RANGE;
 use product_policy::ProductPolicy;
 use serde::Deserialize;
@@ -191,9 +192,13 @@ impl Image {
                 return Err(ImageValidationError::MemoryByteCountTooLarge { memory_page_count });
             }
 
-            // Encrypted PTEs store the C-bit in the physical-address field.
-            // Page-offset and control bits cannot carry it.
-            if !X64_PTE_ADDRESS_BIT_RANGE.contains(&c_bit_position) {
+            // The Linux startup page tables identity-map the lower 4 GiB and
+            // set the C-bit by ORing it into each PTE. The bit must therefore
+            // be outside that mapped address range as well as inside the
+            // architectural PTE address field.
+            let valid_c_bit = X64_PTE_ADDRESS_BIT_RANGE.contains(&c_bit_position)
+                && (1u64 << c_bit_position) >= IdentityMapSize::Size4Gb.address_space_size();
+            if !valid_c_bit {
                 return Err(ImageValidationError::InvalidCBitPosition { c_bit_position });
             }
         }
@@ -218,8 +223,11 @@ pub enum ImageValidationError {
         /// The invalid number of 4-KiB pages.
         memory_page_count: u64,
     },
-    /// The SNP C-bit is outside the address bits available in x64 page tables.
-    #[error("c_bit_position {c_bit_position} is outside the x64 PTE address field")]
+    /// The SNP C-bit overlaps the identity map or lies outside the x64 PTE
+    /// address field.
+    #[error(
+        "c_bit_position {c_bit_position} overlaps the 4-GiB identity map or lies outside the x64 PTE address field"
+    )]
     InvalidCBitPosition {
         /// The invalid C-bit position.
         c_bit_position: u8,
@@ -530,7 +538,7 @@ mod test {
 
     #[test]
     fn snp_linux_direct_rejects_invalid_c_bit_positions() {
-        for c_bit_position in [11, 52] {
+        for c_bit_position in [11, 31, 52] {
             let image = snp_linux_direct_image(false, 1, 40960, c_bit_position);
 
             assert_eq!(
@@ -538,6 +546,10 @@ mod test {
                 Err(ImageValidationError::InvalidCBitPosition { c_bit_position })
             );
         }
+
+        snp_linux_direct_image(false, 1, 40960, 32)
+            .validate()
+            .unwrap();
     }
 
     #[test]

--- a/vm/loader/manifests/README.md
+++ b/vm/loader/manifests/README.md
@@ -15,15 +15,15 @@ normally creates the resource file that supplies each recipe's binary inputs.
 - an initrd and the kernel command line
   `console=ttyS0 earlyprintk=serial earlycon panic=-1`
 - SNP C-bit position 51, which is a test-host assumption rather than a portable
-  SNP property
+  SNP property; the generator requires bit 32 or higher because the startup
+  page tables identity-map the lower 4 GiB
 
 The IGVM contains only the BSP VMSA, regardless of processor count. Backends
-are responsible for any AP launch state they require. Current KVM synthesizes
-and measures one additional VMSA for every AP from the reset state configured
-by `virt_kvm`. Those backend-created VMSAs are not part of the IGVM launch
-measurement, so `virt_kvm` does not submit the file's SNP ID block for a
-multi-processor KVM guest. Multi-processor KVM attestation against that ID
-block remains unsupported until KVM accepts userspace-provided VMSAs.
+are responsible for any AP launch state they require. Current KVM constructs
+and measures the initial VMSAs itself rather than accepting the IGVM VMSA page.
+Those KVM-created VMSAs are not part of the IGVM launch measurement, so the
+file's SNP ID block is not valid for KVM. KVM attestation against that ID block
+remains unsupported until KVM accepts userspace-provided VMSAs.
 
 To build it manually, create a resources file containing absolute paths:
 

--- a/vm/loader/manifests/README.md
+++ b/vm/loader/manifests/README.md
@@ -1,9 +1,44 @@
-This folder contains different manifest recipes to build various IGVM files.
-These contain the functional configuration for a given igvm recipe.
+This folder contains manifest recipes for building IGVM files. The build system
+normally creates the resource file that supplies each recipe's binary inputs.
 
-The build system will automatically create the required resource file used by
-this tool.
+## SNP Linux-direct profile
 
-If you want to run this tool manually and specify a custom resource file, see
-igvmfilegen_config's `Resources` type and usage on how to manually create a
-resource file for a given recipe.
+`snp-linux-direct.json` is a bring-up profile with these assumptions:
+
+- x64 and one VTL0 SEV-SNP guest that boots Linux directly
+- one virtual processor; `snp-linux-direct-multi-vp.json` uses two
+- 160 MiB of contiguous RAM (40,960 4-KiB pages)
+- COM1-only serial ACPI, with no VMBus, PCIe, disks, IOMMU, or PSP
+- no shared GPA boundary, normal interrupt injection, and secure AVIC disabled
+- base SNP policy `0x30000`; `enable_debug` adds the debug bit to produce the
+  current debug-capable policy `0xb0000`
+- an initrd and the kernel command line
+  `console=ttyS0 earlyprintk=serial earlycon panic=-1`
+- SNP C-bit position 51, which is a test-host assumption rather than a portable
+  SNP property
+
+To build it manually, create a resources file containing absolute paths:
+
+```json
+{
+    "resources": {
+        "linux_kernel": "/absolute/path/to/vmlinux-or-bzImage",
+        "linux_initrd": "/absolute/path/to/initrd"
+    }
+}
+```
+
+Then run:
+
+```bash
+cargo run -p igvmfilegen -- manifest \
+  --manifest /absolute/path/to/openvmm/vm/loader/manifests/snp-linux-direct.json \
+  --resources /absolute/path/to/snp-linux-direct-resources.json \
+  --output /absolute/path/to/snp-linux-direct.bin
+```
+
+The standard outputs are:
+
+- `snp-linux-direct.bin`
+- `snp-linux-direct.bin.map`
+- `snp-linux-direct-snp.json`

--- a/vm/loader/manifests/README.md
+++ b/vm/loader/manifests/README.md
@@ -17,6 +17,14 @@ normally creates the resource file that supplies each recipe's binary inputs.
 - SNP C-bit position 51, which is a test-host assumption rather than a portable
   SNP property
 
+The IGVM contains only the BSP VMSA, regardless of processor count. Backends
+are responsible for any AP launch state they require. Current KVM synthesizes
+and measures one additional VMSA for every AP from the reset state configured
+by `virt_kvm`. Those backend-created VMSAs are not part of the IGVM launch
+measurement, so `virt_kvm` does not submit the file's SNP ID block for a
+multi-processor KVM guest. Multi-processor KVM attestation against that ID
+block remains unsupported until KVM accepts userspace-provided VMSAs.
+
 To build it manually, create a resources file containing absolute paths:
 
 ```json

--- a/vm/loader/manifests/snp-linux-direct-multi-vp.json
+++ b/vm/loader/manifests/snp-linux-direct-multi-vp.json
@@ -1,0 +1,29 @@
+{
+    "guest_arch": "x64",
+    "guest_configs": [
+        {
+            "guest_svn": 1,
+            "max_vtl": 0,
+            "isolation_type": {
+                "snp": {
+                    "shared_gpa_boundary_bits": null,
+                    "policy": 196608,
+                    "enable_debug": true,
+                    "injection_type": "normal",
+                    "secure_avic": "disabled"
+                }
+            },
+            "image": {
+                "snp_linux_direct": {
+                    "processor_count": 2,
+                    "linux": {
+                        "use_initrd": true,
+                        "command_line": "console=ttyS0 earlyprintk=serial earlycon panic=-1"
+                    },
+                    "memory_page_count": 40960,
+                    "c_bit_position": 51
+                }
+            }
+        }
+    ]
+}

--- a/vm/loader/manifests/snp-linux-direct.json
+++ b/vm/loader/manifests/snp-linux-direct.json
@@ -1,0 +1,29 @@
+{
+    "guest_arch": "x64",
+    "guest_configs": [
+        {
+            "guest_svn": 1,
+            "max_vtl": 0,
+            "isolation_type": {
+                "snp": {
+                    "shared_gpa_boundary_bits": null,
+                    "policy": 196608,
+                    "enable_debug": true,
+                    "injection_type": "normal",
+                    "secure_avic": "disabled"
+                }
+            },
+            "image": {
+                "snp_linux_direct": {
+                    "processor_count": 1,
+                    "linux": {
+                        "use_initrd": true,
+                        "command_line": "console=ttyS0 earlyprintk=serial earlycon panic=-1"
+                    },
+                    "memory_page_count": 40960,
+                    "c_bit_position": 51
+                }
+            }
+        }
+    ]
+}

--- a/vm/loader/page_table/src/lib.rs
+++ b/vm/loader/page_table/src/lib.rs
@@ -53,3 +53,13 @@ pub enum IdentityMapSize {
     /// Identity-map the bottom 8GB
     Size8Gb,
 }
+
+impl IdentityMapSize {
+    /// The size of the identity-mapped address space in bytes.
+    pub const fn address_space_size(self) -> u64 {
+        match self {
+            Self::Size4Gb => 0x1_0000_0000,
+            Self::Size8Gb => 0x2_0000_0000,
+        }
+    }
+}

--- a/vm/loader/page_table/src/x64.rs
+++ b/vm/loader/page_table/src/x64.rs
@@ -5,6 +5,7 @@
 
 use crate::Error;
 use crate::IdentityMapSize;
+use core::ops::RangeInclusive;
 use zerocopy::FromBytes;
 use zerocopy::Immutable;
 use zerocopy::IntoBytes;
@@ -21,6 +22,13 @@ const PAGE_TABLE_ENTRY_SIZE: usize = 8;
 
 const X64_PAGE_SHIFT: u64 = 12;
 const X64_PTE_BITS: u64 = 9;
+const X64_PTE_ADDRESS_MASK: u64 = 0x000f_ffff_ffff_f000;
+const X64_PTE_ADDRESS_LAST_BIT: u8 = (u64::BITS - X64_PTE_ADDRESS_MASK.leading_zeros() - 1) as u8;
+
+/// Inclusive bit positions occupied by the physical address in an x64 page
+/// table entry.
+pub const X64_PTE_ADDRESS_BIT_RANGE: RangeInclusive<u8> =
+    X64_PAGE_SHIFT as u8..=X64_PTE_ADDRESS_LAST_BIT;
 
 /// Number of bytes in a page for X64.
 pub const X64_PAGE_SIZE: u64 = 4096;
@@ -328,8 +336,7 @@ pub struct PageTableBuilder<'a> {
 
 impl PageTableBuilderInner {
     fn get_addr_mask(&self) -> u64 {
-        const ALL_ADDR_BITS: u64 = 0x000f_ffff_ffff_f000;
-        ALL_ADDR_BITS & !self.get_confidential_mask()
+        X64_PTE_ADDRESS_MASK & !self.get_confidential_mask()
     }
 
     fn get_confidential_mask(&self) -> u64 {

--- a/vm/loader/page_table/src/x64.rs
+++ b/vm/loader/page_table/src/x64.rs
@@ -715,10 +715,7 @@ impl<'a> IdentityMapBuilder<'a> {
         };
 
         // Build PDEs that point to 2 MB pages.
-        let top_address = match params.identity_map_size {
-            IdentityMapSize::Size4Gb => 0x100000000u64,
-            IdentityMapSize::Size8Gb => 0x200000000u64,
-        };
+        let top_address = params.identity_map_size.address_space_size();
         let mut current_va = 0;
 
         while current_va < top_address {


### PR DESCRIPTION
## Why

OpenVMM needs a deterministic SEV-SNP Linux-direct IGVM that can be generated
from test artifacts without relying on an existing firmware image. This gives
the KVM and MSHV bring-up stacks a common, inspectable input and provides a
focused way to validate SNP launch measurement and VMSA generation.

## What

- Add a dedicated `snp_linux_direct` image strategy to `igvmfilegen`.
- Build a fixed x64 VTL0 SNP image from a Linux kernel and initrd, including:
  - ACPI and SMBIOS data;
  - SNP secrets and CPUID pages;
  - a `RequiredMemory` directive for the configured contiguous RAM;
  - measured page directives covering the complete RAM layout; and
  - one SNP VMSA context for the BSP; backends supply any AP launch state
    required by their hypervisor.
- Model the processor count, RAM page count, and SNP C-bit position in the
  manifest schema.
- Use `IgvmSerializer` as the source of truth for the launch digest, validate
  the serialized file by reparsing and remeasuring it, and emit a distinct
  Linux-direct SNP ID-block identity.
- Add documented one-VP and two-VP example manifests.

The initial profile is intentionally narrow: x64, VTL0, contiguous RAM starting
at GPA 0, COM1 serial, normal interrupt injection, and no VMBus, PCIe, disks,
IOMMU, or PSP device. The checked-in manifests use C-bit position 51 as a test
host assumption.

This PR deliberately emits a complete measured RAM image. Sparse RAM generation
and the measured bootshim will be introduced by later.
