### PR TITLE
virt: keep reference time monotonic across a machine reset

### DIFF
--- a/vmm_core/virt/src/state.rs
+++ b/vmm_core/virt/src/state.rs
@@ -26,6 +26,12 @@ pub trait StateElement<C, V>: Sized + Inspect {
     fn can_compare(_caps: &C) -> bool {
         true
     }
+
+    /// Returns whether this state survives a machine reset instead of being
+    /// returned to its reset value.
+    fn survives_machine_reset(_caps: &C) -> bool {
+        false
+    }
 }
 
 pub trait HvRegisterState<T, const COUNT: usize>: Default {
@@ -112,16 +118,18 @@ mod macros {
                     self.commit().map_err(|err| $crate::state::StateError{phase: "commit restore", err})
                 }
 
-                /// Resets all the state elements to their initial state (after machine reset).
+                /// Resets the state elements that a machine reset affects to their initial
+                /// state. An element whose `survives_machine_reset` is set keeps its value.
                 fn reset_all(&mut self, vp_info: &$vp) -> Result<(), $crate::state::StateError<Self::Error>> {
                     $(
-                        if <$ty as $crate::state::StateElement<$caps, $vp>>::is_present(self.caps()) {
+                        if <$ty as $crate::state::StateElement<$caps, $vp>>::is_present(self.caps())
+                            && !<$ty as $crate::state::StateElement<$caps, $vp>>::survives_machine_reset(self.caps()) {
                             self.$set(&<$ty as $crate::state::StateElement<$caps, $vp>>::at_reset(self.caps(), vp_info)).map_err(|err| $crate::state::StateError{phase: concat!("reset ", stringify!($id)), err})?;
                         }
                     )*
 
                     if cfg!(debug_assertions) {
-                        self.check_reset_all(vp_info);
+                        self.check_machine_reset(vp_info);
                     }
                     Ok(())
                 }
@@ -131,6 +139,22 @@ mod macros {
                 fn check_reset_all(&mut self, vp_info: &$vp) {
                     $(
                         if <$ty as $crate::state::StateElement<$caps, $vp>>::can_compare(self.caps()) && <$ty as $crate::state::StateElement<$caps, $vp>>::is_present(self.caps()) {
+                            assert_eq!(self.$get().expect($id), <$ty as $crate::state::StateElement<$caps, $vp>>::at_reset(self.caps(), vp_info), "reset state mismatch (actual/expected)");
+                        }
+                    )*
+                }
+
+                /// Validates the state elements that a machine reset affects, ignoring those
+                /// that survive one.
+                ///
+                /// `check_reset_all` stays strict: a caller that reset the partition by some
+                /// other means still gets to assert that every element, including a surviving
+                /// one, came back at its reset value.
+                #[allow(unused_variables)]
+                fn check_machine_reset(&mut self, vp_info: &$vp) {
+                    $(
+                        if <$ty as $crate::state::StateElement<$caps, $vp>>::can_compare(self.caps()) && <$ty as $crate::state::StateElement<$caps, $vp>>::is_present(self.caps())
+                            && !<$ty as $crate::state::StateElement<$caps, $vp>>::survives_machine_reset(self.caps()) {
                             assert_eq!(self.$get().expect($id), <$ty as $crate::state::StateElement<$caps, $vp>>::at_reset(self.caps(), vp_info), "reset state mismatch (actual/expected)");
                         }
                     )*

--- a/vmm_core/virt/src/x86/vm.rs
+++ b/vmm_core/virt/src/x86/vm.rs
@@ -129,6 +129,12 @@ impl StateElement<X86PartitionCapabilities, X86VpInfo> for ReferenceTime {
     fn can_compare(caps: &X86PartitionCapabilities) -> bool {
         caps.can_freeze_time
     }
+
+    /// The reference time counter increases monotonically for the life of the
+    /// partition, and resetting a VM in place does not create a new partition.
+    fn survives_machine_reset(_caps: &X86PartitionCapabilities) -> bool {
+        true
+    }
 }
 
 state_trait!(


### PR DESCRIPTION
## The problem

`reset_all()` returns every state element to its at-reset value. For `ReferenceTime` that
value is 0, so resetting a VM in place moves the partition's reference time counter backwards
by however long the guest had been running. The counter increases monotonically for the life
of the partition, and a reset in place keeps the same partition.

A guest's own view of reference time does not necessarily follow that jump.

## How it shows up

On KVM, a Windows guest with Hyper-V enlightenments and VBS enabled stops booting after a
guest initiated restart. It looks like a hang at the firmware logo, but the guest has
bugchecked: `0x5C HAL_INITIALIZATION_FAILED`, early enough that nothing is painted to the
screen, which is why it reads as a hang.

Traced on the host across the reset:

* the guest installs its clock timer (`config=0x1ef8`, direct mode, vector `0xEF`) and writes
  a deadline of `384962560`, which is 38.50 s;
* the reference counter at that moment reads `22352044`, which is 2.24 s;
* the timer fires 36 seconds later, and that is exactly how long the previous boot ran.

The HAL arms that timer during clock initialization and polls for it with a bounded budget.
When it does not fire, the HAL retires it, runs out of timer candidates and bugchecks. On a
cold start both sides begin at zero, the deadline is correct, and the guest boots.

For scale, over the same 180 second window the clock produced 91 expirations after a reset,
against roughly 99,000 per vCPU on a cold boot.

## The fix

Add `StateElement::survives_machine_reset()`, defaulting to false, and set it for
`ReferenceTime`. `reset_all()` skips an element that declares it, and `check_reset_all()` no
longer requires such an element to match its at-reset value.

The at-reset value stays 0. It is still what a newly created partition starts from, and
restore still compares against it: restore goes through `restore()` rather than `reset_all()`,
where writing the saved value is correct.

## Scope

`virt_kvm` and `virt_mshv` partition resets both go through `reset_all()`, so both were
affected. `virt_whp` resets through the platform's own partition reset and does not take this
path. aarch64 has an empty per-VM state trait, so there is no reference time element there.

## Testing

Verified on KVM with a nested Windows guest running Hyper-V and VBS: a guest initiated restart
returns, with uptime dropping across the reboot and the VMM taking the reset in place path.
Repeated on a second guest with HVCI enabled, and on a non-VBS guest that was never affected.
Before the change the same test timed out every run.

I do not have an mshv host, so that side is fixed by construction and is untested.
