### PR TITLE
cvm: improve boot times by parallelize applying vtl protections and zeroing memory

### DIFF
--- a/openhcl/underhill_mem/src/init.rs
+++ b/openhcl/underhill_mem/src/init.rs
@@ -141,7 +141,7 @@ pub async fn init(params: &Init<'_>) -> anyhow::Result<MemoryMappings> {
                 let accepted_ram: Vec<_> =
                     memory_range::overlapping_ranges(ram.clone(), accepted_ranges.clone())
                         .collect();
-                parallelize_mem_op(accepted_ram.iter().copied(), vp_count, |range| {
+                parallelize_mem_op(&accepted_ram, vp_count, |range| {
                     acceptor.apply_initial_lower_vtl_protections(range)
                 })?;
             }
@@ -165,8 +165,8 @@ pub async fn init(params: &Init<'_>) -> anyhow::Result<MemoryMappings> {
                 memory_range::subtract_ranges(ram, accepted_ranges).collect::<Vec<_>>();
             validated_ranges.extend_from_slice(&source_ranges);
 
-            parallelize_mem_op(source_ranges.iter().copied(), vp_count, accept_subrange)
-                .unwrap_or_else(|err| panic!("accepting VTL0 memory failed: {err}"));
+            parallelize_mem_op(&source_ranges, vp_count, accept_subrange)
+                .expect("accepting VTL0 memory should not fail");
         }
     }
 
@@ -424,10 +424,10 @@ pub async fn init(params: &Init<'_>) -> anyhow::Result<MemoryMappings> {
                 tracing::info_span!("zeroing lower vtl memory for SNP", CVM_ALLOWED).entered();
 
             tracing::debug!("zeroing lower vtl memory for SNP");
-            parallelize_mem_op(validated_ranges.iter().copied(), vp_count, |range| {
+            parallelize_mem_op(&validated_ranges, vp_count, |range| {
                 vtl0_gm.fill_at(range.start(), 0, range.len() as usize)
             })
-            .unwrap_or_else(|err| panic!("private memory should be valid at this stage: {err}"));
+            .expect("private memory should be valid at this stage");
         }
 
         // Untrusted devices can only access shared memory, but they can do so

--- a/openhcl/underhill_mem/src/init.rs
+++ b/openhcl/underhill_mem/src/init.rs
@@ -144,25 +144,23 @@ pub async fn init(params: &Init<'_>) -> anyhow::Result<MemoryMappings> {
 
             // Accept the memory that was not accepted by the boot loader.
             // FUTURE: do this lazily.
-            let vp_count = std::cmp::max(1, params.processor_topology.vp_count() - 1);
-            let accept_subrange = move |subrange| {
-                acceptor.accept_lower_vtl_pages(subrange).unwrap();
+            let vp_count = params.processor_topology.vp_count();
+            let accept_subrange = move |subrange| -> anyhow::Result<()> {
+                acceptor.accept_lower_vtl_pages(subrange)?;
                 if hardware_isolated {
                     // For VBS-isolated VMs, the VTL protections are set as
                     // part of the accept call.
-                    acceptor
-                        .apply_initial_lower_vtl_protections(subrange)
-                        .unwrap();
+                    acceptor.apply_initial_lower_vtl_protections(subrange)?;
                 }
+                Ok(())
             };
             tracing::debug!("Accepting VTL0 memory");
-            std::thread::scope(|scope| {
-                for source_range in memory_range::subtract_ranges(ram, accepted_ranges) {
-                    validated_ranges.push(source_range);
 
-                    parallelize_mem_op(source_range, vp_count, scope, accept_subrange);
-                }
-            });
+            let source_ranges =
+                memory_range::subtract_ranges(ram, accepted_ranges).collect::<Vec<_>>();
+            validated_ranges.extend_from_slice(&source_ranges);
+
+            parallelize_mem_op(&source_ranges, vp_count, accept_subrange).unwrap();
         }
     }
 

--- a/openhcl/underhill_mem/src/init.rs
+++ b/openhcl/underhill_mem/src/init.rs
@@ -9,6 +9,7 @@ use crate::mapping::GuestMemoryMapping;
 use crate::mapping::GuestMemoryView;
 use crate::mapping::GuestMemoryViewReadType;
 use crate::mapping::GuestPartitionMemoryView;
+use crate::parallelize_mem_op;
 use anyhow::Context;
 use cvm_tracing::CVM_ALLOWED;
 use futures::future::try_join_all;
@@ -159,34 +160,7 @@ pub async fn init(params: &Init<'_>) -> anyhow::Result<MemoryMappings> {
                 for source_range in memory_range::subtract_ranges(ram, accepted_ranges) {
                     validated_ranges.push(source_range);
 
-                    // Chunks must be 2mb aligned
-                    let two_mb = 2 * 1024 * 1024;
-                    let mut range = source_range.aligned_subrange(two_mb);
-                    if !range.is_empty() {
-                        let chunk_size = (range.page_count_2m().div_ceil(vp_count as u64)) * two_mb;
-                        let chunk_count = range.len().div_ceil(chunk_size);
-
-                        for _ in 0..chunk_count {
-                            let subrange;
-                            (subrange, range) = if range.len() >= chunk_size {
-                                range.split_at_offset(chunk_size)
-                            } else {
-                                (range, MemoryRange::EMPTY)
-                            };
-                            scope.spawn(move || accept_subrange(subrange));
-                        }
-                        assert!(range.is_empty());
-                    }
-
-                    // Now accept whatever wasn't aligned on the edges
-                    scope.spawn(move || {
-                        for unaligned_subrange in memory_range::subtract_ranges(
-                            [source_range],
-                            [source_range.aligned_subrange(two_mb)],
-                        ) {
-                            accept_subrange(unaligned_subrange);
-                        }
-                    });
+                    parallelize_mem_op(source_range, vp_count, scope, accept_subrange);
                 }
             });
         }

--- a/openhcl/underhill_mem/src/init.rs
+++ b/openhcl/underhill_mem/src/init.rs
@@ -141,7 +141,7 @@ pub async fn init(params: &Init<'_>) -> anyhow::Result<MemoryMappings> {
                 let accepted_ram: Vec<_> =
                     memory_range::overlapping_ranges(ram.clone(), accepted_ranges.clone())
                         .collect();
-                parallelize_mem_op(accepted_ram.as_slice(), vp_count, |range| {
+                parallelize_mem_op(accepted_ram.iter().copied(), vp_count, |range| {
                     acceptor.apply_initial_lower_vtl_protections(range)
                 })?;
             }
@@ -165,7 +165,8 @@ pub async fn init(params: &Init<'_>) -> anyhow::Result<MemoryMappings> {
                 memory_range::subtract_ranges(ram, accepted_ranges).collect::<Vec<_>>();
             validated_ranges.extend_from_slice(&source_ranges);
 
-            parallelize_mem_op(&source_ranges, vp_count, accept_subrange).unwrap();
+            parallelize_mem_op(source_ranges.iter().copied(), vp_count, accept_subrange)
+                .unwrap_or_else(|err| panic!("accepting VTL0 memory failed: {err}"));
         }
     }
 
@@ -355,6 +356,7 @@ pub async fn init(params: &Init<'_>) -> anyhow::Result<MemoryMappings> {
             vtl0_mapping.clone(),
             params.mem_layout.clone(),
             acceptor.as_ref().unwrap().clone(),
+            params.processor_topology.vp_count(),
         )) as Arc<dyn ProtectIsolatedMemory>;
 
         tracing::debug!("Creating VTL0 guest memory");
@@ -422,10 +424,10 @@ pub async fn init(params: &Init<'_>) -> anyhow::Result<MemoryMappings> {
                 tracing::info_span!("zeroing lower vtl memory for SNP", CVM_ALLOWED).entered();
 
             tracing::debug!("zeroing lower vtl memory for SNP");
-            parallelize_mem_op(&validated_ranges, vp_count, |range| {
+            parallelize_mem_op(validated_ranges.iter().copied(), vp_count, |range| {
                 vtl0_gm.fill_at(range.start(), 0, range.len() as usize)
             })
-            .expect("private memory should be valid at this stage");
+            .unwrap_or_else(|err| panic!("private memory should be valid at this stage: {err}"));
         }
 
         // Untrusted devices can only access shared memory, but they can do so

--- a/openhcl/underhill_mem/src/init.rs
+++ b/openhcl/underhill_mem/src/init.rs
@@ -113,6 +113,8 @@ pub async fn init(params: &Init<'_>) -> anyhow::Result<MemoryMappings> {
         None
     };
 
+    let vp_count = params.processor_topology.vp_count();
+
     let hardware_isolated = params.isolation.is_hardware_isolated();
 
     if let Some(boot_init) = &params.boot_init {
@@ -136,21 +138,24 @@ pub async fn init(params: &Init<'_>) -> anyhow::Result<MemoryMappings> {
             // VTL2 only permissions. Provide VTL0 access here.
             tracing::debug!("Applying VTL0 protections");
             if hardware_isolated {
-                for range in memory_range::overlapping_ranges(ram.clone(), accepted_ranges.clone())
-                {
-                    acceptor.apply_initial_lower_vtl_protections(range)?;
-                }
+                let accepted_ram: Vec<_> =
+                    memory_range::overlapping_ranges(ram.clone(), accepted_ranges.clone())
+                        .collect();
+                parallelize_mem_op(accepted_ram.as_slice(), vp_count, |range| {
+                    acceptor.apply_initial_lower_vtl_protections(range)
+                })?;
             }
 
             // Accept the memory that was not accepted by the boot loader.
             // FUTURE: do this lazily.
-            let vp_count = params.processor_topology.vp_count();
-            let accept_subrange = move |subrange| -> anyhow::Result<()> {
-                acceptor.accept_lower_vtl_pages(subrange)?;
+            let accept_subrange = move |subrange| -> Result<(), std::convert::Infallible> {
+                acceptor.accept_lower_vtl_pages(subrange).unwrap();
                 if hardware_isolated {
                     // For VBS-isolated VMs, the VTL protections are set as
                     // part of the accept call.
-                    acceptor.apply_initial_lower_vtl_protections(subrange)?;
+                    acceptor
+                        .apply_initial_lower_vtl_protections(subrange)
+                        .unwrap();
                 }
                 Ok(())
             };
@@ -244,8 +249,17 @@ pub async fn init(params: &Init<'_>) -> anyhow::Result<MemoryMappings> {
         // that devices will do DMA to them.
         let shared_offset = match params.isolation {
             IsolationType::Tdx => {
-                // TDX has one mapping for each page. The shared bit is reserved
-                // from the kernel's perspective, so no VA offset is needed.
+                // Register memory just once, as shared memory. This
+                // registration will be used both to map pages as shared and as
+                // encrypted. If the kernel remaps a page into a kernel address,
+                // it will be marked as shared, which can cause a fault or,
+                // worse, an information leak.
+                //
+                // This is done this way because in TDX, there is only one
+                // mapping for each page. The distinguishing bit is a reserved
+                // bit, from the kernel's perspective. (You can also just see it
+                // as the high bit of the GPA, but the Linux kernel does not
+                // treat it that way.)
                 //
                 // TODO CVM: figure out how to prevent passing encrypted pages
                 // to syscalls. Idea: prohibit locking of `GuestMemory` pages
@@ -257,8 +271,20 @@ pub async fn init(params: &Init<'_>) -> anyhow::Result<MemoryMappings> {
                 0
             }
             IsolationType::Snp | IsolationType::Cca => {
-                // SNP and CCA map shared pages above VTOM, separately from the
-                // private mapping below VTOM.
+                // SNP and CCA have two mappings for each shared page: one below
+                // and one above VTOM. So, unlike for TDX, we could choose to
+                // register memory twice, allowing the kernel to operate on
+                // either shared or encrypted memory. But, for consistency with
+                // TDX, just register the shared mapping.
+                //
+                // Register the VTOM mapping instead of the low mapping. In
+                // theory it shouldn't matter; we should be able to ignore VTOM.
+                // However, the ioctls to issue pvalidate and rmpadjust
+                // instructions operate on VAs, and they must either be VAs
+                // mapping unregistered pages or pages that were registered as
+                // encrypted. Since we want to avoid registering the pages as
+                // encrypted, the lower alias must remain unregistered, and so
+                // the shared registration must use the high mapping.
                 vtom
             }
             _ => unreachable!(),
@@ -396,11 +422,10 @@ pub async fn init(params: &Init<'_>) -> anyhow::Result<MemoryMappings> {
                 tracing::info_span!("zeroing lower vtl memory for SNP", CVM_ALLOWED).entered();
 
             tracing::debug!("zeroing lower vtl memory for SNP");
-            for range in validated_ranges {
-                vtl0_gm
-                    .fill_at(range.start(), 0, range.len() as usize)
-                    .expect("private memory should be valid at this stage");
-            }
+            parallelize_mem_op(&validated_ranges, vp_count, |range| {
+                vtl0_gm.fill_at(range.start(), 0, range.len() as usize)
+            })
+            .expect("private memory should be valid at this stage");
         }
 
         // Untrusted devices can only access shared memory, but they can do so

--- a/openhcl/underhill_mem/src/init.rs
+++ b/openhcl/underhill_mem/src/init.rs
@@ -198,9 +198,9 @@ pub async fn init(params: &Init<'_>) -> anyhow::Result<MemoryMappings> {
 
         // Create the encrypted mapping with just the lower VTL memory.
         //
-        // Do not register this mapping with the kernel. It will not be safe for
-        // use with syscalls that expect virtual addresses to be in
-        // kernel-registered RAM.
+        // Do not register this mapping object with the kernel. SNP registration
+        // is associated with the separate VTL0 mapping below after every lower
+        // VTL mapping has been established.
 
         tracing::debug!("Building valid encrypted memory view");
         let encrypted_memory_view = {
@@ -227,31 +227,25 @@ pub async fn init(params: &Init<'_>) -> anyhow::Result<MemoryMappings> {
         // TODO GUEST VSM: with lazy acceptance, it should instead be initialized to no
         // access.
         tracing::debug!("Building VTL0 memory map");
-        let vtl0_mapping = Arc::new({
+        let vtl0_mapping = {
             let _span = tracing::info_span!("map_vtl0_memory", CVM_ALLOWED).entered();
             GuestMemoryMapping::builder(0)
                 .dma_base_address(None)
+                // Configure the registrar now, but do not register until all
+                // aliases have been mapped.
+                .for_kernel_access(params.isolation == IsolationType::Snp)
                 .use_permissions_bitmaps(if use_vtl1 { Some(true) } else { None })
                 .build_with_bitmap(&gpa_fd, &encrypted_memory_view)
                 .context("failed to map vtl0 memory")?
-        });
+        };
 
         // Create the shared mapping with the complete memory map, to include
         // the shared pool. This memory is not private to VTL2 and is expected
         // that devices will do DMA to them.
         let shared_offset = match params.isolation {
             IsolationType::Tdx => {
-                // Register memory just once, as shared memory. This
-                // registration will be used both to map pages as shared and as
-                // encrypted. If the kernel remaps a page into a kernel address,
-                // it will be marked as shared, which can cause a fault or,
-                // worse, an information leak.
-                //
-                // This is done this way because in TDX, there is only one
-                // mapping for each page. The distinguishing bit is a reserved
-                // bit, from the kernel's perspective. (You can also just see it
-                // as the high bit of the GPA, but the Linux kernel does not
-                // treat it that way.)
+                // TDX has one mapping for each page. The shared bit is reserved
+                // from the kernel's perspective, so no VA offset is needed.
                 //
                 // TODO CVM: figure out how to prevent passing encrypted pages
                 // to syscalls. Idea: prohibit locking of `GuestMemory` pages
@@ -263,20 +257,8 @@ pub async fn init(params: &Init<'_>) -> anyhow::Result<MemoryMappings> {
                 0
             }
             IsolationType::Snp | IsolationType::Cca => {
-                // SNP and CCA have two mappings for each shared page: one below
-                // and one above VTOM. So, unlike for TDX, we could choose to
-                // register memory twice, allowing the kernel to operate on
-                // either shared or encrypted memory. But, for consistency with
-                // TDX, just register the shared mapping.
-                //
-                // Register the VTOM mapping instead of the low mapping. In
-                // theory it shouldn't matter; we should be able to ignore VTOM.
-                // However, the ioctls to issue pvalidate and rmpadjust
-                // instructions operate on VAs, and they must either be VAs
-                // mapping unregistered pages or pages that were registered as
-                // encrypted. Since we want to avoid registering the pages as
-                // encrypted, the lower alias must remain unregistered, and so
-                // the shared registration must use the high mapping.
+                // SNP and CCA map shared pages above VTOM, separately from the
+                // private mapping below VTOM.
                 vtom
             }
             _ => unreachable!(),
@@ -329,6 +311,16 @@ pub async fn init(params: &Init<'_>) -> anyhow::Result<MemoryMappings> {
                 .build_with_bitmap(&gpa_fd, &shared_memory_view)
                 .context("failed to map shared memory")?
         });
+
+        if params.isolation == IsolationType::Snp {
+            // The kernel can now create PUD-sized backing for aligned 1-GB
+            // ranges before the zeroing pass faults in the private mapping.
+            let _span = tracing::info_span!("register_vtl0_memory", CVM_ALLOWED).entered();
+            vtl0_mapping
+                .register_all_memory()
+                .context("failed to eagerly register SNP VTL0 memory")?;
+        }
+        let vtl0_mapping = Arc::new(vtl0_mapping);
 
         let protector = Arc::new(HardwareIsolatedMemoryProtector::new(
             encrypted_memory_view.partition_valid_memory().clone(),

--- a/openhcl/underhill_mem/src/lib.rs
+++ b/openhcl/underhill_mem/src/lib.rs
@@ -45,7 +45,6 @@ use registrar::RegisterMemory;
 use std::collections::VecDeque;
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
-use std::time::Instant;
 use thiserror::Error;
 use virt::IsolationType;
 use virt_mshv_vtl::GpnSource;
@@ -468,25 +467,12 @@ impl HardwareIsolatedMemoryProtector {
             // Only permissions imposed on VTL 0 guest memory are explicitly tracked
             // let start = Instant::now();
             self.vtl0.update_permission_bitmaps(range, protections);
-            // tracing::info!(
-            //     CVM_ALLOWED,
-            //     ?range,
-            //     ?target_vtl,
-            //     elapsed = ?start.elapsed(),
-            //     "updated VTL permission bitmaps"
-            // );
         }
-        // let start = Instant::now();
+
         let result = self
             .acceptor
             .apply_protections(range, target_vtl, protections);
-        // tracing::info!(
-        //     CVM_ALLOWED,
-        //     ?range,
-        //     ?target_vtl,
-        //     elapsed = ?start.elapsed(),
-        //     "applied VTL protections"
-        // );
+
         result
     }
 
@@ -863,128 +849,53 @@ impl ProtectIsolatedMemory for HardwareIsolatedMemoryProtector {
             }
         }
 
-        // Apply default protections to overlay pages first
-        {
-            const BITMAP_BYTE_GRANULARITY: u64 = PAGE_SIZE as u64 * 8; // TODO: don't magic number this
+        tracing::trace!("Applying default vtl protections.");
 
-            let _span =
-                tracing::info_span!("applying default vtl protections", CVM_ALLOWED).entered();
-            tracing::info!("logging applying default vtl protections");
-            let mut aligned_ranges = Vec::new();
+        let protect_subrange = move |subrange: MemoryRange| {
+            self.apply_protections(
+                subrange,
+                target_vtl,
+                vtl_protections,
+                GpnSource::GuestMemory,
+            )
+            .unwrap();
+        };
 
-            let _permission_bitmap_lock = (target_vtl == GuestVtl::Vtl0)
-                .then(|| self.vtl0.lock_permission_bitmaps())
-                .flatten();
+        // Handle overlay pages first
+        for source_range in ranges {
+            let mut range_queue = VecDeque::new();
+            range_queue.push_back(source_range);
 
-            let protect_subrange = move |subrange: MemoryRange| {
-                ////////
-                // self.apply_protections(
-                //     subrange,
-                //     target_vtl,
-                //     vtl_protections,
-                //     GpnSource::GuestMemory,
-                // )
-                // .unwrap();
-                ////////
-
-                if target_vtl == GuestVtl::Vtl0 {
-                    // let start = Instant::now();
-                    self.vtl0
-                        .update_permission_bitmaps_locked(subrange, vtl_protections);
-                    // tracing::info!(
-                    //     CVM_ALLOWED,
-                    //     range = ?subrange,
-                    //     ?target_vtl,
-                    //     elapsed = ?start.elapsed(),
-                    //     "updated VTL permission bitmaps"
-                    // );
+            'outer: while let Some(range) = range_queue.pop_front() {
+                for overlay_page in inner.overlay_pages[target_vtl].iter_mut() {
+                    let overlay_addr = overlay_page.gpn * HV_PAGE_SIZE;
+                    if range.contains_addr(overlay_addr) {
+                        // If the overlay page is within the range, update the
+                        // permissions that will be restored when it is unlocked.
+                        overlay_page.previous_permissions = vtl_protections;
+                        // And split the range around it.
+                        let (left, right_with_overlay) =
+                            range.split_at_offset(range.offset_of(overlay_addr).unwrap());
+                        let (overlay, right) = right_with_overlay.split_at_offset(HV_PAGE_SIZE);
+                        debug_assert_eq!(overlay.start_4k_gpn(), overlay_page.gpn);
+                        debug_assert_eq!(overlay.len(), HV_PAGE_SIZE);
+                        if !left.is_empty() {
+                            range_queue.push_back(left);
+                        }
+                        if !right.is_empty() {
+                            range_queue.push_back(right);
+                        }
+                        continue 'outer;
+                    }
                 }
 
-                // let start = Instant::now();
-                let result = self
-                    .acceptor
-                    .apply_protections(subrange, target_vtl, vtl_protections);
-                // tracing::info!(
-                //     CVM_ALLOWED,
-                //     range = ?subrange,
-                //     ?target_vtl,
-                //     elapsed = ?start.elapsed(),
-                //     "applied VTL protections"
-                // );
-                result.unwrap();
-            };
-
-            // tracing::info!("handling overlay pages for default vtl protections");
-            for source_range in ranges {
-                let mut range_queue = VecDeque::new();
-                range_queue.push_back(source_range);
-
-                'outer: while let Some(range) = range_queue.pop_front() {
-                    for overlay_page in inner.overlay_pages[target_vtl].iter_mut() {
-                        let overlay_addr = overlay_page.gpn * HV_PAGE_SIZE;
-                        if range.contains_addr(overlay_addr) {
-                            // If the overlay page is within the range, update the
-                            // permissions that will be restored when it is unlocked.
-                            overlay_page.previous_permissions = vtl_protections;
-                            // And split the range around it.
-                            let (left, right_with_overlay) =
-                                range.split_at_offset(range.offset_of(overlay_addr).unwrap());
-                            let (overlay, right) = right_with_overlay.split_at_offset(HV_PAGE_SIZE);
-                            debug_assert_eq!(overlay.start_4k_gpn(), overlay_page.gpn);
-                            debug_assert_eq!(overlay.len(), HV_PAGE_SIZE);
-                            if !left.is_empty() {
-                                range_queue.push_back(left);
-                            }
-                            if !right.is_empty() {
-                                range_queue.push_back(right);
-                            }
-                            continue 'outer;
-                        }
-                    }
-
-                    ///////////////
-                    // std::thread::scope(|scope| {
-                    //     parallelize_mem_op(range, thread_count, scope, protect_subrange);
-                    // });
-                    ///////////////
-
-                    let aligned = range.aligned_subrange(BITMAP_BYTE_GRANULARITY);
-                    for unaligned in memory_range::subtract_ranges([range], [aligned]) {
-                        if unaligned.is_empty() {
-                            continue;
-                        }
-
-                        // tracing::info!(
-                        //     "applying default vtl protections to unaligned range: {:?}",
-                        //     unaligned
-                        // );
-                        protect_subrange(unaligned);
-                        // tracing::info!(
-                        //     "finished applying default vtl protections to unaligned range: {:?}",
-                        //     unaligned
-                        // );
-                    }
-
-                    if !aligned.is_empty() {
-                        aligned_ranges.push(aligned);
-                    }
-                }
-            }
-            // tracing::info!("finished handling overlay pages for default vtl protections");
-
-            // tracing::info!("applying default vtl protections to aligned ranges in parallel");
-            std::thread::scope(|scope| {
-                for range in aligned_ranges {
+                std::thread::scope(|scope| {
                     parallelize_mem_op(range, thread_count, scope, protect_subrange);
-                }
-            });
-            // tracing::info!(
-            //     "finished applying default vtl protections to aligned ranges in parallel"
-            // );
-
-            tracing::info!("logging finished applying default vtl protections");
+                });
+            }
         }
-        // tracing::debug!("Finished applying default vtl protections");
+
+        tracing::debug!("Finished applying default vtl protections.");
 
         // Flush any threads accessing pages that had their VTL protections
         // changed.

--- a/openhcl/underhill_mem/src/lib.rs
+++ b/openhcl/underhill_mem/src/lib.rs
@@ -45,6 +45,7 @@ use registrar::RegisterMemory;
 use std::collections::VecDeque;
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
+use std::time::Instant;
 use thiserror::Error;
 use virt::IsolationType;
 use virt_mshv_vtl::GpnSource;
@@ -453,46 +454,9 @@ impl HardwareIsolatedMemoryProtector {
         }
     }
 
-    fn apply_protections_with_overlay_handling(
-        &self,
-        range: MemoryRange,
-        target_vtl: GuestVtl,
-        protections: HvMapGpaFlags,
-        inner: &mut MutexGuard<'_, HardwareIsolatedMemoryProtectorInner>,
-    ) -> Result<(), ApplyVtlProtectionsError> {
-        let mut range_queue = VecDeque::new();
-        range_queue.push_back(range);
-
-        'outer: while let Some(range) = range_queue.pop_front() {
-            for overlay_page in inner.overlay_pages[target_vtl].iter_mut() {
-                let overlay_addr = overlay_page.gpn * HV_PAGE_SIZE;
-                if range.contains_addr(overlay_addr) {
-                    // If the overlay page is within the range, update the
-                    // permissions that will be restored when it is unlocked.
-                    overlay_page.previous_permissions = protections;
-                    // And split the range around it.
-                    let (left, right_with_overlay) =
-                        range.split_at_offset(range.offset_of(overlay_addr).unwrap());
-                    let (overlay, right) = right_with_overlay.split_at_offset(HV_PAGE_SIZE);
-                    debug_assert_eq!(overlay.start_4k_gpn(), overlay_page.gpn);
-                    debug_assert_eq!(overlay.len(), HV_PAGE_SIZE);
-                    if !left.is_empty() {
-                        range_queue.push_back(left);
-                    }
-                    if !right.is_empty() {
-                        range_queue.push_back(right);
-                    }
-                    continue 'outer;
-                }
-            }
-            // We can only reach here if the range does not contain any overlay
-            // pages, so now we can apply the protections to the range.
-            self.apply_protections(range, target_vtl, protections, GpnSource::GuestMemory)?
-        }
-
-        Ok(())
-    }
-
+    /// Apply the given protections to the given range for the given VTL.
+    /// Overlay page permissions are tracked separately; those permissions are
+    /// not updated here.
     fn apply_protections(
         &self,
         range: MemoryRange,
@@ -502,10 +466,28 @@ impl HardwareIsolatedMemoryProtector {
     ) -> Result<(), ApplyVtlProtectionsError> {
         if gpn_source == GpnSource::GuestMemory && target_vtl == GuestVtl::Vtl0 {
             // Only permissions imposed on VTL 0 guest memory are explicitly tracked
+            // let start = Instant::now();
             self.vtl0.update_permission_bitmaps(range, protections);
+            // tracing::info!(
+            //     CVM_ALLOWED,
+            //     ?range,
+            //     ?target_vtl,
+            //     elapsed = ?start.elapsed(),
+            //     "updated VTL permission bitmaps"
+            // );
         }
-        self.acceptor
-            .apply_protections(range, target_vtl, protections)
+        // let start = Instant::now();
+        let result = self
+            .acceptor
+            .apply_protections(range, target_vtl, protections);
+        // tracing::info!(
+        //     CVM_ALLOWED,
+        //     ?range,
+        //     ?target_vtl,
+        //     elapsed = ?start.elapsed(),
+        //     "applied VTL protections"
+        // );
+        result
     }
 
     /// Get the permissions that the given VTL has to the given GPN.
@@ -835,6 +817,7 @@ impl ProtectIsolatedMemory for HardwareIsolatedMemoryProtector {
         target_vtl: GuestVtl,
         vtl_protections: HvMapGpaFlags,
         tlb_access: &mut dyn TlbFlushLockAccess,
+        thread_count: u32,
     ) -> Result<(), HvError> {
         // Prevent visibility changes while VTL protections are being
         // applied.
@@ -880,15 +863,128 @@ impl ProtectIsolatedMemory for HardwareIsolatedMemoryProtector {
             }
         }
 
-        for range in ranges {
-            self.apply_protections_with_overlay_handling(
-                range,
-                target_vtl,
-                vtl_protections,
-                &mut inner,
-            )
-            .unwrap();
+        // Apply default protections to overlay pages first
+        {
+            const BITMAP_BYTE_GRANULARITY: u64 = PAGE_SIZE as u64 * 8; // TODO: don't magic number this
+
+            let _span =
+                tracing::info_span!("applying default vtl protections", CVM_ALLOWED).entered();
+            tracing::info!("logging applying default vtl protections");
+            let mut aligned_ranges = Vec::new();
+
+            let _permission_bitmap_lock = (target_vtl == GuestVtl::Vtl0)
+                .then(|| self.vtl0.lock_permission_bitmaps())
+                .flatten();
+
+            let protect_subrange = move |subrange: MemoryRange| {
+                ////////
+                // self.apply_protections(
+                //     subrange,
+                //     target_vtl,
+                //     vtl_protections,
+                //     GpnSource::GuestMemory,
+                // )
+                // .unwrap();
+                ////////
+
+                if target_vtl == GuestVtl::Vtl0 {
+                    // let start = Instant::now();
+                    self.vtl0
+                        .update_permission_bitmaps_locked(subrange, vtl_protections);
+                    // tracing::info!(
+                    //     CVM_ALLOWED,
+                    //     range = ?subrange,
+                    //     ?target_vtl,
+                    //     elapsed = ?start.elapsed(),
+                    //     "updated VTL permission bitmaps"
+                    // );
+                }
+
+                // let start = Instant::now();
+                let result = self
+                    .acceptor
+                    .apply_protections(subrange, target_vtl, vtl_protections);
+                // tracing::info!(
+                //     CVM_ALLOWED,
+                //     range = ?subrange,
+                //     ?target_vtl,
+                //     elapsed = ?start.elapsed(),
+                //     "applied VTL protections"
+                // );
+                result.unwrap();
+            };
+
+            // tracing::info!("handling overlay pages for default vtl protections");
+            for source_range in ranges {
+                let mut range_queue = VecDeque::new();
+                range_queue.push_back(source_range);
+
+                'outer: while let Some(range) = range_queue.pop_front() {
+                    for overlay_page in inner.overlay_pages[target_vtl].iter_mut() {
+                        let overlay_addr = overlay_page.gpn * HV_PAGE_SIZE;
+                        if range.contains_addr(overlay_addr) {
+                            // If the overlay page is within the range, update the
+                            // permissions that will be restored when it is unlocked.
+                            overlay_page.previous_permissions = vtl_protections;
+                            // And split the range around it.
+                            let (left, right_with_overlay) =
+                                range.split_at_offset(range.offset_of(overlay_addr).unwrap());
+                            let (overlay, right) = right_with_overlay.split_at_offset(HV_PAGE_SIZE);
+                            debug_assert_eq!(overlay.start_4k_gpn(), overlay_page.gpn);
+                            debug_assert_eq!(overlay.len(), HV_PAGE_SIZE);
+                            if !left.is_empty() {
+                                range_queue.push_back(left);
+                            }
+                            if !right.is_empty() {
+                                range_queue.push_back(right);
+                            }
+                            continue 'outer;
+                        }
+                    }
+
+                    ///////////////
+                    // std::thread::scope(|scope| {
+                    //     parallelize_mem_op(range, thread_count, scope, protect_subrange);
+                    // });
+                    ///////////////
+
+                    let aligned = range.aligned_subrange(BITMAP_BYTE_GRANULARITY);
+                    for unaligned in memory_range::subtract_ranges([range], [aligned]) {
+                        if unaligned.is_empty() {
+                            continue;
+                        }
+
+                        // tracing::info!(
+                        //     "applying default vtl protections to unaligned range: {:?}",
+                        //     unaligned
+                        // );
+                        protect_subrange(unaligned);
+                        // tracing::info!(
+                        //     "finished applying default vtl protections to unaligned range: {:?}",
+                        //     unaligned
+                        // );
+                    }
+
+                    if !aligned.is_empty() {
+                        aligned_ranges.push(aligned);
+                    }
+                }
+            }
+            // tracing::info!("finished handling overlay pages for default vtl protections");
+
+            // tracing::info!("applying default vtl protections to aligned ranges in parallel");
+            std::thread::scope(|scope| {
+                for range in aligned_ranges {
+                    parallelize_mem_op(range, thread_count, scope, protect_subrange);
+                }
+            });
+            // tracing::info!(
+            //     "finished applying default vtl protections to aligned ranges in parallel"
+            // );
+
+            tracing::info!("logging finished applying default vtl protections");
         }
+        // tracing::debug!("Finished applying default vtl protections");
 
         // Flush any threads accessing pages that had their VTL protections
         // changed.
@@ -1144,4 +1240,43 @@ impl ProtectIsolatedMemory for HardwareIsolatedMemoryProtector {
         self.vtl1_protections_enabled
             .load(std::sync::atomic::Ordering::Relaxed)
     }
+}
+
+pub(crate) fn parallelize_mem_op<'a>(
+    source_range: MemoryRange,
+    thread_count: u32,
+    scope: &'a std::thread::Scope<'a, '_>,
+    op: impl Fn(MemoryRange) + Send + Sync + Copy + 'a,
+) {
+    assert_ne!(thread_count, 0, "thread_count must be non-zero");
+
+    // Chunks must be 2mb aligned
+    let two_mb = 2 * 1024 * 1024;
+    let mut range = source_range.aligned_subrange(two_mb);
+    if !range.is_empty() {
+        let chunk_size = (range.page_count_2m().div_ceil(thread_count as u64)) * two_mb;
+        let chunk_count = range.len().div_ceil(chunk_size);
+
+        for _ in 0..chunk_count {
+            let subrange;
+            (subrange, range) = if range.len() >= chunk_size {
+                range.split_at_offset(chunk_size)
+            } else {
+                (range, MemoryRange::EMPTY)
+            };
+            scope.spawn(move || {
+                op(subrange);
+            });
+        }
+        assert!(range.is_empty());
+    }
+
+    // Now accept whatever wasn't aligned on the edges
+    scope.spawn(move || {
+        for unaligned_subrange in
+            memory_range::subtract_ranges([source_range], [source_range.aligned_subrange(two_mb)])
+        {
+            op(unaligned_subrange);
+        }
+    });
 }

--- a/openhcl/underhill_mem/src/lib.rs
+++ b/openhcl/underhill_mem/src/lib.rs
@@ -465,15 +465,11 @@ impl HardwareIsolatedMemoryProtector {
     ) -> Result<(), ApplyVtlProtectionsError> {
         if gpn_source == GpnSource::GuestMemory && target_vtl == GuestVtl::Vtl0 {
             // Only permissions imposed on VTL 0 guest memory are explicitly tracked
-            // let start = Instant::now();
             self.vtl0.update_permission_bitmaps(range, protections);
         }
 
-        let result = self
-            .acceptor
-            .apply_protections(range, target_vtl, protections);
-
-        result
+        self.acceptor
+            .apply_protections(range, target_vtl, protections)
     }
 
     /// Get the permissions that the given VTL has to the given GPN.
@@ -803,7 +799,7 @@ impl ProtectIsolatedMemory for HardwareIsolatedMemoryProtector {
         target_vtl: GuestVtl,
         vtl_protections: HvMapGpaFlags,
         tlb_access: &mut dyn TlbFlushLockAccess,
-        thread_count: u32,
+        vp_count: u32,
     ) -> Result<(), HvError> {
         // Prevent visibility changes while VTL protections are being
         // applied.
@@ -858,10 +854,11 @@ impl ProtectIsolatedMemory for HardwareIsolatedMemoryProtector {
                 vtl_protections,
                 GpnSource::GuestMemory,
             )
-            .unwrap();
         };
 
-        // Handle overlay pages first
+        // Handle overlay pages first, collecting the ranges that don't contain
+        // any so they can be protected in parallel below.
+        let mut protect_ranges = Vec::new();
         for source_range in ranges {
             let mut range_queue = VecDeque::new();
             range_queue.push_back(source_range);
@@ -889,13 +886,15 @@ impl ProtectIsolatedMemory for HardwareIsolatedMemoryProtector {
                     }
                 }
 
-                std::thread::scope(|scope| {
-                    parallelize_mem_op(range, thread_count, scope, protect_subrange);
-                });
+                // We can only reach here if the range does not contain any overlay
+                // pages, so it can be protected in parallel.
+                protect_ranges.push(range);
             }
         }
 
-        tracing::debug!("Finished applying default vtl protections.");
+        parallelize_mem_op(&protect_ranges, vp_count, protect_subrange).unwrap();
+
+        tracing::trace!("Finished applying default vtl protections.");
 
         // Flush any threads accessing pages that had their VTL protections
         // changed.
@@ -1153,41 +1152,51 @@ impl ProtectIsolatedMemory for HardwareIsolatedMemoryProtector {
     }
 }
 
-pub(crate) fn parallelize_mem_op<'a>(
-    source_range: MemoryRange,
-    thread_count: u32,
-    scope: &'a std::thread::Scope<'a, '_>,
-    op: impl Fn(MemoryRange) + Send + Sync + Copy + 'a,
-) {
-    assert_ne!(thread_count, 0, "thread_count must be non-zero");
+pub(crate) fn parallelize_mem_op<E>(
+    source_ranges: &[MemoryRange],
+    vp_count: u32,
+    op: impl Fn(MemoryRange) -> Result<(), E> + Send + Sync + Copy,
+) -> Result<(), E>
+where
+    E: Send,
+{
+    std::thread::scope(|scope| -> Result<(), E> {
+        let thread_count = vp_count.saturating_sub(1).max(1);
+        let mut workers = Vec::new();
 
-    // Chunks must be 2mb aligned
-    let two_mb = 2 * 1024 * 1024;
-    let mut range = source_range.aligned_subrange(two_mb);
-    if !range.is_empty() {
-        let chunk_size = (range.page_count_2m().div_ceil(thread_count as u64)) * two_mb;
-        let chunk_count = range.len().div_ceil(chunk_size);
+        for &source_range in source_ranges {
+            let two_mb = 2 * 1024 * 1024;
+            let aligned_range = source_range.aligned_subrange(two_mb);
+            let mut range = aligned_range;
 
-        for _ in 0..chunk_count {
-            let subrange;
-            (subrange, range) = if range.len() >= chunk_size {
-                range.split_at_offset(chunk_size)
-            } else {
-                (range, MemoryRange::EMPTY)
-            };
-            scope.spawn(move || {
-                op(subrange);
-            });
+            if !range.is_empty() {
+                let chunk_size = range.page_count_2m().div_ceil(thread_count as u64) * two_mb;
+
+                while !range.is_empty() {
+                    let (subrange, remainder) = if range.len() > chunk_size {
+                        range.split_at_offset(chunk_size)
+                    } else {
+                        (range, MemoryRange::EMPTY)
+                    };
+                    range = remainder;
+                    workers.push(scope.spawn(move || op(subrange)));
+                }
+            }
+
+            if aligned_range != source_range {
+                workers.push(scope.spawn(move || {
+                    for subrange in memory_range::subtract_ranges([source_range], [aligned_range]) {
+                        op(subrange)?;
+                    }
+                    Ok(())
+                }));
+            }
         }
-        assert!(range.is_empty());
-    }
 
-    // Now accept whatever wasn't aligned on the edges
-    scope.spawn(move || {
-        for unaligned_subrange in
-            memory_range::subtract_ranges([source_range], [source_range.aligned_subrange(two_mb)])
-        {
-            op(unaligned_subrange);
+        for handle in workers {
+            handle.join().expect("memory operation thread panicked")?;
         }
-    });
+
+        Ok(())
+    })
 }

--- a/openhcl/underhill_mem/src/lib.rs
+++ b/openhcl/underhill_mem/src/lib.rs
@@ -46,7 +46,6 @@ use registrar::RegisterMemory;
 use std::collections::VecDeque;
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
-use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 use thiserror::Error;
 use virt::IsolationType;
@@ -403,6 +402,8 @@ pub struct HardwareIsolatedMemoryProtector {
     acceptor: Arc<MemoryAcceptor>,
     vtl0: Arc<GuestMemoryMapping>,
     vtl1_protections_enabled: AtomicBool,
+    /// Number of VPs, used to parallelize long-running memory operations.
+    vp_count: u32,
 }
 
 struct HardwareIsolatedMemoryProtectorInner {
@@ -434,6 +435,7 @@ impl HardwareIsolatedMemoryProtector {
         vtl0: Arc<GuestMemoryMapping>,
         layout: MemoryLayout,
         acceptor: Arc<MemoryAcceptor>,
+        vp_count: u32,
     ) -> Self {
         Self {
             inner: Mutex::new(HardwareIsolatedMemoryProtectorInner {
@@ -453,6 +455,7 @@ impl HardwareIsolatedMemoryProtector {
             acceptor,
             vtl0,
             vtl1_protections_enabled: AtomicBool::new(false),
+            vp_count,
         }
     }
 
@@ -802,7 +805,6 @@ impl ProtectIsolatedMemory for HardwareIsolatedMemoryProtector {
         target_vtl: GuestVtl,
         vtl_protections: HvMapGpaFlags,
         tlb_access: &mut dyn TlbFlushLockAccess,
-        vp_count: u32,
     ) -> Result<(), HvError> {
         // Prevent visibility changes while VTL protections are being
         // applied.
@@ -895,7 +897,12 @@ impl ProtectIsolatedMemory for HardwareIsolatedMemoryProtector {
             }
         }
 
-        parallelize_mem_op(&protect_ranges, vp_count, protect_subrange).unwrap();
+        parallelize_mem_op(
+            protect_ranges.iter().copied(),
+            self.vp_count,
+            protect_subrange,
+        )
+        .unwrap_or_else(|err| panic!("applying default VTL protections failed: {err}"));
 
         tracing::trace!("Finished applying default vtl protections.");
 
@@ -1154,7 +1161,7 @@ impl ProtectIsolatedMemory for HardwareIsolatedMemoryProtector {
 }
 
 pub(crate) fn parallelize_mem_op<E>(
-    source_ranges: &[MemoryRange],
+    source_ranges: impl Iterator<Item = MemoryRange> + Clone,
     vp_count: u32,
     op: impl Fn(MemoryRange) -> Result<(), E> + Send + Sync + Copy,
 ) -> Result<(), E>
@@ -1162,14 +1169,14 @@ where
     E: Send,
 {
     const LARGE_PAGE_SIZE: u64 = 2 * 1024 * 1024;
-    const MAX_RANGE_LEN: u64 = 2 << 30;
+    // Cap the work unit size so that very large ranges are split across multiple
+    // workers instead of being handled by a single one.
+    const MAX_RANGE_LEN: u64 = 2 * 1024 * 1024 * 1024;
 
     let worker_count = vp_count.saturating_sub(1).max(1);
 
-    assert_ne!(worker_count, 0);
-    let ranges: Vec<_> = source_ranges.into_iter().collect();
-    let total_len = ranges
-        .iter()
+    let total_len = source_ranges
+        .clone()
         .fold(0_u64, |len, range| len.saturating_add(range.len()));
     let target_range_len = total_len
         .div_ceil(u64::from(worker_count))
@@ -1179,24 +1186,25 @@ where
 
     // Preserve large-page alignment while creating enough work to keep all
     // workers busy, with a ceiling to balance very large memory ranges.
-    let ranges: Vec<_> = ranges
-        .into_iter()
-        .flat_map(|range| AlignedSubranges::new(*range).with_max_range_len(target_range_len))
+    let ranges: Vec<_> = source_ranges
+        .flat_map(|range| AlignedSubranges::new(range).with_max_range_len(target_range_len))
         .collect();
-    let worker_count = usize::min(worker_count as usize, ranges.len());
-    let next_range = AtomicUsize::new(0);
+    if ranges.is_empty() {
+        return Ok(());
+    }
 
     std::thread::scope(|scope| {
-        let workers: Vec<_> = (0..worker_count)
-            .map(|_| {
-                scope.spawn(|| {
-                    loop {
-                        let index = next_range.fetch_add(1, Ordering::Relaxed);
-                        let Some(&range) = ranges.get(index) else {
-                            return Ok::<(), E>(());
-                        };
+        // Divide the work up front so each worker owns a contiguous chunk of
+        // ranges, avoiding shared state between workers.
+        let chunk_len = ranges.len().div_ceil(worker_count as usize);
+        let workers: Vec<_> = ranges
+            .chunks(chunk_len)
+            .map(|chunk| {
+                scope.spawn(move || {
+                    for &range in chunk {
                         op(range)?;
                     }
+                    Ok::<(), E>(())
                 })
             })
             .collect();
@@ -1204,6 +1212,91 @@ where
         for worker in workers {
             worker.join().expect("memory range worker panicked")?;
         }
+
         Ok(())
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::convert::Infallible;
+
+    #[test]
+    fn parallelize_mem_op_covers_source_ranges() {
+        const MB: u64 = 1024 * 1024;
+
+        let source_ranges = [
+            MemoryRange::new(0x1000..7 * MB + 0x1000),
+            MemoryRange::new(10 * MB..11 * MB),
+        ];
+        let completed = Mutex::new(Vec::new());
+
+        parallelize_mem_op(source_ranges.iter().copied(), 5, |range| {
+            completed.lock().push(range);
+            Ok::<_, Infallible>(())
+        })
+        .unwrap();
+
+        let mut completed = completed.into_inner();
+        completed.sort_by_key(|range| range.start());
+
+        // The exact subdivision doesn't matter, only that the subranges tile
+        // the source ranges without gaps or overlaps.
+        assert!(
+            memory_range::flatten_ranges(completed).eq(memory_range::flatten_ranges(source_ranges))
+        );
+    }
+
+    #[test]
+    fn parallelize_mem_op_handles_empty_input() {
+        parallelize_mem_op(std::iter::empty(), 0, |_| Ok::<_, Infallible>(())).unwrap();
+    }
+
+    #[test]
+    fn parallelize_mem_op_fewer_workers_than_ranges() {
+        const MB: u64 = 1024 * 1024;
+        const PAGE: u64 = 0x1000;
+
+        // A mix of ranges that exercise the 2MB boundary in different ways:
+        // smaller and larger than 2MB, with aligned and unaligned starts/ends.
+        let source_ranges = [
+            // Sub-2MB, unaligned on both ends.
+            MemoryRange::new(PAGE..3 * PAGE),
+            // Sub-2MB, starts exactly on a 2MB boundary.
+            MemoryRange::new(2 * MB..2 * MB + PAGE),
+            // Sub-2MB, straddles a 2MB boundary.
+            MemoryRange::new(4 * MB - PAGE..4 * MB + PAGE),
+            // Exactly 2MB and fully aligned.
+            MemoryRange::new(6 * MB..8 * MB),
+            // Larger than 2MB, aligned start, unaligned end.
+            MemoryRange::new(10 * MB..12 * MB + PAGE),
+            // Larger than 2MB, unaligned start, aligned end, spanning boundaries.
+            MemoryRange::new(14 * MB + PAGE..18 * MB),
+        ];
+        let completed = Mutex::new(Vec::new());
+
+        // Fewer workers than ranges, so each worker processes multiple ranges.
+        parallelize_mem_op(source_ranges.iter().copied(), 4, |range| {
+            completed.lock().push(range);
+            Ok::<_, Infallible>(())
+        })
+        .unwrap();
+
+        let mut completed = completed.into_inner();
+        completed.sort_by_key(|range| range.start());
+
+        assert!(
+            memory_range::flatten_ranges(completed).eq(memory_range::flatten_ranges(source_ranges))
+        );
+    }
+
+    #[test]
+    fn parallelize_mem_op_propagates_worker_error() {
+        let error = parallelize_mem_op([MemoryRange::new(0..0x1000)].into_iter(), 2, |_| {
+            Err("failed")
+        });
+
+        assert_eq!(error, Err("failed"));
+    }
 }

--- a/openhcl/underhill_mem/src/lib.rs
+++ b/openhcl/underhill_mem/src/lib.rs
@@ -897,12 +897,8 @@ impl ProtectIsolatedMemory for HardwareIsolatedMemoryProtector {
             }
         }
 
-        parallelize_mem_op(
-            protect_ranges.iter().copied(),
-            self.vp_count,
-            protect_subrange,
-        )
-        .unwrap_or_else(|err| panic!("applying default VTL protections failed: {err}"));
+        parallelize_mem_op(&protect_ranges, self.vp_count, protect_subrange)
+            .expect("applying default VTL protections should not fail");
 
         tracing::trace!("Finished applying default vtl protections.");
 
@@ -1161,7 +1157,7 @@ impl ProtectIsolatedMemory for HardwareIsolatedMemoryProtector {
 }
 
 pub(crate) fn parallelize_mem_op<E>(
-    source_ranges: impl Iterator<Item = MemoryRange> + Clone,
+    source_ranges: &[MemoryRange],
     vp_count: u32,
     op: impl Fn(MemoryRange) -> Result<(), E> + Send + Sync + Copy,
 ) -> Result<(), E>
@@ -1176,7 +1172,7 @@ where
     let worker_count = vp_count.saturating_sub(1).max(1);
 
     let total_len = source_ranges
-        .clone()
+        .iter()
         .fold(0_u64, |len, range| len.saturating_add(range.len()));
     let target_range_len = total_len
         .div_ceil(u64::from(worker_count))
@@ -1187,7 +1183,8 @@ where
     // Preserve large-page alignment while creating enough work to keep all
     // workers busy, with a ceiling to balance very large memory ranges.
     let ranges: Vec<_> = source_ranges
-        .flat_map(|range| AlignedSubranges::new(range).with_max_range_len(target_range_len))
+        .iter()
+        .flat_map(|range| AlignedSubranges::new(*range).with_max_range_len(target_range_len))
         .collect();
     if ranges.is_empty() {
         return Ok(());
@@ -1232,7 +1229,7 @@ mod tests {
         ];
         let completed = Mutex::new(Vec::new());
 
-        parallelize_mem_op(source_ranges.iter().copied(), 5, |range| {
+        parallelize_mem_op(&source_ranges, 5, |range| {
             completed.lock().push(range);
             Ok::<_, Infallible>(())
         })
@@ -1250,7 +1247,7 @@ mod tests {
 
     #[test]
     fn parallelize_mem_op_handles_empty_input() {
-        parallelize_mem_op(std::iter::empty(), 0, |_| Ok::<_, Infallible>(())).unwrap();
+        parallelize_mem_op(&[], 0, |_| Ok::<_, Infallible>(())).unwrap();
     }
 
     #[test]
@@ -1277,7 +1274,7 @@ mod tests {
         let completed = Mutex::new(Vec::new());
 
         // Fewer workers than ranges, so each worker processes multiple ranges.
-        parallelize_mem_op(source_ranges.iter().copied(), 4, |range| {
+        parallelize_mem_op(&source_ranges, 4, |range| {
             completed.lock().push(range);
             Ok::<_, Infallible>(())
         })
@@ -1293,9 +1290,7 @@ mod tests {
 
     #[test]
     fn parallelize_mem_op_propagates_worker_error() {
-        let error = parallelize_mem_op([MemoryRange::new(0..0x1000)].into_iter(), 2, |_| {
-            Err("failed")
-        });
+        let error = parallelize_mem_op(&[MemoryRange::new(0..0x1000)], 2, |_| Err("failed"));
 
         assert_eq!(error, Err("failed"));
     }

--- a/openhcl/underhill_mem/src/lib.rs
+++ b/openhcl/underhill_mem/src/lib.rs
@@ -38,6 +38,7 @@ use hvdef::hypercall::HostVisibilityType;
 use hvdef::hypercall::HvInputVtl;
 use mapping::GuestMemoryMapping;
 use mapping::GuestValidMemory;
+use memory_range::AlignedSubranges;
 use memory_range::MemoryRange;
 use parking_lot::Mutex;
 use parking_lot::MutexGuard;
@@ -45,6 +46,8 @@ use registrar::RegisterMemory;
 use std::collections::VecDeque;
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
 use thiserror::Error;
 use virt::IsolationType;
 use virt_mshv_vtl::GpnSource;
@@ -1142,13 +1145,11 @@ impl ProtectIsolatedMemory for HardwareIsolatedMemoryProtector {
     }
 
     fn set_vtl1_protections_enabled(&self) {
-        self.vtl1_protections_enabled
-            .store(true, std::sync::atomic::Ordering::Relaxed);
+        self.vtl1_protections_enabled.store(true, Ordering::Relaxed);
     }
 
     fn vtl1_protections_enabled(&self) -> bool {
-        self.vtl1_protections_enabled
-            .load(std::sync::atomic::Ordering::Relaxed)
+        self.vtl1_protections_enabled.load(Ordering::Relaxed)
     }
 }
 
@@ -1160,43 +1161,49 @@ pub(crate) fn parallelize_mem_op<E>(
 where
     E: Send,
 {
-    std::thread::scope(|scope| -> Result<(), E> {
-        let thread_count = vp_count.saturating_sub(1).max(1);
-        let mut workers = Vec::new();
+    const LARGE_PAGE_SIZE: u64 = 2 * 1024 * 1024;
+    const MAX_RANGE_LEN: u64 = 2 << 30;
 
-        for &source_range in source_ranges {
-            let two_mb = 2 * 1024 * 1024;
-            let aligned_range = source_range.aligned_subrange(two_mb);
-            let mut range = aligned_range;
+    let worker_count = vp_count.saturating_sub(1).max(1);
 
-            if !range.is_empty() {
-                let chunk_size = range.page_count_2m().div_ceil(thread_count as u64) * two_mb;
+    assert_ne!(worker_count, 0);
+    let ranges: Vec<_> = source_ranges.into_iter().collect();
+    let total_len = ranges
+        .iter()
+        .fold(0_u64, |len, range| len.saturating_add(range.len()));
+    let target_range_len = total_len
+        .div_ceil(u64::from(worker_count))
+        .clamp(LARGE_PAGE_SIZE, MAX_RANGE_LEN)
+        .next_multiple_of(LARGE_PAGE_SIZE)
+        .min(MAX_RANGE_LEN);
 
-                while !range.is_empty() {
-                    let (subrange, remainder) = if range.len() > chunk_size {
-                        range.split_at_offset(chunk_size)
-                    } else {
-                        (range, MemoryRange::EMPTY)
-                    };
-                    range = remainder;
-                    workers.push(scope.spawn(move || op(subrange)));
-                }
-            }
+    // Preserve large-page alignment while creating enough work to keep all
+    // workers busy, with a ceiling to balance very large memory ranges.
+    let ranges: Vec<_> = ranges
+        .into_iter()
+        .flat_map(|range| AlignedSubranges::new(*range).with_max_range_len(target_range_len))
+        .collect();
+    let worker_count = usize::min(worker_count as usize, ranges.len());
+    let next_range = AtomicUsize::new(0);
 
-            if aligned_range != source_range {
-                workers.push(scope.spawn(move || {
-                    for subrange in memory_range::subtract_ranges([source_range], [aligned_range]) {
-                        op(subrange)?;
+    std::thread::scope(|scope| {
+        let workers: Vec<_> = (0..worker_count)
+            .map(|_| {
+                scope.spawn(|| {
+                    loop {
+                        let index = next_range.fetch_add(1, Ordering::Relaxed);
+                        let Some(&range) = ranges.get(index) else {
+                            return Ok::<(), E>(());
+                        };
+                        op(range)?;
                     }
-                    Ok(())
-                }));
-            }
-        }
+                })
+            })
+            .collect();
 
-        for handle in workers {
-            handle.join().expect("memory operation thread panicked")?;
+        for worker in workers {
+            worker.join().expect("memory range worker panicked")?;
         }
-
         Ok(())
     })
 }

--- a/openhcl/underhill_mem/src/mapping.rs
+++ b/openhcl/underhill_mem/src/mapping.rs
@@ -834,7 +834,9 @@ mod tests {
     fn test_bitmap_update() {
         const PAGE_COUNT: u64 = 24;
 
-        for gpn_range in [8..16, 3..21] {
+        // Cover fully-aligned, single-edge, both-edge, sub-byte, and
+        // full-coverage ranges.
+        for gpn_range in [8..16, 3..21, 5..6, 8..13, 3..8, 0..24, 7..17] {
             let mut bitmap = GuestMemoryBitmap::new(PAGE_COUNT as usize * PAGE_SIZE).unwrap();
             bitmap
                 .init(MemoryRange::from_4k_gpn_range(0..PAGE_COUNT), false)
@@ -849,6 +851,41 @@ mod tests {
             bitmap.update(range, false);
             for gpn in 0..PAGE_COUNT {
                 assert!(!bitmap.page_state(gpn), "{gpn}");
+            }
+        }
+    }
+
+    // Apply a sequence of overlapping and partially-overlapping updates and
+    // check the running state after each one.
+    #[test]
+    fn test_bitmap_update_overlapping() {
+        const PAGE_COUNT: u64 = 24;
+
+        let mut bitmap = GuestMemoryBitmap::new(PAGE_COUNT as usize * PAGE_SIZE).unwrap();
+        bitmap
+            .init(MemoryRange::from_4k_gpn_range(0..PAGE_COUNT), false)
+            .unwrap();
+
+        let mut expected = [false; PAGE_COUNT as usize];
+        let ops = [
+            (3..21, true),   // unaligned on both edges
+            (0..4, false),   // clears the left chunk, shares an edge
+            (6..10, true),   // partial overlap, re-sets some pages
+            (9..24, true),   // shares the right edge
+            (20..22, false), // clears an interior sub-byte span
+        ];
+
+        for (gpn_range, state) in ops {
+            bitmap.update(MemoryRange::from_4k_gpn_range(gpn_range.clone()), state);
+            for gpn in gpn_range.clone() {
+                expected[gpn as usize] = state;
+            }
+            for gpn in 0..PAGE_COUNT {
+                assert_eq!(
+                    bitmap.page_state(gpn),
+                    expected[gpn as usize],
+                    "gpn {gpn} after updating {gpn_range:?} to {state}"
+                );
             }
         }
     }

--- a/openhcl/underhill_mem/src/mapping.rs
+++ b/openhcl/underhill_mem/src/mapping.rs
@@ -17,6 +17,7 @@ use hvdef::HvMapGpaFlags;
 use inspect::Inspect;
 use memory_range::MemoryRange;
 use parking_lot::Mutex;
+use parking_lot::MutexGuard;
 use sparse_mmap::SparseMapping;
 use std::ptr::NonNull;
 use std::sync::Arc;
@@ -444,20 +445,35 @@ impl GuestMemoryBitmap {
 
     /// Panics if the range is outside of guest RAM.
     fn update(&self, range: MemoryRange, state: bool) {
-        for gpn in range.start() / PAGE_SIZE as u64..range.end() / PAGE_SIZE as u64 {
-            // TODO: use `fill_at` for the aligned part of the range.
-            let mut b = 0;
+        let aligned_range = range.aligned_subrange(PAGE_SIZE as u64 * 8);
+        if !aligned_range.is_empty() {
             self.bitmap
-                .read_at(gpn as usize / 8, std::slice::from_mut(&mut b))
+                .fill_at(
+                    aligned_range.start() as usize / PAGE_SIZE / 8,
+                    if state { u8::MAX } else { 0u8 },
+                    aligned_range.len() as usize / PAGE_SIZE / 8,
+                )
                 .unwrap();
-            if state {
-                b |= 1 << (gpn % 8);
-            } else {
-                b &= !(1 << (gpn % 8));
+        }
+
+        for unaligned_range in memory_range::subtract_ranges([range], [aligned_range]) {
+            for gpn in
+                unaligned_range.start() / PAGE_SIZE as u64..unaligned_range.end() / PAGE_SIZE as u64
+            {
+                // TODO: use `fill_at` for the aligned part of the range.
+                let mut b = 0;
+                self.bitmap
+                    .read_at(gpn as usize / 8, std::slice::from_mut(&mut b))
+                    .unwrap();
+                if state {
+                    b |= 1 << (gpn % 8);
+                } else {
+                    b &= !(1 << (gpn % 8));
+                }
+                self.bitmap
+                    .write_at(gpn as usize / 8, std::slice::from_ref(&b))
+                    .unwrap();
             }
-            self.bitmap
-                .write_at(gpn as usize / 8, std::slice::from_ref(&b))
-                .unwrap();
         }
     }
 
@@ -718,8 +734,26 @@ impl GuestMemoryMapping {
     /// Update the permission bitmaps to reflect the given flags.
     /// Panics if the range is outside of guest RAM.
     pub fn update_permission_bitmaps(&self, range: MemoryRange, flags: HvMapGpaFlags) {
+        if let Some(_lock) = self.lock_permission_bitmaps() {
+            self.update_permission_bitmaps_locked(range, flags);
+        }
+    }
+
+    pub(crate) fn lock_permission_bitmaps(&self) -> Option<MutexGuard<'_, ()>> {
+        self.permission_bitmaps
+            .as_ref()
+            .map(|bitmaps| bitmaps.permission_update_lock.lock())
+    }
+
+    /// Update the permission bitmaps to reflect the given flags.
+    ///
+    /// The caller must hold the permission bitmap update lock.
+    pub(crate) fn update_permission_bitmaps_locked(
+        &self,
+        range: MemoryRange,
+        flags: HvMapGpaFlags,
+    ) {
         if let Some(bitmaps) = self.permission_bitmaps.as_ref() {
-            let _lock = bitmaps.permission_update_lock.lock();
             bitmaps.read_bitmap.update(range, flags.readable());
             bitmaps.write_bitmap.update(range, flags.writable());
             bitmaps

--- a/openhcl/underhill_mem/src/mapping.rs
+++ b/openhcl/underhill_mem/src/mapping.rs
@@ -388,6 +388,14 @@ pub enum VtlPermissionsError {
     NoPermissionsTracked,
 }
 
+#[derive(Debug, Error)]
+pub(crate) enum RegisterMemoryError {
+    #[error("memory mapping is not configured for kernel registration")]
+    NotConfigured,
+    #[error("failed to register memory starting at {address:#x}")]
+    RegistrationFailed { address: u64 },
+}
+
 #[derive(Debug)]
 struct GuestMemoryBitmap {
     bitmap: SparseMapping,
@@ -744,6 +752,15 @@ impl GuestMemoryMapping {
             dma_base_address: None,
             ignore_registration_failure: false,
         }
+    }
+
+    /// Register all mapped RAM before it is accessed.
+    pub(crate) fn register_all_memory(&self) -> Result<(), RegisterMemoryError> {
+        self.registrar
+            .as_ref()
+            .ok_or(RegisterMemoryError::NotConfigured)?
+            .register_all()
+            .map_err(|address| RegisterMemoryError::RegistrationFailed { address })
     }
 
     /// Update the permission bitmaps to reflect the given flags.

--- a/openhcl/underhill_mem/src/mapping.rs
+++ b/openhcl/underhill_mem/src/mapping.rs
@@ -17,7 +17,6 @@ use hvdef::HvMapGpaFlags;
 use inspect::Inspect;
 use memory_range::MemoryRange;
 use parking_lot::Mutex;
-use parking_lot::MutexGuard;
 use sparse_mmap::SparseMapping;
 use std::ptr::NonNull;
 use std::sync::Arc;
@@ -395,9 +394,13 @@ struct GuestMemoryBitmap {
 }
 
 impl GuestMemoryBitmap {
+    const PAGES_PER_CHUNK: u64 = 8;
+    const BYTES_PER_CHUNK: u64 = PAGE_SIZE as u64 * Self::PAGES_PER_CHUNK;
     fn new(address_space_size: usize) -> Result<Self, MappingError> {
-        let bitmap = SparseMapping::new((address_space_size / PAGE_SIZE).div_ceil(8))
-            .map_err(MappingError::BitmapReserve)?;
+        let bitmap = SparseMapping::new(
+            (address_space_size / PAGE_SIZE).div_ceil(Self::PAGES_PER_CHUNK as usize),
+        )
+        .map_err(MappingError::BitmapReserve)?;
         bitmap
             .map_zero(0, bitmap.len())
             .map_err(MappingError::BitmapMap)?;
@@ -405,14 +408,14 @@ impl GuestMemoryBitmap {
     }
 
     fn init(&mut self, range: MemoryRange, state: bool) -> Result<(), MappingError> {
-        if !range.start().is_multiple_of(PAGE_SIZE as u64 * 8)
-            || !range.end().is_multiple_of(PAGE_SIZE as u64 * 8)
+        if !range.start().is_multiple_of(Self::BYTES_PER_CHUNK)
+            || !range.end().is_multiple_of(Self::BYTES_PER_CHUNK)
         {
             return Err(MappingError::BadAlignment(range));
         }
 
-        let bitmap_start = range.start() as usize / PAGE_SIZE / 8;
-        let bitmap_end = (range.end() - 1) as usize / PAGE_SIZE / 8;
+        let bitmap_start = (range.start() / Self::BYTES_PER_CHUNK) as usize;
+        let bitmap_end = ((range.end() - 1) / Self::BYTES_PER_CHUNK) as usize;
         let bitmap_page_start = bitmap_start / PAGE_SIZE;
         let bitmap_page_end = bitmap_end / PAGE_SIZE;
         let page_count = bitmap_page_end + 1 - bitmap_page_start;
@@ -433,10 +436,14 @@ impl GuestMemoryBitmap {
         if state {
             let start_gpn = range.start() / PAGE_SIZE as u64;
             let gpn_count = range.len() / PAGE_SIZE as u64;
-            assert_eq!(range.start() % 8, 0);
-            assert_eq!(gpn_count % 8, 0);
+            assert_eq!(range.start() % Self::PAGES_PER_CHUNK, 0);
+            assert_eq!(gpn_count % Self::PAGES_PER_CHUNK, 0);
             self.bitmap
-                .fill_at(start_gpn as usize / 8, 0xff, gpn_count as usize / 8)
+                .fill_at(
+                    (start_gpn / Self::PAGES_PER_CHUNK) as usize,
+                    0xff,
+                    (gpn_count / Self::PAGES_PER_CHUNK) as usize,
+                )
                 .unwrap();
         }
 
@@ -445,13 +452,13 @@ impl GuestMemoryBitmap {
 
     /// Panics if the range is outside of guest RAM.
     fn update(&self, range: MemoryRange, state: bool) {
-        let aligned_range = range.aligned_subrange(PAGE_SIZE as u64 * 8);
+        let aligned_range = range.aligned_subrange(Self::BYTES_PER_CHUNK);
         if !aligned_range.is_empty() {
             self.bitmap
                 .fill_at(
-                    aligned_range.start() as usize / PAGE_SIZE / 8,
+                    (aligned_range.start() / Self::BYTES_PER_CHUNK) as usize,
                     if state { u8::MAX } else { 0u8 },
-                    aligned_range.len() as usize / PAGE_SIZE / 8,
+                    (aligned_range.len() / Self::BYTES_PER_CHUNK) as usize,
                 )
                 .unwrap();
         }
@@ -462,15 +469,21 @@ impl GuestMemoryBitmap {
             {
                 let mut b = 0;
                 self.bitmap
-                    .read_at(gpn as usize / 8, std::slice::from_mut(&mut b))
+                    .read_at(
+                        (gpn / Self::PAGES_PER_CHUNK) as usize,
+                        std::slice::from_mut(&mut b),
+                    )
                     .unwrap();
                 if state {
-                    b |= 1 << (gpn % 8);
+                    b |= 1 << (gpn % Self::PAGES_PER_CHUNK);
                 } else {
-                    b &= !(1 << (gpn % 8));
+                    b &= !(1 << (gpn % Self::PAGES_PER_CHUNK));
                 }
                 self.bitmap
-                    .write_at(gpn as usize / 8, std::slice::from_ref(&b))
+                    .write_at(
+                        (gpn / Self::PAGES_PER_CHUNK) as usize,
+                        std::slice::from_ref(&b),
+                    )
                     .unwrap();
             }
         }
@@ -481,9 +494,12 @@ impl GuestMemoryBitmap {
     fn page_state(&self, gpn: u64) -> bool {
         let mut b = 0;
         self.bitmap
-            .read_at(gpn as usize / 8, std::slice::from_mut(&mut b))
+            .read_at(
+                (gpn / Self::PAGES_PER_CHUNK) as usize,
+                std::slice::from_mut(&mut b),
+            )
             .unwrap();
-        b & (1 << (gpn % 8)) != 0
+        b & (1 << (gpn % Self::PAGES_PER_CHUNK)) != 0
     }
 
     fn as_ptr(&self) -> *mut u8 {
@@ -772,8 +788,10 @@ impl GuestMemoryMapping {
 
 #[cfg(test)]
 mod tests {
+    use crate::mapping::GuestMemoryBitmap;
     use crate::mapping::GuestValidMemory;
     use crate::mapping::GuestValidMemoryType;
+    use guestmem::PAGE_SIZE;
     use memory_range::MemoryRange;
     use vm_topology::memory::MemoryLayout;
     use vm_topology::memory::MemoryRangeWithNode;
@@ -792,6 +810,29 @@ mod tests {
             GuestValidMemory::new(&memory_layout, GuestValidMemoryType::Encrypted, true).unwrap();
         for (i, &b) in [true, true, false, true, false].iter().enumerate() {
             assert_eq!(guest_valid_mem.check_valid(i as u64 * 8), b, "{i}");
+        }
+    }
+
+    #[test]
+    fn test_bitmap_update() {
+        const PAGE_COUNT: u64 = 24;
+
+        for gpn_range in [8..16, 3..21] {
+            let mut bitmap = GuestMemoryBitmap::new(PAGE_COUNT as usize * PAGE_SIZE).unwrap();
+            bitmap
+                .init(MemoryRange::from_4k_gpn_range(0..PAGE_COUNT), false)
+                .unwrap();
+
+            let range = MemoryRange::from_4k_gpn_range(gpn_range.clone());
+            bitmap.update(range, true);
+            for gpn in 0..PAGE_COUNT {
+                assert_eq!(bitmap.page_state(gpn), gpn_range.contains(&gpn), "{gpn}");
+            }
+
+            bitmap.update(range, false);
+            for gpn in 0..PAGE_COUNT {
+                assert!(!bitmap.page_state(gpn), "{gpn}");
+            }
         }
     }
 }

--- a/openhcl/underhill_mem/src/mapping.rs
+++ b/openhcl/underhill_mem/src/mapping.rs
@@ -460,7 +460,6 @@ impl GuestMemoryBitmap {
             for gpn in
                 unaligned_range.start() / PAGE_SIZE as u64..unaligned_range.end() / PAGE_SIZE as u64
             {
-                // TODO: use `fill_at` for the aligned part of the range.
                 let mut b = 0;
                 self.bitmap
                     .read_at(gpn as usize / 8, std::slice::from_mut(&mut b))
@@ -734,26 +733,8 @@ impl GuestMemoryMapping {
     /// Update the permission bitmaps to reflect the given flags.
     /// Panics if the range is outside of guest RAM.
     pub fn update_permission_bitmaps(&self, range: MemoryRange, flags: HvMapGpaFlags) {
-        if let Some(_lock) = self.lock_permission_bitmaps() {
-            self.update_permission_bitmaps_locked(range, flags);
-        }
-    }
-
-    pub(crate) fn lock_permission_bitmaps(&self) -> Option<MutexGuard<'_, ()>> {
-        self.permission_bitmaps
-            .as_ref()
-            .map(|bitmaps| bitmaps.permission_update_lock.lock())
-    }
-
-    /// Update the permission bitmaps to reflect the given flags.
-    ///
-    /// The caller must hold the permission bitmap update lock.
-    pub(crate) fn update_permission_bitmaps_locked(
-        &self,
-        range: MemoryRange,
-        flags: HvMapGpaFlags,
-    ) {
         if let Some(bitmaps) = self.permission_bitmaps.as_ref() {
+            let _lock = bitmaps.permission_update_lock.lock();
             bitmaps.read_bitmap.update(range, flags.readable());
             bitmaps.write_bitmap.update(range, flags.writable());
             bitmaps

--- a/openhcl/underhill_mem/src/registrar.rs
+++ b/openhcl/underhill_mem/src/registrar.rs
@@ -14,10 +14,10 @@
 //! when a VA might leak out of a `GuestMemory` object and possibly be passed to
 //! a kernel routine.
 //!
-//! This is done by registering memory in 2GB chunks, which is large enough to
-//! get large pages in the kernel, but small enough to keep the overhead of the
-//! initial registration for a chunk small. We track whether a given chunk has
-//! been registered via a small bitmap.
+//! This is done by registering memory in 1-GB chunks. Fully aligned chunks can
+//! use PUD mappings in the kernel, while unaligned RAM edges automatically fall
+//! back to smaller mappings. We track whether a given chunk has been registered
+//! via a small bitmap.
 
 use cvm_tracing::CVM_ALLOWED;
 use inspect::Inspect;
@@ -107,8 +107,8 @@ impl<T: Fn(MemoryRange) -> Result<(), E>, E: 'static + std::error::Error> Regist
     }
 }
 
-/// Register in 2GB chunks.
-const GRANULARITY: u64 = 2 << 30;
+/// Register in 1-GB chunks so aligned RAM can use PUD mappings.
+const GRANULARITY: u64 = 1 << 30;
 
 impl<T: RegisterMemory> MemoryRegistrar<T> {
     pub fn new(layout: &MemoryLayout, registration_offset: u64, register: T) -> Self {
@@ -184,6 +184,12 @@ impl<T: RegisterMemory> MemoryRegistrar<T> {
         }
         Ok(())
     }
+
+    /// Register every RAM range in the address space.
+    pub fn register_all(&self) -> Result<(), u64> {
+        let address_space_size = self.ram.last().unwrap().end();
+        self.register(0, address_space_size)
+    }
 }
 
 #[cfg(test)]
@@ -194,6 +200,7 @@ mod tests {
     use std::cell::RefCell;
     use std::convert::Infallible;
     use vm_topology::memory::MemoryLayout;
+    use vm_topology::memory::MemoryRangeWithNode;
 
     #[test]
     fn test_registrar() {
@@ -253,6 +260,35 @@ mod tests {
                 .map(|r| r.to_string())
                 .collect::<Vec<_>>()
                 .join("\n")
+        );
+    }
+
+    #[test]
+    fn test_register_all_preserves_aligned_interior() {
+        let layout = MemoryLayout::new_from_ranges(
+            &[MemoryRangeWithNode {
+                range: MemoryRange::new(0x10000..2 * GRANULARITY + 0x20000),
+                vnode: 0,
+            }],
+            &[],
+        )
+        .unwrap();
+
+        let ranges = RefCell::new(Vec::new());
+        let registrar = MemoryRegistrar::new(&layout, 0, |range| {
+            ranges.borrow_mut().push(range);
+            Ok::<_, Infallible>(())
+        });
+
+        registrar.register_all().unwrap();
+
+        assert_eq!(
+            ranges.take(),
+            [
+                MemoryRange::new(0x10000..GRANULARITY),
+                MemoryRange::new(GRANULARITY..2 * GRANULARITY),
+                MemoryRange::new(2 * GRANULARITY..2 * GRANULARITY + 0x20000),
+            ]
         );
     }
 }

--- a/openhcl/underhill_mem/src/registrar.rs
+++ b/openhcl/underhill_mem/src/registrar.rs
@@ -291,4 +291,60 @@ mod tests {
             ]
         );
     }
+
+    #[test]
+    fn test_register_all_multiple_ranges_with_gap() {
+        // A mix of RAM ranges with unbacked gaps between them: one spanning a
+        // chunk boundary, one contained in a single chunk, one spanning
+        // several whole chunks, and one crossing a boundary with unaligned ends.
+        let layout = MemoryLayout::new_from_ranges(
+            &[
+                MemoryRangeWithNode {
+                    range: MemoryRange::new(0x10000..GRANULARITY + 0x20000),
+                    vnode: 0,
+                },
+                MemoryRangeWithNode {
+                    range: MemoryRange::new(3 * GRANULARITY + 0x10000..3 * GRANULARITY + 0x30000),
+                    vnode: 0,
+                },
+                MemoryRangeWithNode {
+                    range: MemoryRange::new(4 * GRANULARITY + 0x40000..4 * GRANULARITY + 0x50000),
+                    vnode: 0,
+                },
+                MemoryRangeWithNode {
+                    range: MemoryRange::new(5 * GRANULARITY..8 * GRANULARITY),
+                    vnode: 0,
+                },
+                MemoryRangeWithNode {
+                    range: MemoryRange::new(9 * GRANULARITY + 0x30000..10 * GRANULARITY + 0x10000),
+                    vnode: 0,
+                },
+            ],
+            &[],
+        )
+        .unwrap();
+
+        let ranges = RefCell::new(Vec::new());
+        let registrar = MemoryRegistrar::new(&layout, 0, |range| {
+            ranges.borrow_mut().push(range);
+            Ok::<_, Infallible>(())
+        });
+
+        registrar.register_all().unwrap();
+
+        assert_eq!(
+            ranges.take(),
+            [
+                MemoryRange::new(0x10000..GRANULARITY),
+                MemoryRange::new(GRANULARITY..GRANULARITY + 0x20000),
+                MemoryRange::new(3 * GRANULARITY + 0x10000..3 * GRANULARITY + 0x30000),
+                MemoryRange::new(4 * GRANULARITY + 0x40000..4 * GRANULARITY + 0x50000),
+                MemoryRange::new(5 * GRANULARITY..6 * GRANULARITY),
+                MemoryRange::new(6 * GRANULARITY..7 * GRANULARITY),
+                MemoryRange::new(7 * GRANULARITY..8 * GRANULARITY),
+                MemoryRange::new(9 * GRANULARITY + 0x30000..10 * GRANULARITY),
+                MemoryRange::new(10 * GRANULARITY..10 * GRANULARITY + 0x10000),
+            ]
+        );
+    }
 }

--- a/openhcl/virt_mshv_vtl/src/lib.rs
+++ b/openhcl/virt_mshv_vtl/src/lib.rs
@@ -1581,6 +1581,7 @@ pub trait ProtectIsolatedMemory: Send + Sync {
         target_vtl: GuestVtl,
         protections: HvMapGpaFlags,
         tlb_access: &mut dyn TlbFlushLockAccess,
+        thread_count: u32,
     ) -> Result<(), HvError>;
 
     /// Changes the vtl protections on a range of guest memory.

--- a/openhcl/virt_mshv_vtl/src/lib.rs
+++ b/openhcl/virt_mshv_vtl/src/lib.rs
@@ -1581,7 +1581,6 @@ pub trait ProtectIsolatedMemory: Send + Sync {
         target_vtl: GuestVtl,
         protections: HvMapGpaFlags,
         tlb_access: &mut dyn TlbFlushLockAccess,
-        vp_count: u32,
     ) -> Result<(), HvError>;
 
     /// Changes the vtl protections on a range of guest memory.

--- a/openhcl/virt_mshv_vtl/src/lib.rs
+++ b/openhcl/virt_mshv_vtl/src/lib.rs
@@ -1581,7 +1581,7 @@ pub trait ProtectIsolatedMemory: Send + Sync {
         target_vtl: GuestVtl,
         protections: HvMapGpaFlags,
         tlb_access: &mut dyn TlbFlushLockAccess,
-        thread_count: u32,
+        vp_count: u32,
     ) -> Result<(), HvError>;
 
     /// Changes the vtl protections on a range of guest memory.

--- a/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
@@ -1822,7 +1822,6 @@ impl<B: HardwareIsolatedBacking> hv1_hypercall::EnablePartitionVtl
             GuestVtl::Vtl1,
             hvdef::HV_MAP_GPA_PERMISSIONS_ALL,
             &mut self.vp.tlb_flush_lock_access(),
-            // 1,
             std::cmp::max(1, (self.vp.partition.vps.len().saturating_sub(1)) as u32),
         )?;
 
@@ -2262,10 +2261,11 @@ impl<B: HardwareIsolatedBacking> UhProcessor<'_, B> {
         // than the VTL specified as an argument for hardware CVMs.
         let targeted_vtl = GuestVtl::Vtl0;
 
-        // Don't allow changing existing protections once vtl protection is enabled
         let current_protections = protector.default_vtl0_protections();
         if protections != current_protections {
             if protector.vtl1_protections_enabled() {
+                // Don't allow changing existing protections once vtl protection
+                // is enabled
                 return Err(HvError::InvalidRegisterValue);
             } else {
                 protector.change_default_vtl_protections(

--- a/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
@@ -1822,7 +1822,7 @@ impl<B: HardwareIsolatedBacking> hv1_hypercall::EnablePartitionVtl
             GuestVtl::Vtl1,
             hvdef::HV_MAP_GPA_PERMISSIONS_ALL,
             &mut self.vp.tlb_flush_lock_access(),
-            std::cmp::max(1, (self.vp.partition.vps.len().saturating_sub(1)) as u32),
+            self.vp.partition.vps.len() as u32,
         )?;
 
         tracing::debug!("Successfully granted vtl 1 access to lower vtl memory");
@@ -2272,7 +2272,7 @@ impl<B: HardwareIsolatedBacking> UhProcessor<'_, B> {
                     targeted_vtl,
                     protections,
                     &mut self.tlb_flush_lock_access(),
-                    std::cmp::max(1, (self.partition.vps.len().saturating_sub(1)) as u32),
+                    self.partition.vps.len() as u32,
                 )?;
             }
         }

--- a/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
@@ -1822,6 +1822,8 @@ impl<B: HardwareIsolatedBacking> hv1_hypercall::EnablePartitionVtl
             GuestVtl::Vtl1,
             hvdef::HV_MAP_GPA_PERMISSIONS_ALL,
             &mut self.vp.tlb_flush_lock_access(),
+            // 1,
+            std::cmp::max(1, (self.vp.partition.vps.len().saturating_sub(1)) as u32),
         )?;
 
         tracing::debug!("Successfully granted vtl 1 access to lower vtl memory");
@@ -2261,18 +2263,19 @@ impl<B: HardwareIsolatedBacking> UhProcessor<'_, B> {
         let targeted_vtl = GuestVtl::Vtl0;
 
         // Don't allow changing existing protections once vtl protection is enabled
-        if protector.vtl1_protections_enabled() {
-            let current_protections = protector.default_vtl0_protections();
-            if protections != current_protections {
+        let current_protections = protector.default_vtl0_protections();
+        if protections != current_protections {
+            if protector.vtl1_protections_enabled() {
                 return Err(HvError::InvalidRegisterValue);
+            } else {
+                protector.change_default_vtl_protections(
+                    targeted_vtl,
+                    protections,
+                    &mut self.tlb_flush_lock_access(),
+                    std::cmp::max(1, (self.partition.vps.len().saturating_sub(1)) as u32),
+                )?;
             }
         }
-
-        protector.change_default_vtl_protections(
-            targeted_vtl,
-            protections,
-            &mut self.tlb_flush_lock_access(),
-        )?;
 
         // TODO GUEST VSM: should only be set if enable_vtl_protection is true?
         // We're not to spec but match the HCL, so good enough for now?

--- a/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
@@ -1822,7 +1822,6 @@ impl<B: HardwareIsolatedBacking> hv1_hypercall::EnablePartitionVtl
             GuestVtl::Vtl1,
             hvdef::HV_MAP_GPA_PERMISSIONS_ALL,
             &mut self.vp.tlb_flush_lock_access(),
-            self.vp.partition.vps.len() as u32,
         )?;
 
         tracing::debug!("Successfully granted vtl 1 access to lower vtl memory");
@@ -2272,7 +2271,6 @@ impl<B: HardwareIsolatedBacking> UhProcessor<'_, B> {
                     targeted_vtl,
                     protections,
                     &mut self.tlb_flush_lock_access(),
-                    self.partition.vps.len() as u32,
                 )?;
             }
         }


### PR DESCRIPTION
Changes to default protections must apply over all lower VTL memory, which can be a long-running operation. This change parallelizes the operation, and updates the permission bitmap updates to be more performant as well.

Tested:
Booted SNP Windows with SK and measured performance of applying default VTL protections.