### PR TITLE
Revert "openvmm_core: populate IORT for ARM64 UEFI boot (#3769)"

### DIFF
--- a/openhcl/underhill_core/src/loader/mod.rs
+++ b/openhcl/underhill_core/src/loader/mod.rs
@@ -77,6 +77,8 @@ pub enum Error {
     Finalize(#[source] vtl0_config::Error),
     #[error("invalid acpi table: too short")]
     InvalidAcpiTableLength,
+    #[error("invalid acpi table: unknown header signature {0:?}")]
+    InvalidAcpiTableSignature([u8; 4]),
     #[cfg(guest_arch = "aarch64")]
     #[error("expected GICv3 topology")]
     ExpectedGicV3,
@@ -430,11 +432,20 @@ pub fn write_uefi_config(
                 .map_err(|_| Error::InvalidAcpiTableLength)? // TODO: zerocopy: map_err (https://github.com/microsoft/openvmm/issues/759)
                 .0;
             match &header.signature {
-                b"APIC" => build_madt = false,
-                b"SRAT" => build_srat = false,
-                _ => {}
+                b"APIC" => {
+                    build_madt = false;
+                    cfg.add_raw(config::BlobStructureType::Madt, table)
+                }
+                b"HMAT" => cfg.add_raw(config::BlobStructureType::Hmat, table),
+                b"IORT" => cfg.add_raw(config::BlobStructureType::Iort, table),
+                b"MCFG" => cfg.add_raw(config::BlobStructureType::Mcfg, table),
+                b"SRAT" => {
+                    build_srat = false;
+                    cfg.add_raw(config::BlobStructureType::Srat, table)
+                }
+                b"SSDT" => cfg.add_raw(config::BlobStructureType::Ssdt, table),
+                _ => return Err(Error::InvalidAcpiTableSignature(header.signature)),
             };
-            cfg.add_raw(config::BlobStructureType::AcpiTable, table);
         }
     }
 
@@ -469,17 +480,13 @@ pub fn write_uefi_config(
 
         // Build the ACPI tables as specified.
         if build_madt {
-            cfg.add_raw(
-                config::BlobStructureType::AcpiTable,
-                &acpi_builder.build_madt(),
-            );
+            let madt = acpi_builder.build_madt();
+            cfg.add_raw(config::BlobStructureType::Madt, &madt);
         }
 
         if build_srat {
-            cfg.add_raw(
-                config::BlobStructureType::AcpiTable,
-                &acpi_builder.build_srat(),
-            );
+            let srat = acpi_builder.build_srat();
+            cfg.add_raw(config::BlobStructureType::Srat, &srat);
         }
     }
 
@@ -520,12 +527,12 @@ pub fn write_uefi_config(
         });
 
         if let Some(slit) = igvm_parameters.slit() {
-            cfg.add_raw(config::BlobStructureType::AcpiTable, slit);
+            cfg.add_raw(config::BlobStructureType::Slit, slit);
         }
 
         // TODO: reconstruct this instead of getting it from the host.
         if let Some(pptt) = igvm_parameters.pptt() {
-            cfg.add_raw(config::BlobStructureType::AcpiTable, pptt);
+            cfg.add_raw(config::BlobStructureType::Pptt, pptt);
         }
     }
 

--- a/openvmm/openvmm_core/src/worker/dispatch.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch.rs
@@ -3226,27 +3226,13 @@ impl LoadedVmInner {
                 enable_vmbus,
                 force_dma_bounce,
             } => {
-                let acpi_tables = [
-                    // MADT
-                    Some(acpi_builder.build_madt()),
-                    // SRAT
-                    Some(acpi_builder.build_srat()),
-                    // SLIT
-                    acpi_builder.build_slit(),
-                    // MCFG
-                    (!self.pcie_host_bridges.is_empty()).then(|| acpi_builder.build_mcfg()),
-                    // PPTT
-                    cache_topology.is_some().then(|| acpi_builder.build_pptt()),
-                    // IORT
-                    acpi_builder.build_iort(),
-                    // IVRS (AMD IOMMU)
-                    acpi_builder.build_ivrs(),
-                    // DMAR (Intel VT-d)
-                    acpi_builder.build_dmar(),
-                ];
-                let acpi_tables: Vec<_> =
-                    acpi_tables.iter().flatten().map(|t| t.as_ref()).collect();
-
+                let madt = acpi_builder.build_madt();
+                let srat = acpi_builder.build_srat();
+                let slit = acpi_builder.build_slit();
+                let mcfg = (!self.pcie_host_bridges.is_empty()).then(|| acpi_builder.build_mcfg());
+                let pptt = cache_topology.is_some().then(|| acpi_builder.build_pptt());
+                let ivrs = acpi_builder.build_ivrs();
+                let dmar = acpi_builder.build_dmar();
                 let load_settings = super::vm_loaders::uefi::UefiLoadSettings {
                     debugging: enable_debugging,
                     memory_protections: enable_memory_protections,
@@ -3271,7 +3257,13 @@ impl LoadedVmInner {
                         pcie_host_bridges: &self.pcie_host_bridges,
                         settings: load_settings,
                         chipset_mmio: &self.chipset_mmio,
-                        acpi_tables: &acpi_tables,
+                        madt: &madt,
+                        srat: &srat,
+                        slit: slit.as_deref(),
+                        mcfg: mcfg.as_deref(),
+                        pptt: pptt.as_deref(),
+                        ivrs: ivrs.as_deref(),
+                        dmar: dmar.as_deref(),
                     })?;
 
                 (regs, Vec::new())

--- a/openvmm/openvmm_core/src/worker/vm_loaders/uefi.rs
+++ b/openvmm/openvmm_core/src/worker/vm_loaders/uefi.rs
@@ -61,7 +61,13 @@ pub struct LoadUefiParams<'a> {
     pub pcie_host_bridges: &'a [PcieHostBridge],
     pub settings: UefiLoadSettings,
     pub chipset_mmio: &'a ChipsetMmioRanges,
-    pub acpi_tables: &'a [&'a [u8]],
+    pub madt: &'a [u8],
+    pub srat: &'a [u8],
+    pub slit: Option<&'a [u8]>,
+    pub mcfg: Option<&'a [u8]>,
+    pub pptt: Option<&'a [u8]>,
+    pub ivrs: Option<&'a [u8]>,
+    pub dmar: Option<&'a [u8]>,
 }
 
 /// Loads the UEFI firmware.
@@ -74,7 +80,13 @@ pub fn load_uefi(params: &LoadUefiParams<'_>) -> Result<Vec<Register>, Error> {
         pcie_host_bridges,
         ref settings,
         chipset_mmio,
-        acpi_tables,
+        madt,
+        srat,
+        slit,
+        mcfg,
+        pptt,
+        ivrs,
+        dmar,
     } = *params;
 
     let mut loaded_image;
@@ -142,6 +154,8 @@ pub fn load_uefi(params: &LoadUefiParams<'_>) -> Result<Vec<Register>, Error> {
         bios_size_pages: (IMAGE_SIZE / HV_PAGE_SIZE) as u32,
         flags: 0,
     })
+    .add_raw(config::BlobStructureType::Madt, madt)
+    .add_raw(config::BlobStructureType::Srat, srat)
     .add_raw(config::BlobStructureType::MemoryMap, memory_map.as_bytes())
     .add(&config::BiosGuid(settings.bios_guid))
     .add(&config::Entropy(entropy))
@@ -183,14 +197,30 @@ pub fn load_uefi(params: &LoadUefiParams<'_>) -> Result<Vec<Register>, Error> {
         });
     }
 
-    for table in acpi_tables {
-        cfg.add_raw(config::BlobStructureType::AcpiTable, table);
+    if let Some(mcfg) = mcfg {
+        cfg.add_raw(config::BlobStructureType::Mcfg, mcfg);
+    }
+
+    if let Some(slit) = slit {
+        cfg.add_raw(config::BlobStructureType::Slit, slit);
+    }
+
+    if let Some(pptt) = pptt {
+        cfg.add_raw(config::BlobStructureType::Pptt, pptt);
+    }
+
+    if let Some(ivrs) = ivrs {
+        cfg.add_raw(config::BlobStructureType::AcpiTable, ivrs);
+    }
+
+    if let Some(dmar) = dmar {
+        cfg.add_raw(config::BlobStructureType::AcpiTable, dmar);
     }
 
     if !pcie_host_bridges.is_empty() {
         let pcie_tables = vmm_core::acpi_builder::build_pcie_acpi_tables(pcie_host_bridges)
             .map_err(Error::PcieAcpi)?;
-        cfg.add_raw(config::BlobStructureType::AcpiTable, &pcie_tables.ssdt);
+        cfg.add_raw(config::BlobStructureType::Ssdt, &pcie_tables.ssdt);
         if let Some(cedt) = pcie_tables.cedt {
             cfg.add_raw(config::BlobStructureType::AcpiTable, &cedt);
         }

--- a/vm/loader/src/uefi/config.rs
+++ b/vm/loader/src/uefi/config.rs
@@ -146,7 +146,6 @@ blobtypes! {
 pub enum BlobStructureType {
     StructureCount = 0x00,
     BiosInformation = 0x01,
-    #[deprecated(note = "use AcpiTable")]
     Srat = 0x02,
     MemoryMap = 0x03,
     Entropy = 0x04,
@@ -169,7 +168,6 @@ pub enum BlobStructureType {
     Aarch64Mpidr = 0x15,
     AcpiTable = 0x16,
     NvdimmCount = 0x17,
-    #[deprecated(note = "use AcpiTable")]
     Madt = 0x18,
     VpciInstanceFilter = 0x19,
     SmbiosSystemManufacturer = 0x1A,
@@ -178,20 +176,13 @@ pub enum BlobStructureType {
     SmbiosSystemSkuNumber = 0x1D,
     SmbiosSystemFamily = 0x1E,
     SmbiosMemoryDeviceSerialNumber = 0x1F,
-    #[deprecated(note = "use AcpiTable")]
     Slit = 0x20,
-    #[deprecated(note = "use AcpiTable")]
     Aspt = 0x21,
-    #[deprecated(note = "use AcpiTable")]
     Pptt = 0x22,
     Gic = 0x23,
-    #[deprecated(note = "use AcpiTable")]
     Mcfg = 0x24,
-    #[deprecated(note = "use AcpiTable")]
     Ssdt = 0x25,
-    #[deprecated(note = "use AcpiTable")]
     Hmat = 0x26,
-    #[deprecated(note = "use AcpiTable")]
     Iort = 0x27,
     PcieBarApertures = 0x28,
 }
@@ -469,7 +460,7 @@ mod tests {
 
         let data = {
             let mut blob = Blob::new();
-            blob.add_raw(BlobStructureType::AcpiTable, &madt);
+            blob.add_raw(BlobStructureType::Madt, &madt);
             blob.complete()
         };
 
@@ -504,7 +495,7 @@ mod tests {
         let structure = &data[2 * size_of::<Header>() + size_of::<StructureCount>()..][..length];
 
         let header_exp = Header {
-            structure_type: 0x16,
+            structure_type: 0x18,
             length: (size_of::<Header>() + padded_length) as u32,
         };
         let structure_exp = &madt[..];
@@ -629,8 +620,7 @@ mod tests {
 
         let data = {
             let mut blob = Blob::new();
-            blob.add_raw(BlobStructureType::AcpiTable, &madt)
-                .add(&procinfo);
+            blob.add_raw(BlobStructureType::Madt, &madt).add(&procinfo);
             blob.complete()
         };
 
@@ -668,7 +658,7 @@ mod tests {
             [..PADDED_LENGTH - LENGTH];
 
         let header_exp = Header {
-            structure_type: 0x16,
+            structure_type: 0x18,
             length: (size_of::<Header>() + PADDED_LENGTH) as u32,
         };
         let structure_exp = &madt[..];


### PR DESCRIPTION
This reverts commit 9dec36dad09c11fd5e40d2bed4c9fde0c0a23cc1 on release/1.8.2607.

The IORT population and the migration to deprecated-blob-free ACPI table plumbing are reverted. Later IVRS/DMAR UEFI support (#3824) is preserved by passing those tables through as generic AcpiTable blobs.