### PR TITLE
[release/1.8.2607] crypto: Error message cleanup

### DIFF
--- a/support/crypto/src/aes_256_cbc/mod.rs
+++ b/support/crypto/src/aes_256_cbc/mod.rs
@@ -32,7 +32,7 @@ pub struct Aes256Cbc(sys::Aes256CbcInner);
 
 /// An error for AES-256-CBC cryptographic operations.
 #[derive(Clone, Debug, Error)]
-#[error("AES-256-CBC error")]
+#[error("AES-256-CBC operation failed")]
 pub struct Aes256CbcError(#[source] super::BackendError);
 
 impl Aes256Cbc {

--- a/support/crypto/src/aes_256_cbc/ossl.rs
+++ b/support/crypto/src/aes_256_cbc/ossl.rs
@@ -30,26 +30,26 @@ impl Aes256CbcInner {
 
     pub fn enc_ctx(&self) -> Result<Aes256CbcEncCtxInner<'_>, Aes256CbcError> {
         let mut ctx = openssl::cipher_ctx::CipherCtx::new()
-            .map_err(|e| err(e, "creating encrypt context"))?;
+            .map_err(|e| err(e, "creating the encryption context"))?;
         ctx.encrypt_init(
             Some(openssl::cipher::Cipher::aes_256_cbc()),
             Some(&self.key),
             None,
         )
-        .map_err(|e| err(e, "encrypt init"))?;
+        .map_err(|e| err(e, "initializing the encryption context"))?;
         ctx.set_padding(false);
         Ok(Aes256CbcEncCtxInner { ctx, _dummy: &() })
     }
 
     pub fn dec_ctx(&self) -> Result<Aes256CbcDecCtxInner<'_>, Aes256CbcError> {
         let mut ctx = openssl::cipher_ctx::CipherCtx::new()
-            .map_err(|e| err(e, "creating decrypt context"))?;
+            .map_err(|e| err(e, "creating the decryption context"))?;
         ctx.decrypt_init(
             Some(openssl::cipher::Cipher::aes_256_cbc()),
             Some(&self.key),
             None,
         )
-        .map_err(|e| err(e, "decrypt init"))?;
+        .map_err(|e| err(e, "initializing the decryption context"))?;
         ctx.set_padding(false);
         Ok(Aes256CbcDecCtxInner { ctx, _dummy: &() })
     }
@@ -61,7 +61,7 @@ impl Aes256CbcEncCtxInner<'_> {
             vec![0u8; data.len() + openssl::cipher::Cipher::aes_256_cbc().block_size()]; // block size padding room
         self.ctx
             .encrypt_init(None, None, Some(iv))
-            .map_err(|e| err(e, "setting iv for encryption"))?;
+            .map_err(|e| err(e, "setting the encryption IV"))?;
         let count = self
             .ctx
             .cipher_update(data, Some(&mut output))
@@ -81,7 +81,7 @@ impl Aes256CbcDecCtxInner<'_> {
             vec![0u8; data.len() + openssl::cipher::Cipher::aes_256_cbc().block_size()]; // block size padding room
         self.ctx
             .decrypt_init(None, None, Some(iv))
-            .map_err(|e| err(e, "setting iv for decryption"))?;
+            .map_err(|e| err(e, "setting the decryption IV"))?;
         let count = self
             .ctx
             .cipher_update(data, Some(&mut output))

--- a/support/crypto/src/aes_256_cbc/symcrypt.rs
+++ b/support/crypto/src/aes_256_cbc/symcrypt.rs
@@ -26,7 +26,7 @@ fn err(e: symcrypt::errors::SymCryptError, op: &'static str) -> Aes256CbcError {
 
 impl Aes256CbcInner {
     pub fn new(key: &[u8; KEY_LEN]) -> Result<Self, Aes256CbcError> {
-        let expanded = AesExpandedKey::new(key).map_err(|e| err(e, "expanding AES key"))?;
+        let expanded = AesExpandedKey::new(key).map_err(|e| err(e, "expanding the AES key"))?;
         Ok(Aes256CbcInner { key: expanded })
     }
 

--- a/support/crypto/src/aes_256_gcm/mod.rs
+++ b/support/crypto/src/aes_256_gcm/mod.rs
@@ -37,7 +37,7 @@ pub struct Aes256Gcm(sys::Aes256GcmInner);
 
 /// An error for AES-256-GCM cryptographic operations.
 #[derive(Clone, Debug, Error)]
-#[error("AES-256-GCM error")]
+#[error("AES-256-GCM operation failed")]
 pub struct Aes256GcmError(#[source] super::BackendError);
 
 impl Aes256Gcm {

--- a/support/crypto/src/aes_256_gcm/ossl.rs
+++ b/support/crypto/src/aes_256_gcm/ossl.rs
@@ -30,25 +30,25 @@ impl Aes256GcmInner {
 
     pub fn enc_ctx(&self) -> Result<Aes256GcmEncCtxInner<'_>, Aes256GcmError> {
         let mut ctx = openssl::cipher_ctx::CipherCtx::new()
-            .map_err(|e| err(e, "creating encrypt context"))?;
+            .map_err(|e| err(e, "creating the encryption context"))?;
         ctx.encrypt_init(
             Some(openssl::cipher::Cipher::aes_256_gcm()),
             Some(&self.key),
             None,
         )
-        .map_err(|e| err(e, "encrypt init"))?;
+        .map_err(|e| err(e, "initializing the encryption context"))?;
         Ok(Aes256GcmEncCtxInner { ctx, _dummy: &() })
     }
 
     pub fn dec_ctx(&self) -> Result<Aes256GcmDecCtxInner<'_>, Aes256GcmError> {
         let mut ctx = openssl::cipher_ctx::CipherCtx::new()
-            .map_err(|e| err(e, "creating decrypt context"))?;
+            .map_err(|e| err(e, "creating the decryption context"))?;
         ctx.decrypt_init(
             Some(openssl::cipher::Cipher::aes_256_gcm()),
             Some(&self.key),
             None,
         )
-        .map_err(|e| err(e, "decrypt init"))?;
+        .map_err(|e| err(e, "initializing the decryption context"))?;
         Ok(Aes256GcmDecCtxInner { ctx, _dummy: &() })
     }
 }
@@ -63,7 +63,7 @@ impl Aes256GcmEncCtxInner<'_> {
         let mut output = vec![0u8; data.len()];
         self.ctx
             .encrypt_init(None, None, Some(iv))
-            .map_err(|e| err(e, "setting iv for encryption"))?;
+            .map_err(|e| err(e, "setting the encryption IV"))?;
         let count = self
             .ctx
             .cipher_update(data, Some(&mut output))
@@ -75,7 +75,7 @@ impl Aes256GcmEncCtxInner<'_> {
         output.truncate(count + rest);
         self.ctx
             .tag(tag)
-            .map_err(|e| err(e, "getting authentication tag"))?;
+            .map_err(|e| err(e, "reading the authentication tag"))?;
         Ok(output)
     }
 }
@@ -90,7 +90,7 @@ impl Aes256GcmDecCtxInner<'_> {
         let mut output = vec![0u8; data.len()];
         self.ctx
             .decrypt_init(None, None, Some(iv))
-            .map_err(|e| err(e, "setting iv for decryption"))?;
+            .map_err(|e| err(e, "setting the decryption IV"))?;
         let count = self
             .ctx
             .cipher_update(data, Some(&mut output))

--- a/support/crypto/src/aes_256_gcm/symcrypt.rs
+++ b/support/crypto/src/aes_256_gcm/symcrypt.rs
@@ -27,7 +27,7 @@ fn err(e: symcrypt::errors::SymCryptError, op: &'static str) -> Aes256GcmError {
 impl Aes256GcmInner {
     pub fn new(key: &[u8; KEY_LEN]) -> Result<Self, Aes256GcmError> {
         let key = GcmExpandedKey::new(key, symcrypt::cipher::BlockCipherType::AesBlock)
-            .map_err(|e| err(e, "expanding gcm key"))?;
+            .map_err(|e| err(e, "expanding the AES-GCM key"))?;
         Ok(Self { key })
     }
 

--- a/support/crypto/src/aes_256_gcm/win.rs
+++ b/support/crypto/src/aes_256_gcm/win.rs
@@ -26,7 +26,7 @@ static AES_256_GCM: LazyLock<Result<AlgHandle, Aes256GcmError>> = LazyLock::new(
         )
         .ok()
         .map(|()| AlgHandle(handle))
-        .map_err(|e| err(e, "open algorithm provider"))?;
+        .map_err(|e| err(e, "opening the AES algorithm provider"))?;
 
         windows::Win32::Security::Cryptography::BCryptSetProperty(
             handle.0.into(),
@@ -35,14 +35,14 @@ static AES_256_GCM: LazyLock<Result<AlgHandle, Aes256GcmError>> = LazyLock::new(
             0,
         )
         .ok()
-        .map_err(|e| err(e, "setting GCM Property"))?;
+        .map_err(|e| err(e, "selecting the GCM chaining mode"))?;
 
         Ok(handle)
     }
 });
 
 fn err(err: windows_result::Error, op: &'static str) -> Aes256GcmError {
-    Aes256GcmError(crate::BackendError(err, op))
+    Aes256GcmError(crate::BackendError::Windows(err, op))
 }
 
 pub struct Aes256GcmInner {
@@ -74,7 +74,7 @@ impl Aes256GcmInner {
         }
         .ok()
         .map(|()| KeyHandle(handle))
-        .map_err(|e| err(e, "importing key"))?;
+        .map_err(|e| err(e, "importing the AES key"))?;
 
         Ok(Aes256GcmInner { key })
     }
@@ -122,7 +122,7 @@ impl Aes256GcmEncCtxInner<'_> {
                 windows::Win32::Security::Cryptography::BCRYPT_FLAGS(0),
             )
             .ok()
-            .map_err(|e| err(e, "encrypt"))
+            .map_err(|e| err(e, "encrypting data"))
         }?;
         assert_eq!(crypted_len as usize, data.len());
         Ok(crypted_data)
@@ -164,7 +164,7 @@ impl Aes256GcmDecCtxInner<'_> {
                 windows::Win32::Security::Cryptography::BCRYPT_FLAGS(0),
             )
             .ok()
-            .map_err(|e| err(e, "decrypt"))
+            .map_err(|e| err(e, "decrypting data"))
         }?;
         assert_eq!(crypted_len as usize, data.len());
         Ok(crypted_data)

--- a/support/crypto/src/aes_kwp/mac.rs
+++ b/support/crypto/src/aes_kwp/mac.rs
@@ -16,6 +16,9 @@ const K_CC_ENCRYPT: u32 = 0;
 const K_CC_DECRYPT: u32 = 1;
 const K_CC_ALGORITHM_AES: u32 = 0;
 const K_CC_OPTION_ECB_MODE: u32 = 2;
+/// `kCCDecodeError`, the CommonCrypto status for input that fails an
+/// integrity check.
+const K_CC_DECODE_ERROR: i32 = -4304;
 
 // CommonCrypto ships in libSystem.dylib, which is auto-linked on macOS, so
 // no explicit `#[link]` attribute is required.
@@ -68,9 +71,9 @@ fn ecb_block(
         return Err(err(
             status,
             if op == K_CC_ENCRYPT {
-                "AES-ECB encrypt"
+                "encrypting an AES-ECB block"
             } else {
-                "AES-ECB decrypt"
+                "decrypting an AES-ECB block"
             },
         ));
     }
@@ -119,8 +122,7 @@ impl AesKeyUnwrapCtxInner<'_> {
     pub fn unwrap(&mut self, wrapped: &[u8]) -> Result<Vec<u8>, AesKeyWrapError> {
         match kwp::unwrap(wrapped, |block| ecb_block(self.key, K_CC_DECRYPT, block))? {
             Some(v) => Ok(v),
-            // -4304 == kCCDecodeError
-            None => Err(err(-4304, "AES key unwrap integrity check")),
+            None => Err(err(K_CC_DECODE_ERROR, "checking the key unwrap integrity")),
         }
     }
 }

--- a/support/crypto/src/aes_kwp/mod.rs
+++ b/support/crypto/src/aes_kwp/mod.rs
@@ -43,10 +43,10 @@ pub struct AesKeyWrapError(AesKeyWrapErrorInner);
 #[derive(Clone, Debug, Error)]
 enum AesKeyWrapErrorInner {
     /// The wrapping key size is not 16, 24, or 32 bytes.
-    #[error("invalid wrapping key size {0}")]
+    #[error("invalid wrapping key size {0}, expected 16, 24, or 32 bytes")]
     InvalidKeySize(usize),
     /// A backend cryptographic error occurred.
-    #[error("AES key wrap error")]
+    #[error("AES key wrap operation failed")]
     Backend(#[source] super::BackendError),
 }
 

--- a/support/crypto/src/aes_kwp/ossl.rs
+++ b/support/crypto/src/aes_kwp/ossl.rs
@@ -42,21 +42,21 @@ impl AesKeyWrapInner {
 
     pub fn wrap_ctx(&self) -> Result<AesKeyWrapCtxInner<'_>, AesKeyWrapError> {
         let cipher = openssl_cipher(self.key.len())?;
-        let mut ctx =
-            openssl::cipher_ctx::CipherCtx::new().map_err(|e| err(e, "creating wrap context"))?;
+        let mut ctx = openssl::cipher_ctx::CipherCtx::new()
+            .map_err(|e| err(e, "creating the wrap context"))?;
         ctx.set_flags(openssl::cipher_ctx::CipherCtxFlags::FLAG_WRAP_ALLOW);
         ctx.encrypt_init(Some(cipher), Some(&self.key), None)
-            .map_err(|e| err(e, "wrap init"))?;
+            .map_err(|e| err(e, "initializing the wrap context"))?;
         Ok(AesKeyWrapCtxInner { ctx, _dummy: &() })
     }
 
     pub fn unwrap_ctx(&self) -> Result<AesKeyUnwrapCtxInner<'_>, AesKeyWrapError> {
         let cipher = openssl_cipher(self.key.len())?;
-        let mut ctx =
-            openssl::cipher_ctx::CipherCtx::new().map_err(|e| err(e, "creating unwrap context"))?;
+        let mut ctx = openssl::cipher_ctx::CipherCtx::new()
+            .map_err(|e| err(e, "creating the unwrap context"))?;
         ctx.set_flags(openssl::cipher_ctx::CipherCtxFlags::FLAG_WRAP_ALLOW);
         ctx.decrypt_init(Some(cipher), Some(&self.key), None)
-            .map_err(|e| err(e, "unwrap init"))?;
+            .map_err(|e| err(e, "initializing the unwrap context"))?;
         Ok(AesKeyUnwrapCtxInner { ctx, _dummy: &() })
     }
 }
@@ -66,10 +66,10 @@ impl AesKeyWrapCtxInner<'_> {
         let mut output = Vec::with_capacity(payload.len() + 16);
         self.ctx
             .cipher_update_vec(payload, &mut output)
-            .map_err(|e| err(e, "wrapping key"))?;
+            .map_err(|e| err(e, "wrapping the key"))?;
         self.ctx
             .cipher_final_vec(&mut output)
-            .map_err(|e| err(e, "finalizing key wrap"))?;
+            .map_err(|e| err(e, "finalizing the key wrap"))?;
         Ok(output)
     }
 }
@@ -79,10 +79,10 @@ impl AesKeyUnwrapCtxInner<'_> {
         let mut output = Vec::with_capacity(wrapped_payload.len() + 16);
         self.ctx
             .cipher_update_vec(wrapped_payload, &mut output)
-            .map_err(|e| err(e, "unwrapping key"))?;
+            .map_err(|e| err(e, "unwrapping the key"))?;
         self.ctx
             .cipher_final_vec(&mut output)
-            .map_err(|e| err(e, "finalizing key unwrap"))?;
+            .map_err(|e| err(e, "finalizing the key unwrap"))?;
         Ok(output)
     }
 }

--- a/support/crypto/src/aes_kwp/symcrypt.rs
+++ b/support/crypto/src/aes_kwp/symcrypt.rs
@@ -35,7 +35,7 @@ impl AesKeyWrapInner {
                 )));
             }
         }
-        let key = AesKwpKey::new(key).map_err(|e| err(e, "expanding kwp key"))?;
+        let key = AesKwpKey::new(key).map_err(|e| err(e, "expanding the AES-KWP key"))?;
         Ok(AesKeyWrapInner { key })
     }
 
@@ -52,7 +52,7 @@ impl AesKeyWrapCtxInner<'_> {
     pub fn wrap(&mut self, payload: &[u8]) -> Result<Vec<u8>, AesKeyWrapError> {
         self.key
             .encrypt(payload)
-            .map_err(|e| err(e, "wrapping key"))
+            .map_err(|e| err(e, "wrapping the key"))
     }
 }
 
@@ -60,6 +60,6 @@ impl AesKeyUnwrapCtxInner<'_> {
     pub fn unwrap(&mut self, wrapped_payload: &[u8]) -> Result<Vec<u8>, AesKeyWrapError> {
         self.key
             .decrypt(wrapped_payload)
-            .map_err(|e| err(e, "unwrapping key"))
+            .map_err(|e| err(e, "unwrapping the key"))
     }
 }

--- a/support/crypto/src/aes_kwp/win.rs
+++ b/support/crypto/src/aes_kwp/win.rs
@@ -32,7 +32,7 @@ static AES_ECB: LazyLock<Result<AlgHandle, AesKeyWrapError>> = LazyLock::new(|| 
         )
         .ok()
         .map(|()| AlgHandle(handle))
-        .map_err(|e| err(e, "open algorithm provider"))?;
+        .map_err(|e| err(e, "opening the AES algorithm provider"))?;
 
         windows::Win32::Security::Cryptography::BCryptSetProperty(
             handle.0.into(),
@@ -41,14 +41,16 @@ static AES_ECB: LazyLock<Result<AlgHandle, AesKeyWrapError>> = LazyLock::new(|| 
             0,
         )
         .ok()
-        .map_err(|e| err(e, "setting ECB property"))?;
+        .map_err(|e| err(e, "selecting the ECB chaining mode"))?;
 
         Ok(handle)
     }
 });
 
 fn err(err: windows_result::Error, op: &'static str) -> AesKeyWrapError {
-    AesKeyWrapError(AesKeyWrapErrorInner::Backend(crate::BackendError(err, op)))
+    AesKeyWrapError(AesKeyWrapErrorInner::Backend(crate::BackendError::Windows(
+        err, op,
+    )))
 }
 
 fn import_key(key: &[u8]) -> Result<KeyHandle, AesKeyWrapError> {
@@ -74,7 +76,7 @@ fn import_key(key: &[u8]) -> Result<KeyHandle, AesKeyWrapError> {
         )
         .ok()
         .map(|()| KeyHandle(handle))
-        .map_err(|e| err(e, "importing key"))
+        .map_err(|e| err(e, "importing the wrapping key"))
     }
 }
 
@@ -113,9 +115,9 @@ fn ecb_block(
         err(
             e,
             if op == 0 {
-                "AES-ECB encrypt"
+                "encrypting an AES-ECB block"
             } else {
-                "AES-ECB decrypt"
+                "decrypting an AES-ECB block"
             },
         )
     })?;
@@ -168,7 +170,7 @@ impl AesKeyUnwrapCtxInner<'_> {
             Some(v) => Ok(v),
             None => Err(err(
                 windows_result::Error::from_hresult(NTE_BAD_DATA),
-                "AES key unwrap integrity check",
+                "checking the key unwrap integrity",
             )),
         }
     }

--- a/support/crypto/src/ecdsa/mod.rs
+++ b/support/crypto/src/ecdsa/mod.rs
@@ -25,7 +25,7 @@ use thiserror::Error;
 
 /// An error for ECDSA operations.
 #[derive(Debug, Error)]
-#[error("ECDSA error")]
+#[error("ECDSA operation failed")]
 pub struct EcdsaError(#[source] pub(crate) super::BackendError);
 
 /// The ECC curve to use.

--- a/support/crypto/src/ecdsa/ossl.rs
+++ b/support/crypto/src/ecdsa/ossl.rs
@@ -21,12 +21,12 @@ impl EcdsaKeyPairInner {
         let nid = match curve {
             EcdsaCurve::P384 => openssl::nid::Nid::SECP384R1,
         };
-        let ec_group =
-            openssl::ec::EcGroup::from_curve_name(nid).map_err(|e| err(e, "creating EC group"))?;
+        let ec_group = openssl::ec::EcGroup::from_curve_name(nid)
+            .map_err(|e| err(e, "creating the EC group"))?;
         let ec_key =
-            openssl::ec::EcKey::generate(&ec_group).map_err(|e| err(e, "generating EC key"))?;
+            openssl::ec::EcKey::generate(&ec_group).map_err(|e| err(e, "generating the EC key"))?;
         let pkey = openssl::pkey::PKey::from_ec_key(ec_key)
-            .map_err(|e| err(e, "converting EC key to PKey"))?;
+            .map_err(|e| err(e, "wrapping the EC key in a PKey"))?;
         Ok(Self { pkey, curve })
     }
 
@@ -34,19 +34,19 @@ impl EcdsaKeyPairInner {
         let ec_key = self
             .pkey
             .ec_key()
-            .map_err(|e| err(e, "getting EC key from PKey"))?;
-        let sig =
-            openssl::ecdsa::EcdsaSig::sign(hash, &ec_key).map_err(|e| err(e, "ECDSA sign"))?;
+            .map_err(|e| err(e, "extracting the EC key from the PKey"))?;
+        let sig = openssl::ecdsa::EcdsaSig::sign(hash, &ec_key)
+            .map_err(|e| err(e, "computing the ECDSA signature"))?;
 
         let key_size = self.curve.key_size();
         let r_bytes = sig
             .r()
             .to_vec_padded(key_size as i32)
-            .map_err(|e| err(e, "padding r"))?;
+            .map_err(|e| err(e, "encoding the signature r component"))?;
         let s_bytes = sig
             .s()
             .to_vec_padded(key_size as i32)
-            .map_err(|e| err(e, "padding s"))?;
+            .map_err(|e| err(e, "encoding the signature s component"))?;
 
         let mut result = Vec::with_capacity(key_size * 2);
         result.extend_from_slice(&r_bytes);
@@ -73,10 +73,10 @@ impl EcdsaPublicKeyInner {
         let nid = match curve {
             EcdsaCurve::P384 => openssl::nid::Nid::SECP384R1,
         };
-        let group =
-            openssl::ec::EcGroup::from_curve_name(nid).map_err(|e| err(e, "creating EC group"))?;
+        let group = openssl::ec::EcGroup::from_curve_name(nid)
+            .map_err(|e| err(e, "creating the EC group"))?;
         let mut ctx =
-            openssl::bn::BigNumContext::new().map_err(|e| err(e, "creating BigNumContext"))?;
+            openssl::bn::BigNumContext::new().map_err(|e| err(e, "creating the BigNum context"))?;
 
         // `public_key` is the raw `Qx || Qy` affine coordinates. Prepend the
         // `0x04` uncompressed-point tag and let OpenSSL parse the encoding,
@@ -86,21 +86,21 @@ impl EcdsaPublicKeyInner {
         encoded.push(0x04);
         encoded.extend_from_slice(public_key);
         let point = openssl::ec::EcPoint::from_bytes(&group, &encoded, &mut ctx)
-            .map_err(|e| err(e, "parsing EC public key point"))?;
+            .map_err(|e| err(e, "parsing the EC public key point"))?;
         let ec_key = openssl::ec::EcKey::from_public_key(&group, &point)
-            .map_err(|e| err(e, "constructing EC public key"))?;
+            .map_err(|e| err(e, "constructing the EC public key"))?;
         ec_key
             .check_key()
-            .map_err(|e| err(e, "validating EC public key"))?;
+            .map_err(|e| err(e, "validating the EC public key"))?;
         let pkey = openssl::pkey::PKey::from_ec_key(ec_key)
-            .map_err(|e| err(e, "converting EC key to PKey"))?;
+            .map_err(|e| err(e, "wrapping the EC key in a PKey"))?;
 
         Ok(Self { pkey, curve })
     }
 
     pub fn from_public_key_der(spki_der: &[u8]) -> Result<Self, EcdsaError> {
         let pkey = openssl::pkey::PKey::public_key_from_der(spki_der)
-            .map_err(|e| err(e, "parsing SubjectPublicKeyInfo"))?;
+            .map_err(|e| err(e, "parsing the SubjectPublicKeyInfo"))?;
         Self::from_pkey(pkey)
     }
 
@@ -112,7 +112,7 @@ impl EcdsaPublicKeyInner {
     ) -> Result<Self, EcdsaError> {
         let ec_key = pkey
             .ec_key()
-            .map_err(|e| err(e, "public key is not an EC key"))?;
+            .map_err(|e| err(e, "checking that the public key is an EC key"))?;
         // Determine the curve from the key rather than requiring the caller to
         // specify it.
         let curve = match ec_key.group().curve_name() {
@@ -120,13 +120,13 @@ impl EcdsaPublicKeyInner {
             _ => {
                 return Err(err(
                     openssl::error::ErrorStack::get(),
-                    "unsupported or unrecognized EC curve",
+                    "checking that the public key uses a supported EC curve",
                 ));
             }
         };
         ec_key
             .check_key()
-            .map_err(|e| err(e, "validating EC public key"))?;
+            .map_err(|e| err(e, "validating the EC public key"))?;
         Ok(Self { pkey, curve })
     }
 
@@ -141,43 +141,45 @@ impl EcdsaPublicKeyInner {
         let ec_key = self
             .pkey
             .ec_key()
-            .map_err(|e| err(e, "getting EC key from PKey"))?;
+            .map_err(|e| err(e, "extracting the EC key from the PKey"))?;
 
         let r = openssl::bn::BigNum::from_slice(&signature[..key_size])
-            .map_err(|e| err(e, "parsing r"))?;
+            .map_err(|e| err(e, "parsing the signature r component"))?;
         let s = openssl::bn::BigNum::from_slice(&signature[key_size..])
-            .map_err(|e| err(e, "parsing s"))?;
+            .map_err(|e| err(e, "parsing the signature s component"))?;
         let sig = openssl::ecdsa::EcdsaSig::from_private_components(r, s)
-            .map_err(|e| err(e, "constructing signature"))?;
+            .map_err(|e| err(e, "constructing the ECDSA signature"))?;
 
         sig.verify(hash, &ec_key)
-            .map_err(|e| err(e, "ECDSA verify"))
+            .map_err(|e| err(e, "verifying the ECDSA signature"))
     }
 
     pub fn public_key_bytes(&self) -> Result<Vec<u8>, EcdsaError> {
         let ec_key = self
             .pkey
             .ec_key()
-            .map_err(|e| err(e, "getting EC key from PKey"))?;
+            .map_err(|e| err(e, "extracting the EC key from the PKey"))?;
         let group = ec_key.group();
         let pub_key = ec_key.public_key();
 
         let mut ctx =
-            openssl::bn::BigNumContext::new().map_err(|e| err(e, "creating BigNumContext"))?;
-        let mut x = openssl::bn::BigNum::new().map_err(|e| err(e, "creating BigNum for x"))?;
-        let mut y = openssl::bn::BigNum::new().map_err(|e| err(e, "creating BigNum for y"))?;
+            openssl::bn::BigNumContext::new().map_err(|e| err(e, "creating the BigNum context"))?;
+        let mut x = openssl::bn::BigNum::new()
+            .map_err(|e| err(e, "creating a BigNum for the x coordinate"))?;
+        let mut y = openssl::bn::BigNum::new()
+            .map_err(|e| err(e, "creating a BigNum for the y coordinate"))?;
 
         pub_key
             .affine_coordinates_gfp(group, &mut x, &mut y, &mut ctx)
-            .map_err(|e| err(e, "getting affine coordinates"))?;
+            .map_err(|e| err(e, "reading the public key affine coordinates"))?;
 
         let key_size = self.curve.key_size();
         let x_bytes = x
             .to_vec_padded(key_size as i32)
-            .map_err(|e| err(e, "padding x coordinate"))?;
+            .map_err(|e| err(e, "encoding the x coordinate"))?;
         let y_bytes = y
             .to_vec_padded(key_size as i32)
-            .map_err(|e| err(e, "padding y coordinate"))?;
+            .map_err(|e| err(e, "encoding the y coordinate"))?;
 
         let mut result = Vec::with_capacity(key_size * 2);
         result.extend_from_slice(&x_bytes);

--- a/support/crypto/src/ecdsa/symcrypt.rs
+++ b/support/crypto/src/ecdsa/symcrypt.rs
@@ -19,6 +19,11 @@ fn der_err(err: der::Error, op: &'static str) -> EcdsaError {
     EcdsaError(crate::BackendError::Der(err, op))
 }
 
+/// An error for input that decoded but is not valid or supported.
+fn invalid_err(reason: &'static str) -> EcdsaError {
+    EcdsaError(crate::BackendError::Invalid(reason))
+}
+
 #[repr(transparent)] // Needed for the transmute in as_pub.
 pub struct EcdsaKeyPairInner(EcKey);
 
@@ -28,12 +33,14 @@ impl EcdsaKeyPairInner {
             EcdsaCurve::P384 => CurveType::NistP384,
         };
         let key = EcKey::generate_key_pair(curve_type, EcKeyUsage::EcDsa)
-            .map_err(|e| err(e, "generating ECDSA key pair"))?;
+            .map_err(|e| err(e, "generating the ECDSA key pair"))?;
         Ok(Self(key))
     }
 
     pub fn sign_prehash(&self, hash: &[u8]) -> Result<Vec<u8>, EcdsaError> {
-        self.0.ecdsa_sign(hash).map_err(|e| err(e, "ECDSA sign"))
+        self.0
+            .ecdsa_sign(hash)
+            .map_err(|e| err(e, "computing the ECDSA signature"))
     }
 
     pub(crate) fn as_pub(&self) -> &EcdsaPublicKeyInner {
@@ -55,7 +62,7 @@ impl EcdsaPublicKeyInner {
         // long inputs with `InvalidArgument`), so no separate length check is
         // needed here.
         let key = EcKey::set_public_key(curve_type, public_key, EcKeyUsage::EcDsa)
-            .map_err(|e| err(e, "importing public key"))?;
+            .map_err(|e| err(e, "importing the EC public key"))?;
         Ok(Self(key))
     }
 
@@ -65,37 +72,28 @@ impl EcdsaPublicKeyInner {
             der::asn1::ObjectIdentifier::new_unwrap("1.3.132.0.34");
 
         let spki = x509_cert::spki::SubjectPublicKeyInfoRef::from_der(spki_der)
-            .map_err(|e| der_err(e, "parsing SubjectPublicKeyInfo"))?;
+            .map_err(|e| der_err(e, "parsing the SubjectPublicKeyInfo"))?;
 
         // Determine the curve from the algorithm's named-curve parameter rather
         // than requiring the caller to specify it.
         let curve_oid = spki
             .algorithm
             .parameters
-            .ok_or_else(|| {
-                err(
-                    SymCryptError::InvalidArgument,
-                    "missing EC curve parameters",
-                )
-            })?
+            .ok_or_else(|| invalid_err("EC public key has no named curve parameter"))?
             .decode_as::<der::asn1::ObjectIdentifier>()
-            .map_err(|e| der_err(e, "decoding EC curve OID"))?;
+            .map_err(|e| der_err(e, "decoding the EC curve OID"))?;
         let curve = if curve_oid == SECP384R1 {
             EcdsaCurve::P384
         } else {
-            return Err(err(
-                SymCryptError::InvalidArgument,
-                "unsupported or unrecognized EC curve",
-            ));
+            return Err(invalid_err("public key uses an unsupported EC curve"));
         };
 
         // The SubjectPublicKey bit string is the uncompressed EC point
         // `0x04 || Qx || Qy`; strip the `0x04` tag to get `Qx || Qy`.
         let point = spki.subject_public_key.raw_bytes();
         if point.len() != 1 + 2 * curve.key_size() || point[0] != 0x04 {
-            return Err(err(
-                SymCryptError::InvalidArgument,
-                "public key is not an uncompressed EC point (0x04 || Qx || Qy)",
+            return Err(invalid_err(
+                "EC public key is not an uncompressed point (0x04 || Qx || Qy)",
             ));
         }
         Self::from_public_key_bytes(curve, &point[1..])
@@ -111,13 +109,13 @@ impl EcdsaPublicKeyInner {
             Err(SymCryptError::SignatureVerificationFailure | SymCryptError::InvalidArgument) => {
                 Ok(false)
             }
-            Err(e) => Err(err(e, "ECDSA verify")),
+            Err(e) => Err(err(e, "verifying the ECDSA signature")),
         }
     }
 
     pub fn public_key_bytes(&self) -> Result<Vec<u8>, EcdsaError> {
         self.0
             .export_public_key()
-            .map_err(|e| err(e, "exporting public key"))
+            .map_err(|e| err(e, "exporting the EC public key"))
     }
 }

--- a/support/crypto/src/ecdsa/win.rs
+++ b/support/crypto/src/ecdsa/win.rs
@@ -8,8 +8,6 @@ use super::EcdsaError;
 use crate::win::AlgHandle;
 use crate::win::KeyHandle;
 use std::sync::LazyLock;
-use windows::Win32::Foundation::E_INVALIDARG;
-use windows::Win32::Foundation::E_UNEXPECTED;
 use windows::Win32::Foundation::STATUS_INVALID_SIGNATURE;
 use windows::Win32::Security::Cryptography::BCRYPT_ALG_HANDLE;
 use windows::Win32::Security::Cryptography::BCRYPT_ECCKEY_BLOB;
@@ -51,11 +49,16 @@ static ECDSA_P384: LazyLock<Result<AlgHandle, EcdsaError>> = LazyLock::new(|| {
     }
     .ok()
     .map(|()| AlgHandle(handle))
-    .map_err(|e| err(e, "BCryptOpenAlgorithmProvider"))
+    .map_err(|e| err(e, "opening the ECDSA algorithm provider"))
 });
 
 fn err(err: windows_result::Error, op: &'static str) -> EcdsaError {
-    EcdsaError(crate::BackendError(err, op))
+    EcdsaError(crate::BackendError::Windows(err, op))
+}
+
+/// An error for input that decoded but is not valid or supported.
+fn invalid_err(reason: &'static str) -> EcdsaError {
+    EcdsaError(crate::BackendError::Invalid(reason))
 }
 
 fn alg_handle(curve: EcdsaCurve) -> Result<&'static AlgHandle, EcdsaError> {
@@ -82,7 +85,7 @@ fn key_length_bits(handle: &KeyHandle) -> Result<u32, EcdsaError> {
         )
     }
     .ok()
-    .map_err(|e| err(e, "BCryptGetProperty(BCRYPT_KEY_LENGTH)"))?;
+    .map_err(|e| err(e, "querying the EC key length"))?;
     Ok(u32::from_ne_bytes(value))
 }
 
@@ -101,7 +104,7 @@ impl EcdsaKeyPairInner {
         // SAFETY: FFI call to generate key pair with a valid algorithm handle.
         unsafe { BCryptGenerateKeyPair(alg.0, &mut handle, bits, 0) }
             .ok()
-            .map_err(|e| err(e, "BCryptGenerateKeyPair"))?;
+            .map_err(|e| err(e, "generating the ECDSA key pair"))?;
         // The handle is now owned; `KeyHandle` destroys it on drop, including
         // if finalization below fails.
         let handle = KeyHandle(handle);
@@ -109,7 +112,7 @@ impl EcdsaKeyPairInner {
         // SAFETY: FFI call to finalize key pair with a valid handle.
         unsafe { BCryptFinalizeKeyPair(handle.0, 0) }
             .ok()
-            .map_err(|e| err(e, "BCryptFinalizeKeyPair"))?;
+            .map_err(|e| err(e, "finalizing the ECDSA key pair"))?;
 
         Ok(Self { handle, curve })
     }
@@ -131,7 +134,7 @@ impl EcdsaKeyPairInner {
             )
         }
         .ok()
-        .map_err(|e| err(e, "BCryptSignHash"))?;
+        .map_err(|e| err(e, "signing the message hash"))?;
 
         signature.truncate(bytes_written as usize);
         Ok(signature)
@@ -162,12 +165,8 @@ impl EcdsaPublicKeyInner {
         // the exact `Qx || Qy` length here so all backends reject non-canonical
         // encodings identically.
         if public_key.len() != key_size * 2 {
-            return Err(err(
-                windows_result::Error::new(
-                    E_INVALIDARG,
-                    "ECDSA public key is not the expected length (Qx || Qy)",
-                ),
-                "validating ECDSA public key length",
+            return Err(invalid_err(
+                "EC public key is not the expected Qx || Qy length",
             ));
         }
 
@@ -192,7 +191,7 @@ impl EcdsaPublicKeyInner {
         // SAFETY: FFI import with a valid algorithm handle and a public key blob.
         unsafe { BCryptImportKeyPair(alg.0, None, BCRYPT_ECCPUBLIC_BLOB, &mut handle, &blob, 0) }
             .ok()
-            .map_err(|e| err(e, "BCryptImportKeyPair"))?;
+            .map_err(|e| err(e, "importing the ECDSA public key"))?;
 
         Ok(Self {
             handle: KeyHandle(handle),
@@ -225,10 +224,7 @@ impl EcdsaPublicKeyInner {
         // by crypt32 and the szOID_* constants are null-terminated ASCII.
         let is_ec = !oid.is_null() && unsafe { oid.as_bytes() == szOID_ECC_PUBLIC_KEY.as_bytes() };
         if !is_ec {
-            return Err(err(
-                windows_result::Error::new(E_INVALIDARG, "public key is not an ECDSA key"),
-                "validating public key algorithm",
-            ));
+            return Err(invalid_err("public key is not an EC key"));
         }
 
         let mut handle = BCRYPT_KEY_HANDLE::default();
@@ -243,7 +239,7 @@ impl EcdsaPublicKeyInner {
                 &mut handle,
             )
         }
-        .map_err(|e| err(e, "CryptImportPublicKeyInfoEx2"))?;
+        .map_err(|e| err(e, "importing the certificate public key"))?;
         let handle = KeyHandle(handle);
 
         // Determine the curve from the imported key. NIST prime curves each
@@ -252,13 +248,7 @@ impl EcdsaPublicKeyInner {
         let curve = match key_length_bits(&handle)? {
             384 => EcdsaCurve::P384,
             _ => {
-                return Err(err(
-                    windows_result::Error::new(
-                        E_INVALIDARG,
-                        "unsupported or unrecognized EC curve",
-                    ),
-                    "determining public key curve",
-                ));
+                return Err(invalid_err("public key uses an unsupported EC curve"));
             }
         };
 
@@ -280,7 +270,9 @@ impl EcdsaPublicKeyInner {
         if status == STATUS_INVALID_SIGNATURE {
             return Ok(false);
         }
-        status.ok().map_err(|e| err(e, "BCryptVerifySignature"))?;
+        status
+            .ok()
+            .map_err(|e| err(e, "verifying the ECDSA signature"))?;
         Ok(true)
     }
 
@@ -298,7 +290,7 @@ impl EcdsaPublicKeyInner {
             )
         }
         .ok()
-        .map_err(|e| err(e, "BCryptExportKey(size)"))?;
+        .map_err(|e| err(e, "querying the public key export size"))?;
 
         let mut blob = vec![0u8; blob_len as usize];
         // SAFETY: FFI call to export the key with correctly sized buffer.
@@ -313,17 +305,14 @@ impl EcdsaPublicKeyInner {
             )
         }
         .ok()
-        .map_err(|e| err(e, "BCryptExportKey(data)"))?;
+        .map_err(|e| err(e, "exporting the public key"))?;
 
         // BCrypt ECC public blob layout: BCRYPT_ECCKEY_BLOB header + X + Y
         let header_size = size_of::<BCRYPT_ECCKEY_BLOB>();
         let key_size = self.curve.key_size();
 
         if (blob_len as usize) < header_size + key_size * 2 {
-            return Err(err(
-                windows_result::Error::new(E_UNEXPECTED, "public key blob too small"),
-                "validating public key blob size",
-            ));
+            return Err(invalid_err("exported EC public key blob is too small"));
         }
 
         // Return just Qx || Qy (skip the BCRYPT_ECCKEY_BLOB header).

--- a/support/crypto/src/hmac_sha_256/mod.rs
+++ b/support/crypto/src/hmac_sha_256/mod.rs
@@ -19,7 +19,7 @@ use thiserror::Error;
 
 /// An error for HMAC-SHA-256 operations.
 #[derive(Clone, Debug, Error)]
-#[error("HMAC-SHA-256 error")]
+#[error("HMAC-SHA-256 operation failed")]
 pub struct HmacSha256Error(#[source] super::BackendError);
 
 /// Compute the HMAC-SHA-256 of `data` using `key`.

--- a/support/crypto/src/hmac_sha_256/ossl.rs
+++ b/support/crypto/src/hmac_sha_256/ossl.rs
@@ -10,22 +10,23 @@ fn err(err: openssl::error::ErrorStack, op: &'static str) -> HmacSha256Error {
 }
 
 pub fn hmac_sha_256(key: &[u8], data: &[u8]) -> Result<[u8; 32], HmacSha256Error> {
-    let pkey = openssl::pkey::PKey::hmac(key).map_err(|e| err(e, "creating HMAC key"))?;
-    let mut ctx = openssl::md_ctx::MdCtx::new().map_err(|e| err(e, "creating MdCtx"))?;
+    let pkey = openssl::pkey::PKey::hmac(key).map_err(|e| err(e, "creating the HMAC key"))?;
+    let mut ctx =
+        openssl::md_ctx::MdCtx::new().map_err(|e| err(e, "creating the message digest context"))?;
 
     ctx.digest_sign_init(Some(openssl::md::Md::sha256()), &pkey)
-        .map_err(|e| err(e, "HMAC init"))?;
+        .map_err(|e| err(e, "initializing the HMAC context"))?;
     ctx.digest_sign_update(data)
-        .map_err(|e| err(e, "HMAC update"))?;
+        .map_err(|e| err(e, "hashing the input data"))?;
 
     let size = ctx
         .digest_sign_final(None)
-        .map_err(|e| err(e, "HMAC get required size"))?;
+        .map_err(|e| err(e, "querying the HMAC output size"))?;
     assert_eq!(size, 32);
 
     let mut output = [0u8; 32];
     ctx.digest_sign_final(Some(&mut output))
-        .map_err(|e| err(e, "HMAC finalize"))?;
+        .map_err(|e| err(e, "finalizing the HMAC"))?;
 
     Ok(output)
 }

--- a/support/crypto/src/hmac_sha_256/symcrypt.rs
+++ b/support/crypto/src/hmac_sha_256/symcrypt.rs
@@ -12,5 +12,5 @@ fn err(e: SymCryptError, op: &'static str) -> HmacSha256Error {
 }
 
 pub fn hmac_sha_256(key: &[u8], data: &[u8]) -> Result<[u8; 32], HmacSha256Error> {
-    hmac_sha256(key, data).map_err(|e| err(e, "computing HMAC-SHA-256"))
+    hmac_sha256(key, data).map_err(|e| err(e, "computing the HMAC-SHA-256"))
 }

--- a/support/crypto/src/kbkdf/mod.rs
+++ b/support/crypto/src/kbkdf/mod.rs
@@ -21,13 +21,13 @@ use thiserror::Error;
 // DEVNOTE: The openssl variant would use BackendError if the kdf functions were implemented in the openssl crate itself
 #[cfg(openssl)]
 #[derive(Debug, Error)]
-#[error("KBKDF derivation error")]
+#[error("KBKDF derivation failed")]
 pub struct KbkdfError(#[source] openssl_kdf::kdf::KdfError);
 
 /// An error for KBKDF operations.
 #[cfg(not(openssl))]
 #[derive(Debug, Error)]
-#[error("KBKDF derivation error")]
+#[error("KBKDF derivation failed")]
 pub struct KbkdfError(#[source] super::BackendError);
 
 /// Derive key material using SP800-108 KBKDF with HMAC-SHA-256 in counter

--- a/support/crypto/src/kbkdf/symcrypt.rs
+++ b/support/crypto/src/kbkdf/symcrypt.rs
@@ -21,6 +21,12 @@ pub fn kbkdf_hmac_sha256(
             "deriving SP800-108 KBKDF",
         )));
     }
-    sp800_108_counter_mode(HmacAlgorithm::HmacSha256, key, label, context, output_len)
-        .map_err(|e| KbkdfError(crate::BackendError::SymCrypt(e, "deriving SP800-108 KBKDF")))
+    sp800_108_counter_mode(HmacAlgorithm::HmacSha256, key, label, context, output_len).map_err(
+        |e| {
+            KbkdfError(crate::BackendError::SymCrypt(
+                e,
+                "deriving the SP800-108 key",
+            ))
+        },
+    )
 }

--- a/support/crypto/src/lib.rs
+++ b/support/crypto/src/lib.rs
@@ -79,46 +79,60 @@ pub(crate) mod win;
 /// operation being performed when the error occurred.
 #[cfg(openssl)]
 #[derive(Clone, Debug, thiserror::Error)]
-#[error("openssl error during {1}")]
+#[error("openssl error while {1}")]
 pub(crate) struct BackendError(#[source] openssl::error::ErrorStack, &'static str);
 
 /// An error that occurred in the crypto backend, with a description of the
 /// operation being performed when the error occurred.
 #[cfg(all(native, windows))]
 #[derive(Clone, Debug, thiserror::Error)]
-#[error("windows crypto error during {1}")]
-pub(crate) struct BackendError(#[source] windows_result::Error, &'static str);
+pub(crate) enum BackendError {
+    /// An error returned by a CNG or CryptoAPI function.
+    #[error("windows crypto error while {1}")]
+    Windows(#[source] windows_result::Error, &'static str),
+    /// The input decoded successfully but is not valid or supported for the
+    /// operation being attempted.
+    #[error("{0}")]
+    Invalid(&'static str),
+}
 
 /// An error that occurred in the crypto backend, with a description of the
 /// operation being performed when the error occurred.
 #[cfg(symcrypt)]
 #[derive(Clone, Debug, thiserror::Error)]
-#[error("symcrypt backend error during {1}")]
 pub(crate) enum BackendError {
-    /// An error from the SymCrypt library, with the operation being performed when the error occurred.
+    /// An error from the SymCrypt library.
+    #[error("symcrypt error while {1}")]
     SymCrypt(#[source] symcrypt::errors::SymCryptError, &'static str),
-    /// An error from encoding or decoding PKCS#8, with the operation being performed when the error occurred.
-    Pkcs8Encoding(#[source] pkcs8::Error, &'static str),
-    /// An error from DER encoding or decoding, with the operation being performed when the error occurred.
+    /// The input decoded successfully but is not valid or supported for the
+    /// operation being attempted.
+    #[error("{0}")]
+    Invalid(&'static str),
+    /// An error from encoding or decoding DER.
+    #[error("DER error while {1}")]
     Der(#[source] der::Error, &'static str),
 }
 
+/// An error that occurred in the crypto backend, with a description of the
+/// operation being performed when the error occurred.
 #[cfg(all(native, target_os = "macos"))]
 #[derive(Clone, Debug, thiserror::Error)]
 pub(crate) enum BackendError {
     /// An OSStatus error from a Security.framework or CoreFoundation API.
-    #[error("{1} returned a failure status code")]
+    #[error("macOS crypto error while {1}")]
     OsStatus(#[source] mac::OsStatusCode, &'static str),
-    /// A Security.framework or CoreFoundation API returned a null pointer.
-    #[error("{0}: returned null")]
+    /// A Security.framework or CoreFoundation API returned a null pointer
+    /// without reporting an error.
+    #[error("macOS crypto error while {0}: the API returned null")]
     Null(&'static str),
     /// A Security.framework API returned an error via CFErrorRef.
-    #[error("Security.framework error during {1}: {0}")]
+    #[error("macOS crypto error while {1}: {0}")]
     Sec(String, &'static str),
-    /// An error from encoding or decoding PKCS#8.
-    #[error("PKCS#8 error during {1}")]
-    Pkcs8(#[source] pkcs8::Error, &'static str),
-    /// An error from DER encoding or decoding.
-    #[error("DER error during {1}")]
+    /// The input decoded successfully but is not valid or supported for the
+    /// operation being attempted.
+    #[error("{0}")]
+    Invalid(&'static str),
+    /// An error from encoding or decoding DER.
+    #[error("DER error while {1}")]
     Der(#[source] der::Error, &'static str),
 }

--- a/support/crypto/src/mac.rs
+++ b/support/crypto/src/mac.rs
@@ -162,7 +162,7 @@ pub(crate) unsafe fn sec_err(error: CFErrorRef, op: &'static str) -> super::Back
     // CFStringRef (or null) which cf_string_to_string handles.
     let msg = unsafe { cf_string_to_string(CFErrorCopyDescription(error)) };
     drop(release);
-    super::BackendError::Sec(format!("code {}: {}", code, msg), op)
+    super::BackendError::Sec(format!("OSStatus {code}: {msg}"), op)
 }
 
 /// Returns the CFError's numeric code, or `None` if `error` is null. Does

--- a/support/crypto/src/pkcs7/mac.rs
+++ b/support/crypto/src/pkcs7/mac.rs
@@ -66,7 +66,7 @@ pub struct Pkcs7SignedDataInner {
 
 impl Pkcs7SignedDataInner {
     pub fn from_der(data: &[u8]) -> Result<Self, Pkcs7Error> {
-        let raw_der = cf_data(data, "CFDataCreate for SignedData").map_err(err)?;
+        let raw_der = cf_data(data, "creating a CFData for the signed data").map_err(err)?;
         let decoder = decoder_from_cfdata(&raw_der).map_err(err)?;
         // Sanity-check that this is a well-formed CMS SignedData with
         // at least one signer; matches the symmetric check done by the
@@ -77,11 +77,11 @@ impl Pkcs7SignedDataInner {
         if !s.success() {
             return Err(err(crate::BackendError::OsStatus(
                 s,
-                "CMSDecoderGetNumSigners",
+                "counting the PKCS#7 signers",
             )));
         }
         if signers == 0 {
-            return Err(err(crate::BackendError::Null(
+            return Err(err(crate::BackendError::Invalid(
                 "PKCS#7 SignedData has no signers",
             )));
         }
@@ -117,12 +117,12 @@ impl Pkcs7SignedDataInner {
         if !s.success() {
             return Err(err(crate::BackendError::OsStatus(
                 s,
-                "CMSDecoderGetNumSigners",
+                "counting the PKCS#7 signers",
             )));
         }
         if signers != 1 {
-            return Err(err(crate::BackendError::Null(
-                "expected exactly one signer in PKCS#7 SignedData",
+            return Err(err(crate::BackendError::Invalid(
+                "PKCS#7 SignedData does not have exactly one signer",
             )));
         }
         let signer = copy_signer_cert(&self.decoder, 0)?;
@@ -146,7 +146,7 @@ fn decoder_from_cfdata(data: &CfHandle) -> Result<CfHandle, crate::BackendError>
     // SAFETY: decoder is initialized by CMSDecoderCreate.
     let s = unsafe { CMSDecoderCreate(&mut decoder) };
     if !s.success() {
-        return Err(crate::BackendError::OsStatus(s, "CMSDecoderCreate"));
+        return Err(crate::BackendError::OsStatus(s, "creating the CMS decoder"));
     }
     let decoder = CfHandle(decoder);
 
@@ -158,14 +158,17 @@ fn decoder_from_cfdata(data: &CfHandle) -> Result<CfHandle, crate::BackendError>
     // contract; decoder is valid.
     let s = unsafe { CMSDecoderUpdateMessage(decoder.0, ptr, len) };
     if !s.success() {
-        return Err(crate::BackendError::OsStatus(s, "CMSDecoderUpdateMessage"));
+        return Err(crate::BackendError::OsStatus(
+            s,
+            "decoding the PKCS#7 message",
+        ));
     }
     // SAFETY: decoder valid.
     let s = unsafe { CMSDecoderFinalizeMessage(decoder.0) };
     if !s.success() {
         return Err(crate::BackendError::OsStatus(
             s,
-            "CMSDecoderFinalizeMessage",
+            "finalizing the PKCS#7 message",
         ));
     }
     Ok(decoder)
@@ -178,11 +181,13 @@ fn copy_signer_cert(decoder: &CfHandle, index: usize) -> Result<X509Certificate,
     if !s.success() {
         return Err(err(crate::BackendError::OsStatus(
             s,
-            "CMSDecoderCopySignerCert",
+            "copying the signer certificate",
         )));
     }
     if cert.is_null() {
-        return Err(err(crate::BackendError::Null("CMSDecoderCopySignerCert")));
+        return Err(err(crate::BackendError::Null(
+            "copying the signer certificate",
+        )));
     }
     let cert = CfHandle(cert);
     sec_cert_to_x509(cert.0)
@@ -193,7 +198,10 @@ fn copy_all_certs(decoder: &CfHandle) -> Result<Vec<X509Certificate>, crate::Bac
     // SAFETY: decoder valid; arr receives an owned CFArray.
     let s = unsafe { CMSDecoderCopyAllCerts(decoder.0, &mut arr) };
     if !s.success() {
-        return Err(crate::BackendError::OsStatus(s, "CMSDecoderCopyAllCerts"));
+        return Err(crate::BackendError::OsStatus(
+            s,
+            "copying the embedded certificates",
+        ));
     }
     if arr.is_null() {
         return Ok(Vec::new());
@@ -221,7 +229,9 @@ fn sec_cert_to_x509(cert: CFTypeRef) -> Result<X509Certificate, Pkcs7Error> {
     // SAFETY: cert is a valid SecCertificateRef.
     let der = unsafe { SecCertificateCopyData(cert) };
     if der.is_null() {
-        return Err(err(crate::BackendError::Null("SecCertificateCopyData")));
+        return Err(err(crate::BackendError::Null(
+            "copying the certificate DER bytes",
+        )));
     }
     let der = CfHandle(der);
     // SAFETY: der is a valid owned CFDataRef.
@@ -237,7 +247,7 @@ fn sec_cert_to_x509(cert: CFTypeRef) -> Result<X509Certificate, Pkcs7Error> {
 /// API.
 fn extract_first_signer_signature(p7_der: &[u8]) -> Result<Vec<u8>, Pkcs7Error> {
     fn bogus() -> Pkcs7Error {
-        err(crate::BackendError::Null("malformed PKCS#7 SignerInfo"))
+        err(crate::BackendError::Invalid("malformed PKCS#7 SignerInfo"))
     }
 
     /// Parse one DER TLV. Returns `(tag, contents, rest)`. Supports
@@ -337,8 +347,12 @@ fn cms_sign(
     let cert_der = cert
         .to_der()
         .map_err(|e| crate::rsa::RsaError(crate::x509::mac::backend_err(e)))?;
-    let parsed_cert = Certificate::from_der(&cert_der)
-        .map_err(|e| crate::rsa::RsaError(crate::BackendError::Der(e, "parsing signer cert")))?;
+    let parsed_cert = Certificate::from_der(&cert_der).map_err(|e| {
+        crate::rsa::RsaError(crate::BackendError::Der(
+            e,
+            "parsing the signer certificate",
+        ))
+    })?;
 
     let digest_alg = AlgorithmIdentifierOwned {
         oid: der::oid::db::rfc5912::ID_SHA_256,
@@ -387,16 +401,19 @@ fn cms_sign(
         signer_infos: cms::signed_data::SignerInfos(signer_infos),
     };
 
-    let sd_der = signed_data
-        .to_der()
-        .map_err(|e| crate::rsa::RsaError(crate::BackendError::Der(e, "encoding SignedData")))?;
+    let sd_der = signed_data.to_der().map_err(|e| {
+        crate::rsa::RsaError(crate::BackendError::Der(e, "encoding the SignedData"))
+    })?;
     let content = der::AnyRef::try_from(sd_der.as_slice()).map_err(|e| {
-        crate::rsa::RsaError(crate::BackendError::Der(e, "wrapping SignedData in Any"))
+        crate::rsa::RsaError(crate::BackendError::Der(
+            e,
+            "wrapping the SignedData in an ANY",
+        ))
     })?;
     let ci = ContentInfo {
         content_type: ID_SIGNED_DATA,
         content: content.into(),
     };
     ci.to_der()
-        .map_err(|e| crate::rsa::RsaError(crate::BackendError::Der(e, "encoding ContentInfo")))
+        .map_err(|e| crate::rsa::RsaError(crate::BackendError::Der(e, "encoding the ContentInfo")))
 }

--- a/support/crypto/src/pkcs7/mod.rs
+++ b/support/crypto/src/pkcs7/mod.rs
@@ -44,13 +44,13 @@ pub struct Pkcs7SignedData(sys::Pkcs7SignedDataInner);
 /// An error for PKCS#7 operations.
 #[cfg(not(rust))]
 #[derive(Clone, Debug, Error)]
-#[error("PKCS#7 error")]
+#[error("PKCS#7 operation failed")]
 pub struct Pkcs7Error(#[source] super::BackendError);
 
 /// An error for PKCS#7 operations.
 #[cfg(rust)]
 #[derive(Clone, Debug, Error)]
-#[error("PKCS#7 error during {1}")]
+#[error("PKCS#7 operation failed while {1}")]
 pub struct Pkcs7Error(#[source] der::Error, &'static str);
 
 /// An error encountered while verifying a PKCS#7 signed data object.
@@ -58,13 +58,13 @@ pub struct Pkcs7Error(#[source] der::Error, &'static str);
 #[derive(Debug, Error)]
 pub enum Pkcs7VerifyError {
     /// A PKCS#7 parsing or structural error.
-    #[error("PKCS#7 error")]
+    #[error("failed to process the PKCS#7 signed data")]
     Pkcs7(#[from] Pkcs7Error),
     /// An RSA signature verification error.
-    #[error("RSA error")]
+    #[error("failed to verify a signature")]
     Rsa(#[from] crate::rsa::RsaError),
     /// An X.509 certificate error.
-    #[error("X509 error")]
+    #[error("failed to process a certificate")]
     X509(#[from] crate::x509::X509Error),
 }
 

--- a/support/crypto/src/pkcs7/ossl.rs
+++ b/support/crypto/src/pkcs7/ossl.rs
@@ -15,14 +15,14 @@ impl Pkcs7SignedDataInner {
     pub fn from_der(data: &[u8]) -> Result<Self, Pkcs7Error> {
         openssl::pkcs7::Pkcs7::from_der(data)
             .map(Self)
-            .map_err(|e| err(e, "decoding pkcs#7 from DER"))
+            .map_err(|e| err(e, "decoding the PKCS#7 message from DER"))
     }
 
     #[cfg(any(test, feature = "test_helpers"))]
     pub fn to_der(&self) -> Result<Vec<u8>, Pkcs7Error> {
         self.0
             .to_der()
-            .map_err(|e| err(e, "encoding pkcs#7 as DER"))
+            .map_err(|e| err(e, "encoding the PKCS#7 message as DER"))
     }
 
     #[cfg(any(test, feature = "test_helpers"))]
@@ -35,7 +35,7 @@ impl Pkcs7SignedDataInner {
             crate::rsa::RsaError(crate::BackendError(err, op))
         }
         let certs = openssl::stack::Stack::new()
-            .map_err(|e| rsa_err(e, "creating empty certificate stack"))?;
+            .map_err(|e| rsa_err(e, "creating the certificate stack"))?;
         let pkcs7 = openssl::pkcs7::Pkcs7::sign(
             &cert.0.0,
             &key_pair.0.0,
@@ -49,7 +49,7 @@ impl Pkcs7SignedDataInner {
                 | openssl::pkcs7::Pkcs7Flags::BINARY
                 | openssl::pkcs7::Pkcs7Flags::NOATTR,
         )
-        .map_err(|e| rsa_err(e, "pkcs7 signing"))?;
+        .map_err(|e| rsa_err(e, "signing the PKCS#7 message"))?;
         Ok(Self(pkcs7))
     }
 
@@ -59,11 +59,11 @@ impl Pkcs7SignedDataInner {
         signed_content: &[u8],
     ) -> Result<bool, Pkcs7VerifyError> {
         let mut store = openssl::x509::store::X509StoreBuilder::new()
-            .map_err(|e| err(e, "creating x509 store builder"))?;
+            .map_err(|e| err(e, "creating the X.509 trust store"))?;
         for trusted_cert in trusted_certs {
             store
                 .add_cert(trusted_cert.0.0.clone())
-                .map_err(|e| err(e, "adding certificate to store"))?;
+                .map_err(|e| err(e, "adding a certificate to the trust store"))?;
         }
 
         // - `PARTIAL_CHAIN`: accept any cert in the store as a trust
@@ -76,7 +76,7 @@ impl Pkcs7SignedDataInner {
             | openssl::x509::verify::X509VerifyFlags::NO_CHECK_TIME;
         store
             .set_flags(store_flags)
-            .map_err(|e| err(e, "setting x509 verify flags"))?;
+            .map_err(|e| err(e, "setting the trust store verify flags"))?;
 
         // `X509Purpose::ANY`: accept any key-usage / extended-key-usage.
         // Without this, OpenSSL rejects UEFI signature-list certs with
@@ -84,14 +84,14 @@ impl Pkcs7SignedDataInner {
         // with the usages a verifier expects for the default purpose.
         store
             .set_purpose(openssl::x509::X509PurposeId::ANY)
-            .map_err(|e| err(e, "setting x509 purpose"))?;
+            .map_err(|e| err(e, "setting the trust store certificate purpose"))?;
 
         let store = store.build();
 
         // openssl-rs requires an explicit certificate stack here even though
         // PKCS#7 verification supports omitting it.
-        let cert_stack = openssl::stack::Stack::new()
-            .map_err(|e| err(e, "allocating empty certificate stack"))?;
+        let cert_stack =
+            openssl::stack::Stack::new().map_err(|e| err(e, "creating the certificate stack"))?;
 
         match self.0.verify(
             &cert_stack,

--- a/support/crypto/src/pkcs7/symcrypt_rust.rs
+++ b/support/crypto/src/pkcs7/symcrypt_rust.rs
@@ -26,20 +26,21 @@ pub struct Pkcs7SignedDataInner(SignedData);
 
 impl Pkcs7SignedDataInner {
     pub fn from_der(data: &[u8]) -> Result<Self, Pkcs7Error> {
-        let ci = ContentInfo::from_der(data).map_err(|e| err(e, "parsing PKCS#7 ContentInfo"))?;
+        let ci =
+            ContentInfo::from_der(data).map_err(|e| err(e, "parsing the PKCS#7 ContentInfo"))?;
         if ci.content_type != ID_SIGNED_DATA {
             return Err(err(
                 der::ErrorKind::OidUnknown {
                     oid: ci.content_type,
                 }
                 .to_error(),
-                "unrecognized content type OID",
+                "checking that the PKCS#7 content type is signedData",
             ));
         }
         let signed_data = ci
             .content
             .decode_as::<SignedData>()
-            .map_err(|e| err(e, "decoding PKCS#7 SignedData"))?;
+            .map_err(|e| err(e, "decoding the PKCS#7 SignedData"))?;
         Ok(Self(signed_data))
     }
 
@@ -49,15 +50,15 @@ impl Pkcs7SignedDataInner {
         let sd_der = self
             .0
             .to_der()
-            .map_err(|e| err(e, "encoding PKCS#7 SignedData"))?;
+            .map_err(|e| err(e, "encoding the PKCS#7 SignedData"))?;
         let content = der::AnyRef::try_from(sd_der.as_slice())
-            .map_err(|e| err(e, "wrapping SignedData in Any"))?;
+            .map_err(|e| err(e, "wrapping the SignedData in an ANY"))?;
         let ci = ContentInfo {
             content_type: ID_SIGNED_DATA,
             content: content.into(),
         };
         ci.to_der()
-            .map_err(|e| err(e, "encoding PKCS#7 ContentInfo"))
+            .map_err(|e| err(e, "encoding the PKCS#7 ContentInfo"))
     }
 
     #[cfg(any(test, feature = "test_helpers"))]

--- a/support/crypto/src/pkcs7/win.rs
+++ b/support/crypto/src/pkcs7/win.rs
@@ -18,18 +18,15 @@ use windows::Win32::Security::Cryptography::PKCS_7_ASN_ENCODING;
 use windows::Win32::Security::Cryptography::X509_ASN_ENCODING;
 
 fn err(e: windows_result::Error, op: &'static str) -> Pkcs7Error {
-    Pkcs7Error(crate::BackendError(e, op))
+    Pkcs7Error(crate::BackendError::Windows(e, op))
 }
 
 fn last_err(op: &'static str) -> Pkcs7Error {
     err(windows_result::Error::from_thread(), op)
 }
 
-fn bogus_err(op: &'static str) -> Pkcs7Error {
-    err(
-        windows_result::Error::from_hresult(windows::core::HRESULT(-1)),
-        op,
-    )
+fn invalid_err(reason: &'static str) -> Pkcs7Error {
+    Pkcs7Error(crate::BackendError::Invalid(reason))
 }
 
 /// RAII wrapper around `HCRYPTMSG`.
@@ -62,19 +59,19 @@ impl Pkcs7SignedDataInner {
                 encoding, 0, 0, None, None, None,
             )
         };
-        let h = NonNull::new(h).ok_or_else(|| last_err("CryptMsgOpenToDecode"))?;
+        let h = NonNull::new(h).ok_or_else(|| last_err("opening the PKCS#7 message"))?;
         let msg = Msg(h);
 
         // SAFETY: `data` is a valid byte slice; msg is a fresh decode handle.
         unsafe {
             windows::Win32::Security::Cryptography::CryptMsgUpdate(h.as_ptr(), Some(data), true)
         }
-        .map_err(|e| err(e, "CryptMsgUpdate"))?;
+        .map_err(|e| err(e, "decoding the PKCS#7 message"))?;
 
         // Confirm the message is SignedData (type 2)
         let mtype: u32 = get_param_value::<u32>(&msg, CMSG_TYPE_PARAM, 0)?;
         if mtype != CMSG_SIGNED.0 {
-            return Err(bogus_err("PKCS#7 message is not SignedData"));
+            return Err(invalid_err("PKCS#7 message is not SignedData"));
         }
 
         Ok(Self { msg })
@@ -112,7 +109,7 @@ impl Pkcs7SignedDataInner {
         use windows::core::PSTR;
 
         fn rsa_err(e: windows_result::Error, op: &'static str) -> crate::rsa::RsaError {
-            crate::rsa::RsaError(crate::BackendError(e, op))
+            crate::rsa::RsaError(crate::BackendError::Windows(e, op))
         }
 
         // Hand the BCrypt private key to NCrypt as an ephemeral (no-name,
@@ -123,7 +120,7 @@ impl Pkcs7SignedDataInner {
         // SAFETY: standard NCrypt provider open; MS_KEY_STORAGE_PROVIDER is
         // a static, NUL-terminated wide string.
         unsafe { NCryptOpenStorageProvider(&mut prov_raw, MS_KEY_STORAGE_PROVIDER, 0) }
-            .map_err(|e| rsa_err(e, "NCryptOpenStorageProvider"))?;
+            .map_err(|e| rsa_err(e, "opening the software key storage provider"))?;
         let prov = NCryptProv(prov_raw);
 
         let mut nkey_raw = NCRYPT_KEY_HANDLE::default();
@@ -142,7 +139,7 @@ impl Pkcs7SignedDataInner {
                 NCRYPT_FLAGS(0),
             )
         }
-        .map_err(|e| rsa_err(e, "NCryptImportKey"))?;
+        .map_err(|e| rsa_err(e, "importing the signing key"))?;
         let nkey = NCryptKey(nkey_raw);
 
         // Build a fresh CERT_CONTEXT from the DER so we can attach the
@@ -175,7 +172,7 @@ impl Pkcs7SignedDataInner {
                 Some(std::ptr::from_ref(&key_ctx).cast::<c_void>()),
             )
         }
-        .map_err(|e| rsa_err(e, "CertSetCertificateContextProperty"))?;
+        .map_err(|e| rsa_err(e, "associating the signing key with the certificate"))?;
 
         let hash_alg = CRYPT_ALGORITHM_IDENTIFIER {
             pszObjId: PSTR(szOID_NIST_sha256.0.cast_mut()),
@@ -214,7 +211,7 @@ impl Pkcs7SignedDataInner {
                 &mut needed,
             )
         }
-        .map_err(|e| rsa_err(e, "CryptSignMessage (size query)"))?;
+        .map_err(|e| rsa_err(e, "querying the signed message size"))?;
 
         let mut out = vec![0u8; needed as usize];
         // SAFETY: out is sized per the previous query; data buffer pointer
@@ -230,7 +227,7 @@ impl Pkcs7SignedDataInner {
                 &mut needed,
             )
         }
-        .map_err(|e| rsa_err(e, "CryptSignMessage"))?;
+        .map_err(|e| rsa_err(e, "signing the PKCS#7 message"))?;
         out.truncate(needed as usize);
 
         Self::from_der(&out).map_err(|Pkcs7Error(e)| crate::rsa::RsaError(e))
@@ -253,8 +250,8 @@ impl Pkcs7SignedDataInner {
         // Require exactly one signer.
         let signer_count: u32 = get_param_value::<u32>(&self.msg, CMSG_SIGNER_COUNT_PARAM, 0)?;
         if signer_count != 1 {
-            return Err(bogus_err(
-                "expected exactly one signer in PKCS#7 SignedData",
+            return Err(invalid_err(
+                "PKCS#7 SignedData does not have exactly one signer",
             ));
         }
 
@@ -262,7 +259,9 @@ impl Pkcs7SignedDataInner {
         // CMSG_SIGNER_INFO.
         let signer_buf = get_param_bytes(&self.msg, CMSG_SIGNER_INFO_PARAM, 0)?;
         if signer_buf.len() < size_of::<CMSG_SIGNER_INFO>() {
-            return Err(bogus_err("CMSG_SIGNER_INFO buffer smaller than struct"));
+            return Err(invalid_err(
+                "PKCS#7 signer info is smaller than a CMSG_SIGNER_INFO",
+            ));
         }
         // SAFETY: CryptMsgGetParam(CMSG_SIGNER_INFO_PARAM) populates a
         // CMSG_SIGNER_INFO at the start of the buffer. Read unaligned to
@@ -275,16 +274,16 @@ impl Pkcs7SignedDataInner {
         // both blobs empty here; reject them explicitly rather than
         // silently matching an empty issuer.
         if si.Issuer.cbData == 0 || si.SerialNumber.cbData == 0 {
-            return Err(bogus_err(
-                "signer identifier is not IssuerAndSerialNumber (SubjectKeyIdentifier not supported)",
+            return Err(invalid_err(
+                "PKCS#7 signer identifier is not an IssuerAndSerialNumber; SubjectKeyIdentifier signers are not supported",
             ));
         }
         let want_issuer =
-            blob_to_vec(&si.Issuer).ok_or_else(|| bogus_err("malformed signer issuer blob"))?;
+            blob_to_vec(&si.Issuer).ok_or_else(|| invalid_err("malformed signer issuer blob"))?;
         let want_serial = blob_to_vec(&si.SerialNumber)
-            .ok_or_else(|| bogus_err("malformed signer serial blob"))?;
+            .ok_or_else(|| invalid_err("malformed signer serial number blob"))?;
         let signature = blob_to_vec(&si.EncryptedHash)
-            .ok_or_else(|| bogus_err("malformed signer signature blob"))?;
+            .ok_or_else(|| invalid_err("malformed signer signature blob"))?;
 
         let count: u32 = get_param_value::<u32>(&self.msg, CMSG_CERT_COUNT_PARAM, 0)?;
         for i in 0..count {
@@ -297,7 +296,9 @@ impl Pkcs7SignedDataInner {
                 return Ok((cert, signature));
             }
         }
-        Err(bogus_err("no embedded certificate matches the signer"))
+        Err(invalid_err(
+            "no embedded certificate matches the PKCS#7 signer",
+        ))
     }
 }
 
@@ -327,7 +328,7 @@ fn get_param_bytes(msg: &Msg, param: u32, index: u32) -> Result<Vec<u8>, Pkcs7Er
             &mut size,
         )
     }
-    .map_err(|e| err(e, "CryptMsgGetParam (size query)"))?;
+    .map_err(|e| err(e, "querying a PKCS#7 message parameter size"))?;
     let mut buf = vec![0u8; size as usize];
     // SAFETY: buf is sized per the size query.
     unsafe {
@@ -339,7 +340,7 @@ fn get_param_bytes(msg: &Msg, param: u32, index: u32) -> Result<Vec<u8>, Pkcs7Er
             &mut size,
         )
     }
-    .map_err(|e| err(e, "CryptMsgGetParam"))?;
+    .map_err(|e| err(e, "reading a PKCS#7 message parameter"))?;
     buf.truncate(size as usize);
     Ok(buf)
 }
@@ -348,7 +349,9 @@ fn get_param_bytes(msg: &Msg, param: u32, index: u32) -> Result<Vec<u8>, Pkcs7Er
 fn get_param_value<T: Copy>(msg: &Msg, param: u32, index: u32) -> Result<T, Pkcs7Error> {
     let buf = get_param_bytes(msg, param, index)?;
     if buf.len() < size_of::<T>() {
-        return Err(bogus_err("CryptMsgGetParam returned short buffer"));
+        return Err(invalid_err(
+            "CryptMsgGetParam returned fewer bytes than it reported",
+        ));
     }
     // SAFETY: buffer is at least size_of::<T>() bytes; T is Copy.
     Ok(unsafe { std::ptr::read_unaligned(buf.as_ptr().cast::<T>()) })

--- a/support/crypto/src/rsa/mac.rs
+++ b/support/crypto/src/rsa/mac.rs
@@ -66,10 +66,6 @@ fn der_err(e: der::Error, op: &'static str) -> RsaError {
     RsaError(crate::BackendError::Der(e, op))
 }
 
-fn pkcs8_err(e: pkcs8::Error, op: &'static str) -> RsaError {
-    RsaError(crate::BackendError::Pkcs8(e, op))
-}
-
 fn null_err(op: &'static str) -> RsaError {
     RsaError(crate::BackendError::Null(op))
 }
@@ -103,17 +99,17 @@ unsafe fn rsa_sec_err(error: CFErrorRef, op: &'static str) -> RsaError {
 fn build_pkcs1_pub(n: &[u8], e: &[u8]) -> Result<Vec<u8>, RsaError> {
     use der::asn1::UintRef;
     let pk = pkcs1::RsaPublicKey {
-        modulus: UintRef::new(n).map_err(|e| der_err(e, "encoding modulus"))?,
-        public_exponent: UintRef::new(e).map_err(|e| der_err(e, "encoding e"))?,
+        modulus: UintRef::new(n).map_err(|e| der_err(e, "encoding the modulus"))?,
+        public_exponent: UintRef::new(e).map_err(|e| der_err(e, "encoding the public exponent"))?,
     };
     pk.to_der()
-        .map_err(|e| der_err(e, "encoding PKCS#1 RSA public key"))
+        .map_err(|e| der_err(e, "encoding the PKCS#1 RSA public key"))
 }
 
 /// Parse a PKCS#1 RSAPublicKey DER blob into (n, e) byte vectors.
 fn parse_pkcs1_pub(der_bytes: &[u8]) -> Result<(Vec<u8>, Vec<u8>), RsaError> {
     let pk = pkcs1::RsaPublicKey::from_der(der_bytes)
-        .map_err(|e| der_err(e, "parsing PKCS#1 RSA public key"))?;
+        .map_err(|e| der_err(e, "parsing the PKCS#1 RSA public key"))?;
     Ok((
         pk.modulus.as_bytes().to_vec(),
         pk.public_exponent.as_bytes().to_vec(),
@@ -122,7 +118,10 @@ fn parse_pkcs1_pub(der_bytes: &[u8]) -> Result<(Vec<u8>, Vec<u8>), RsaError> {
 
 /// Import an RSA private key from a PKCS#1 RSAPrivateKey DER blob.
 fn import_private(pkcs1_der: &[u8]) -> Result<CfHandle, RsaError> {
-    let key_data = rsa_cf_data(pkcs1_der, "create CFData for PKCS#1 RSA private key")?;
+    let key_data = rsa_cf_data(
+        pkcs1_der,
+        "creating a CFData for the PKCS#1 RSA private key",
+    )?;
     // SAFETY: kSecAttr* are valid CFStringRef extern statics.
     let attrs = unsafe {
         rsa_cf_dict(
@@ -130,7 +129,7 @@ fn import_private(pkcs1_der: &[u8]) -> Result<CfHandle, RsaError> {
                 (kSecAttrKeyType, kSecAttrKeyTypeRSA),
                 (kSecAttrKeyClass, kSecAttrKeyClassPrivate),
             ],
-            "create attrs for RSA private key import",
+            "creating the RSA private key import attributes",
         )?
     };
     let mut error: CFErrorRef = ptr::null();
@@ -138,14 +137,14 @@ fn import_private(pkcs1_der: &[u8]) -> Result<CfHandle, RsaError> {
     let key = unsafe { SecKeyCreateWithData(key_data.0, attrs.0, &mut error) };
     if key.is_null() {
         // SAFETY: error is either null or a valid CFErrorRef.
-        return Err(unsafe { rsa_sec_err(error, "import RSA private key") });
+        return Err(unsafe { rsa_sec_err(error, "importing the RSA private key") });
     }
     Ok(CfHandle(key))
 }
 
 /// Import an RSA public key from a PKCS#1 RSAPublicKey DER blob.
 fn import_public(pkcs1_der: &[u8]) -> Result<CfHandle, RsaError> {
-    let key_data = rsa_cf_data(pkcs1_der, "create CFData for PKCS#1 RSA public key")?;
+    let key_data = rsa_cf_data(pkcs1_der, "creating a CFData for the PKCS#1 RSA public key")?;
     // SAFETY: kSecAttr* are valid CFStringRef extern statics.
     let attrs = unsafe {
         rsa_cf_dict(
@@ -153,7 +152,7 @@ fn import_public(pkcs1_der: &[u8]) -> Result<CfHandle, RsaError> {
                 (kSecAttrKeyType, kSecAttrKeyTypeRSA),
                 (kSecAttrKeyClass, kSecAttrKeyClassPublic),
             ],
-            "create attrs for RSA public key import",
+            "creating the RSA public key import attributes",
         )?
     };
     let mut error: CFErrorRef = ptr::null();
@@ -161,7 +160,7 @@ fn import_public(pkcs1_der: &[u8]) -> Result<CfHandle, RsaError> {
     let key = unsafe { SecKeyCreateWithData(key_data.0, attrs.0, &mut error) };
     if key.is_null() {
         // SAFETY: error is null or valid.
-        return Err(unsafe { rsa_sec_err(error, "import RSA public key") });
+        return Err(unsafe { rsa_sec_err(error, "importing the RSA public key") });
     }
     Ok(CfHandle(key))
 }
@@ -174,7 +173,7 @@ pub(crate) struct RsaPublicKeyInner(CfHandle);
 
 impl RsaKeyPairInner {
     pub fn generate(bits: u32) -> Result<Self, RsaError> {
-        let size = rsa_cf_number(bits as i32, "create CFNumber for key size")?;
+        let size = rsa_cf_number(bits as i32, "creating a CFNumber for the key size")?;
         // SAFETY: kSecAttr* are valid CFStringRef extern statics.
         let params = unsafe {
             rsa_cf_dict(
@@ -182,7 +181,7 @@ impl RsaKeyPairInner {
                     (kSecAttrKeyType, kSecAttrKeyTypeRSA),
                     (kSecAttrKeySizeInBits, size.0),
                 ],
-                "create params for RSA key generation",
+                "creating the RSA key generation parameters",
             )?
         };
         let mut error: CFErrorRef = ptr::null();
@@ -190,19 +189,18 @@ impl RsaKeyPairInner {
         let key = unsafe { SecKeyCreateRandomKey(params.0, &mut error) };
         if key.is_null() {
             // SAFETY: error is null or valid.
-            return Err(unsafe { rsa_sec_err(error, "generate RSA key") });
+            return Err(unsafe { rsa_sec_err(error, "generating the RSA key") });
         }
         Ok(Self(CfHandle(key)))
     }
 
     pub fn from_pkcs8_der(der_bytes: &[u8]) -> Result<Self, RsaError> {
         let pki = pkcs8::PrivateKeyInfoRef::from_der(der_bytes)
-            .map_err(|e| der_err(e, "parsing PKCS#8 DER"))?;
+            .map_err(|e| der_err(e, "parsing the PKCS#8 DER private key"))?;
         if pki.algorithm.oid != pkcs1::ALGORITHM_OID {
-            return Err(pkcs8_err(
-                pkcs8::Error::KeyMalformed(pkcs8::KeyError::Invalid),
-                "PKCS#8 algorithm is not rsaEncryption",
-            ));
+            return Err(RsaError(crate::BackendError::Invalid(
+                "PKCS#8 private key is not an RSA key",
+            )));
         }
         let handle = import_private(pki.private_key.as_bytes())?;
         Ok(Self(handle))
@@ -218,7 +216,7 @@ impl RsaKeyPairInner {
         let data = unsafe { SecKeyCopyExternalRepresentation(self.0.0, &mut error) };
         if data.is_null() {
             // SAFETY: error is null or valid.
-            return Err(unsafe { rsa_sec_err(error, "export RSA private key") });
+            return Err(unsafe { rsa_sec_err(error, "exporting the RSA private key") });
         }
         let data = CfHandle(data);
         // SAFETY: data.0 is a valid CFDataRef.
@@ -230,11 +228,11 @@ impl RsaKeyPairInner {
                 parameters: Some(der::Any::null()),
             },
             private_key: OctetString::new(pkcs1_der)
-                .map_err(|e| der_err(e, "wrapping PKCS#1 in OCTET STRING"))?,
+                .map_err(|e| der_err(e, "wrapping the PKCS#1 key in an OCTET STRING"))?,
             public_key: None,
         };
         pki.to_der()
-            .map_err(|e| der_err(e, "encoding PKCS#8 PrivateKeyInfo"))
+            .map_err(|e| der_err(e, "encoding the PKCS#8 PrivateKeyInfo"))
     }
 
     pub fn oaep_decrypt(
@@ -242,7 +240,7 @@ impl RsaKeyPairInner {
         input: &[u8],
         hash_algorithm: HashAlgorithm,
     ) -> Result<Vec<u8>, RsaError> {
-        let ct = rsa_cf_data(input, "create CFData")?;
+        let ct = rsa_cf_data(input, "creating a CFData for the ciphertext")?;
         let mut error: CFErrorRef = ptr::null();
         // SAFETY: self.0.0 and ct.0 are valid.
         let pt = unsafe {
@@ -255,7 +253,7 @@ impl RsaKeyPairInner {
         };
         if pt.is_null() {
             // SAFETY: error is null or valid.
-            return Err(unsafe { rsa_sec_err(error, "RSA-OAEP decrypt") });
+            return Err(unsafe { rsa_sec_err(error, "decrypting with RSA-OAEP") });
         }
         let pt = CfHandle(pt);
         // SAFETY: pt.0 is valid.
@@ -287,13 +285,13 @@ impl RsaKeyPairInner {
 }
 
 fn sign(key: &CfHandle, alg: CFStringRef, data: &[u8]) -> Result<Vec<u8>, RsaError> {
-    let data_cf = rsa_cf_data(data, "create CFData")?;
+    let data_cf = rsa_cf_data(data, "creating a CFData for the message")?;
     let mut error: CFErrorRef = ptr::null();
     // SAFETY: key, alg, data_cf are valid.
     let sig = unsafe { SecKeyCreateSignature(key.0, alg, data_cf.0, &mut error) };
     if sig.is_null() {
         // SAFETY: error is null or valid.
-        return Err(unsafe { rsa_sec_err(error, "RSA sign") });
+        return Err(unsafe { rsa_sec_err(error, "computing the RSA signature") });
     }
     let sig = CfHandle(sig);
     // SAFETY: sig.0 valid.
@@ -306,8 +304,8 @@ fn verify(
     message: &[u8],
     signature: &[u8],
 ) -> Result<bool, RsaError> {
-    let msg = rsa_cf_data(message, "create CFData for message")?;
-    let sig = rsa_cf_data(signature, "create CFData for signature")?;
+    let msg = rsa_cf_data(message, "creating a CFData for the message")?;
+    let sig = rsa_cf_data(signature, "creating a CFData for the signature")?;
     let mut error: CFErrorRef = ptr::null();
     // SAFETY: all CF refs are valid.
     let ok = unsafe { SecKeyVerifySignature(key.0, alg, msg.0, sig.0, &mut error) };
@@ -326,7 +324,7 @@ fn verify(
             Ok(false)
         }
         // SAFETY: error is a valid CFErrorRef (sec_err takes ownership).
-        Some(_) => Err(unsafe { rsa_sec_err(error, "RSA verify") }),
+        Some(_) => Err(unsafe { rsa_sec_err(error, "verifying the RSA signature") }),
     }
 }
 
@@ -342,7 +340,7 @@ impl RsaPublicKeyInner {
         hash_algorithm: HashAlgorithm,
     ) -> Result<Vec<u8>, RsaError> {
         let pub_key = self.public_key_handle()?;
-        let pt = rsa_cf_data(input, "create CFData")?;
+        let pt = rsa_cf_data(input, "creating a CFData for the plaintext")?;
         let mut error: CFErrorRef = ptr::null();
         // SAFETY: pub_key and pt valid.
         let ct = unsafe {
@@ -355,7 +353,7 @@ impl RsaPublicKeyInner {
         };
         if ct.is_null() {
             // SAFETY: error is null or valid.
-            return Err(unsafe { rsa_sec_err(error, "RSA-OAEP encrypt") });
+            return Err(unsafe { rsa_sec_err(error, "encrypting with RSA-OAEP") });
         }
         let ct = CfHandle(ct);
         // SAFETY: ct.0 valid.
@@ -402,7 +400,7 @@ impl RsaPublicKeyInner {
         let mut error: CFErrorRef = ptr::null();
         // SAFETY: pub_key.0 is valid.
         let data = unsafe { SecKeyCopyExternalRepresentation(pub_key.0, &mut error) };
-        assert!(!data.is_null(), "SecKeyCopyExternalRepresentation failed");
+        assert!(!data.is_null(), "failed to export the RSA public key");
         let data = CfHandle(data);
         // SAFETY: data.0 is valid.
         let der_bytes = unsafe { cf_data_to_vec(data.0) };
@@ -419,7 +417,7 @@ impl RsaPublicKeyInner {
         // SAFETY: self.0.0 is a valid SecKeyRef.
         let pk = unsafe { SecKeyCopyPublicKey(self.0.0) };
         if pk.is_null() {
-            return Err(null_err("SecKeyCopyPublicKey"));
+            return Err(null_err("copying the public key"));
         }
         Ok(CfHandle(pk))
     }

--- a/support/crypto/src/rsa/mod.rs
+++ b/support/crypto/src/rsa/mod.rs
@@ -47,14 +47,14 @@ use thiserror::Error;
     all(native, target_os = "macos")
 ))]
 #[derive(Debug, Error)]
-#[error("RSA error")]
+#[error("RSA operation failed")]
 pub struct RsaError(#[source] pub(crate) super::BackendError);
 
 /// An error for RSA operations.
 // TODO: Make this clone once RustCrypto rsa::errors::Error is cloneable
 #[cfg(rust)]
 #[derive(Debug, Error)]
-#[error("RSA error during {1}")]
+#[error("RSA operation failed while {1}")]
 pub struct RsaError(
     #[source] pub(crate) rsa::errors::Error,
     pub(crate) &'static str,

--- a/support/crypto/src/rsa/ossl.rs
+++ b/support/crypto/src/rsa/ossl.rs
@@ -16,17 +16,19 @@ pub struct RsaKeyPairInner(pub(crate) openssl::pkey::PKey<openssl::pkey::Private
 
 impl RsaKeyPairInner {
     pub fn generate(bits: u32) -> Result<Self, RsaError> {
-        let rsa = openssl::rsa::Rsa::generate(bits).map_err(|e| err(e, "generating RSA key"))?;
-        let pkey =
-            openssl::pkey::PKey::from_rsa(rsa).map_err(|e| err(e, "converting RSA to PKey"))?;
+        let rsa =
+            openssl::rsa::Rsa::generate(bits).map_err(|e| err(e, "generating the RSA key"))?;
+        let pkey = openssl::pkey::PKey::from_rsa(rsa)
+            .map_err(|e| err(e, "wrapping the RSA key in a PKey"))?;
         Ok(Self(pkey))
     }
 
     pub fn from_pkcs8_der(der: &[u8]) -> Result<Self, RsaError> {
         let pkey = openssl::pkey::PKey::private_key_from_pkcs8(der)
-            .map_err(|e| err(e, "parsing PKCS#8 DER"))?;
+            .map_err(|e| err(e, "parsing the PKCS#8 DER private key"))?;
         // Ensure the key is actually an RSA key.
-        pkey.rsa().map_err(|e| err(e, "checking key is RSA"))?;
+        pkey.rsa()
+            .map_err(|e| err(e, "checking that the key is an RSA key"))?;
         Ok(Self(pkey))
     }
 
@@ -34,7 +36,7 @@ impl RsaKeyPairInner {
     pub fn to_pkcs8_der(&self) -> Result<Vec<u8>, RsaError> {
         self.0
             .private_key_to_pkcs8()
-            .map_err(|e| err(e, "exporting PKCS#8 DER"))
+            .map_err(|e| err(e, "encoding the private key as PKCS#8 DER"))
     }
 
     pub fn oaep_decrypt(
@@ -42,16 +44,17 @@ impl RsaKeyPairInner {
         input: &[u8],
         hash_algorithm: HashAlgorithm,
     ) -> Result<Vec<u8>, RsaError> {
-        let mut ctx =
-            openssl::pkey_ctx::PkeyCtx::new(&self.0).map_err(|e| err(e, "creating PkeyCtx"))?;
-        ctx.decrypt_init().map_err(|e| err(e, "decrypt init"))?;
+        let mut ctx = openssl::pkey_ctx::PkeyCtx::new(&self.0)
+            .map_err(|e| err(e, "creating the decryption context"))?;
+        ctx.decrypt_init()
+            .map_err(|e| err(e, "initializing the decryption context"))?;
         ctx.set_rsa_padding(openssl::rsa::Padding::PKCS1_OAEP)
-            .map_err(|e| err(e, "setting RSA padding"))?;
+            .map_err(|e| err(e, "selecting OAEP padding"))?;
         ctx.set_rsa_oaep_md(hash_algorithm.into())
-            .map_err(|e| err(e, "setting OAEP hash"))?;
+            .map_err(|e| err(e, "setting the OAEP hash algorithm"))?;
         let mut output = vec![];
         ctx.decrypt_to_vec(input, &mut output)
-            .map_err(|e| err(e, "RSA-OAEP decrypt"))?;
+            .map_err(|e| err(e, "decrypting with RSA-OAEP"))?;
         Ok(output)
     }
 
@@ -61,12 +64,16 @@ impl RsaKeyPairInner {
         hash_algorithm: HashAlgorithm,
     ) -> Result<Vec<u8>, RsaError> {
         let mut signer = openssl::sign::Signer::new(hash_algorithm.into(), &self.0)
-            .map_err(|e| err(e, "creating signer"))?;
+            .map_err(|e| err(e, "creating the signer"))?;
         signer
             .set_rsa_padding(openssl::rsa::Padding::PKCS1)
-            .map_err(|e| err(e, "setting RSA padding"))?;
-        signer.update(data).map_err(|e| err(e, "signer update"))?;
-        signer.sign_to_vec().map_err(|e| err(e, "signer sign"))
+            .map_err(|e| err(e, "selecting PKCS#1 v1.5 padding"))?;
+        signer
+            .update(data)
+            .map_err(|e| err(e, "hashing the message to sign"))?;
+        signer
+            .sign_to_vec()
+            .map_err(|e| err(e, "computing the PKCS#1 v1.5 signature"))
     }
 
     pub fn pss_sign(
@@ -75,18 +82,22 @@ impl RsaKeyPairInner {
         hash_algorithm: HashAlgorithm,
     ) -> Result<Vec<u8>, RsaError> {
         let mut signer = openssl::sign::Signer::new(hash_algorithm.into(), &self.0)
-            .map_err(|e| err(e, "creating signer"))?;
+            .map_err(|e| err(e, "creating the signer"))?;
         signer
             .set_rsa_padding(openssl::rsa::Padding::PKCS1_PSS)
-            .map_err(|e| err(e, "setting RSA padding"))?;
+            .map_err(|e| err(e, "selecting PSS padding"))?;
         signer
             .set_rsa_mgf1_md(hash_algorithm.into())
-            .map_err(|e| err(e, "setting MGF1 hash"))?;
+            .map_err(|e| err(e, "setting the MGF1 hash algorithm"))?;
         signer
             .set_rsa_pss_saltlen(openssl::sign::RsaPssSaltlen::DIGEST_LENGTH)
-            .map_err(|e| err(e, "setting PSS salt length"))?;
-        signer.update(data).map_err(|e| err(e, "signer update"))?;
-        signer.sign_to_vec().map_err(|e| err(e, "signer sign"))
+            .map_err(|e| err(e, "setting the PSS salt length"))?;
+        signer
+            .update(data)
+            .map_err(|e| err(e, "hashing the message to sign"))?;
+        signer
+            .sign_to_vec()
+            .map_err(|e| err(e, "computing the PSS signature"))
     }
 
     pub(crate) fn as_pub(&self) -> &RsaPublicKeyInner {
@@ -100,13 +111,13 @@ pub struct RsaPublicKeyInner(pub(crate) openssl::pkey::PKey<openssl::pkey::Publi
 
 impl RsaPublicKeyInner {
     pub fn from_components(n: &[u8], e: &[u8]) -> Result<Self, RsaError> {
-        let n = openssl::bn::BigNum::from_slice(n).map_err(|e| err(e, "parsing modulus"))?;
-        let e =
-            openssl::bn::BigNum::from_slice(e).map_err(|e| err(e, "parsing public exponent"))?;
+        let n = openssl::bn::BigNum::from_slice(n).map_err(|e| err(e, "parsing the modulus"))?;
+        let e = openssl::bn::BigNum::from_slice(e)
+            .map_err(|e| err(e, "parsing the public exponent"))?;
         let rsa = openssl::rsa::Rsa::from_public_components(n, e)
-            .map_err(|e| err(e, "constructing RSA public key from components"))?;
-        let pkey =
-            openssl::pkey::PKey::from_rsa(rsa).map_err(|e| err(e, "converting RSA to PKey"))?;
+            .map_err(|e| err(e, "constructing the RSA public key from its components"))?;
+        let pkey = openssl::pkey::PKey::from_rsa(rsa)
+            .map_err(|e| err(e, "wrapping the RSA key in a PKey"))?;
         Ok(Self(pkey))
     }
 
@@ -115,16 +126,17 @@ impl RsaPublicKeyInner {
         input: &[u8],
         hash_algorithm: HashAlgorithm,
     ) -> Result<Vec<u8>, RsaError> {
-        let mut ctx =
-            openssl::pkey_ctx::PkeyCtx::new(&self.0).map_err(|e| err(e, "creating PkeyCtx"))?;
-        ctx.encrypt_init().map_err(|e| err(e, "encrypt init"))?;
+        let mut ctx = openssl::pkey_ctx::PkeyCtx::new(&self.0)
+            .map_err(|e| err(e, "creating the encryption context"))?;
+        ctx.encrypt_init()
+            .map_err(|e| err(e, "initializing the encryption context"))?;
         ctx.set_rsa_padding(openssl::rsa::Padding::PKCS1_OAEP)
-            .map_err(|e| err(e, "setting RSA padding"))?;
+            .map_err(|e| err(e, "selecting OAEP padding"))?;
         ctx.set_rsa_oaep_md(hash_algorithm.into())
-            .map_err(|e| err(e, "setting OAEP hash"))?;
+            .map_err(|e| err(e, "setting the OAEP hash algorithm"))?;
         let mut output = vec![];
         ctx.encrypt_to_vec(input, &mut output)
-            .map_err(|e| err(e, "RSA-OAEP encrypt"))?;
+            .map_err(|e| err(e, "encrypting with RSA-OAEP"))?;
         Ok(output)
     }
 
@@ -135,16 +147,16 @@ impl RsaPublicKeyInner {
         hash_algorithm: HashAlgorithm,
     ) -> Result<bool, RsaError> {
         let mut verifier = openssl::sign::Verifier::new(hash_algorithm.into(), &self.0)
-            .map_err(|e| err(e, "creating verifier"))?;
+            .map_err(|e| err(e, "creating the verifier"))?;
         verifier
             .set_rsa_padding(openssl::rsa::Padding::PKCS1)
-            .map_err(|e| err(e, "setting RSA padding"))?;
+            .map_err(|e| err(e, "selecting PKCS#1 v1.5 padding"))?;
         verifier
             .update(message)
-            .map_err(|e| err(e, "verifier update"))?;
+            .map_err(|e| err(e, "hashing the signed message"))?;
         verifier
             .verify(signature)
-            .map_err(|e| err(e, "verifier verify"))
+            .map_err(|e| err(e, "verifying the PKCS#1 v1.5 signature"))
     }
 
     pub fn pss_verify(
@@ -154,22 +166,22 @@ impl RsaPublicKeyInner {
         hash_algorithm: HashAlgorithm,
     ) -> Result<bool, RsaError> {
         let mut verifier = openssl::sign::Verifier::new(hash_algorithm.into(), &self.0)
-            .map_err(|e| err(e, "creating verifier"))?;
+            .map_err(|e| err(e, "creating the verifier"))?;
         verifier
             .set_rsa_padding(openssl::rsa::Padding::PKCS1_PSS)
-            .map_err(|e| err(e, "setting RSA padding"))?;
+            .map_err(|e| err(e, "selecting PSS padding"))?;
         verifier
             .set_rsa_mgf1_md(hash_algorithm.into())
-            .map_err(|e| err(e, "setting MGF1 hash"))?;
+            .map_err(|e| err(e, "setting the MGF1 hash algorithm"))?;
         verifier
             .set_rsa_pss_saltlen(openssl::sign::RsaPssSaltlen::DIGEST_LENGTH)
-            .map_err(|e| err(e, "setting PSS salt length"))?;
+            .map_err(|e| err(e, "setting the PSS salt length"))?;
         verifier
             .update(message)
-            .map_err(|e| err(e, "verifier update"))?;
+            .map_err(|e| err(e, "hashing the signed message"))?;
         verifier
             .verify(signature)
-            .map_err(|e| err(e, "verifier verify"))
+            .map_err(|e| err(e, "verifying the PSS signature"))
     }
 
     pub fn modulus_size(&self) -> usize {

--- a/support/crypto/src/rsa/rust.rs
+++ b/support/crypto/src/rsa/rust.rs
@@ -29,13 +29,13 @@ pub struct RsaKeyPairInner(pub(crate) RsaPrivateKey);
 impl RsaKeyPairInner {
     pub fn generate(bits: u32) -> Result<Self, RsaError> {
         let rsa = RsaPrivateKey::new(&mut rng(), bits as usize)
-            .map_err(|e| RsaError(e, "generating RSA key"))?;
+            .map_err(|e| RsaError(e, "generating the RSA key"))?;
         Ok(Self(rsa))
     }
 
     pub fn from_pkcs8_der(der: &[u8]) -> Result<Self, RsaError> {
         let parsed = RsaPrivateKey::from_pkcs8_der(der)
-            .map_err(|e| RsaError(e.into(), "parsing PKCS#8 DER"))?;
+            .map_err(|e| RsaError(e.into(), "parsing the PKCS#8 DER private key"))?;
         Ok(Self(parsed))
     }
 
@@ -45,7 +45,7 @@ impl RsaKeyPairInner {
         Ok(self
             .0
             .to_pkcs8_der()
-            .map_err(|e| RsaError(e.into(), "converting to DER"))?
+            .map_err(|e| RsaError(e.into(), "encoding the private key as PKCS#8 DER"))?
             .as_bytes()
             .to_vec())
     }
@@ -73,7 +73,7 @@ impl RsaKeyPairInner {
                     .decrypt_blinded(&mut rng(), Oaep::<sha2::Sha512>::new(), input)
             }
         }
-        .map_err(|e| RsaError(e, "OAEP decryption"))
+        .map_err(|e| RsaError(e, "decrypting with RSA-OAEP"))
     }
 
     pub fn pkcs1_sign(
@@ -103,7 +103,7 @@ impl RsaKeyPairInner {
                     .sign_with_rng(&mut rng(), Pkcs1v15Sign::new::<sha2::Sha512>(), &data)
             }
         }
-        .map_err(|e| RsaError(e, "PKCS#1 signing"))
+        .map_err(|e| RsaError(e, "computing the PKCS#1 v1.5 signature"))
     }
 
     pub fn pss_sign(
@@ -134,7 +134,7 @@ impl RsaKeyPairInner {
                     .sign_with_rng(&mut rng(), Pss::<sha2::Sha512>::new(), &data)
             }
         }
-        .map_err(|e| RsaError(e, "PSS signing"))
+        .map_err(|e| RsaError(e, "computing the PSS signature"))
     }
 
     pub(crate) fn as_pub(&self) -> &RsaPublicKeyInner {
@@ -152,7 +152,7 @@ impl RsaPublicKeyInner {
             rsa::BoxedUint::from_be_slice_vartime(n),
             rsa::BoxedUint::from_be_slice_vartime(e),
         )
-        .map_err(|e| RsaError(e, "constructing RSA public key from components"))?;
+        .map_err(|e| RsaError(e, "constructing the RSA public key from its components"))?;
         Ok(Self(key))
     }
 
@@ -173,7 +173,7 @@ impl RsaPublicKeyInner {
                 .0
                 .encrypt(&mut rng(), Oaep::<sha2::Sha512>::new(), input),
         }
-        .map_err(|e| RsaError(e, "OAEP encryption"))
+        .map_err(|e| RsaError(e, "encrypting with RSA-OAEP"))
     }
 
     pub fn pkcs1_verify(
@@ -207,7 +207,7 @@ impl RsaPublicKeyInner {
         match result {
             Ok(()) => Ok(true),
             Err(rsa::Error::Verification) => Ok(false),
-            Err(e) => Err(RsaError(e, "PKCS#1 signature verification")),
+            Err(e) => Err(RsaError(e, "verifying the PKCS#1 v1.5 signature")),
         }
     }
 
@@ -231,7 +231,7 @@ impl RsaPublicKeyInner {
         match result {
             Ok(()) => Ok(true),
             Err(rsa::Error::Verification) => Ok(false),
-            Err(e) => Err(RsaError(e, "PSS signature verification")),
+            Err(e) => Err(RsaError(e, "verifying the PSS signature")),
         }
     }
 

--- a/support/crypto/src/rsa/symcrypt.rs
+++ b/support/crypto/src/rsa/symcrypt.rs
@@ -23,25 +23,23 @@ pub struct RsaKeyPairInner(pub(crate) RsaKey);
 impl RsaKeyPairInner {
     pub fn generate(bits: u32) -> Result<Self, RsaError> {
         let rsa = RsaKey::generate_key_pair(bits, None, RsaKeyUsage::SignAndEncrypt)
-            .map_err(|e| err(e, "generating RSA key"))?;
+            .map_err(|e| err(e, "generating the RSA key"))?;
         Ok(Self(rsa))
     }
 
     pub fn from_pkcs8_der(der_bytes: &[u8]) -> Result<Self, RsaError> {
         let pki = pkcs8::PrivateKeyInfoRef::from_der(der_bytes)
-            .map_err(|e| der_err(e, "parsing PKCS#8 DER"))?;
+            .map_err(|e| der_err(e, "parsing the PKCS#8 DER private key"))?;
         if pki.algorithm.oid != pkcs1::ALGORITHM_OID {
-            return Err(RsaError(crate::BackendError::Pkcs8Encoding(
-                pkcs8::Error::KeyMalformed(pkcs8::KeyError::Invalid),
-                "PKCS#8 algorithm is not rsaEncryption",
+            return Err(RsaError(crate::BackendError::Invalid(
+                "PKCS#8 private key is not an RSA key",
             )));
         }
         let key = pkcs1::RsaPrivateKey::from_der(pki.private_key.as_bytes())
-            .map_err(|e| der_err(e, "parsing PKCS#1 RSA private key"))?;
+            .map_err(|e| der_err(e, "parsing the PKCS#1 RSA private key"))?;
         if key.other_prime_infos.is_some() {
-            return Err(RsaError(crate::BackendError::Pkcs8Encoding(
-                pkcs8::Error::KeyMalformed(pkcs8::KeyError::Invalid),
-                "multiprime RSA keys not supported",
+            return Err(RsaError(crate::BackendError::Invalid(
+                "multi-prime RSA private keys are not supported",
             )));
         }
         let rsa = RsaKey::set_key_pair(
@@ -51,7 +49,7 @@ impl RsaKeyPairInner {
             key.prime2.as_bytes(),
             RsaKeyUsage::SignAndEncrypt,
         )
-        .map_err(|e| err(e, "setting RSA key pair"))?;
+        .map_err(|e| err(e, "importing the RSA key pair"))?;
         Ok(Self(rsa))
     }
 
@@ -65,25 +63,27 @@ impl RsaKeyPairInner {
         let blob = self
             .0
             .export_key_pair_blob()
-            .map_err(|e| err(e, "exporting RSA key blob"))?;
+            .map_err(|e| err(e, "exporting the RSA key blob"))?;
 
         let pkcs1_key = pkcs1::RsaPrivateKey {
-            modulus: UintRef::new(&blob.modulus).map_err(|e| der_err(e, "encoding modulus"))?,
+            modulus: UintRef::new(&blob.modulus).map_err(|e| der_err(e, "encoding the modulus"))?,
             public_exponent: UintRef::new(&blob.pub_exp)
-                .map_err(|e| der_err(e, "encoding public exponent"))?,
+                .map_err(|e| der_err(e, "encoding the public exponent"))?,
             private_exponent: UintRef::new(&blob.private_exp)
-                .map_err(|e| der_err(e, "encoding private exponent"))?,
-            prime1: UintRef::new(&blob.p).map_err(|e| der_err(e, "encoding prime1"))?,
-            prime2: UintRef::new(&blob.q).map_err(|e| der_err(e, "encoding prime2"))?,
-            exponent1: UintRef::new(&blob.d_p).map_err(|e| der_err(e, "encoding exponent1"))?,
-            exponent2: UintRef::new(&blob.d_q).map_err(|e| der_err(e, "encoding exponent2"))?,
+                .map_err(|e| der_err(e, "encoding the private exponent"))?,
+            prime1: UintRef::new(&blob.p).map_err(|e| der_err(e, "encoding the first prime"))?,
+            prime2: UintRef::new(&blob.q).map_err(|e| der_err(e, "encoding the second prime"))?,
+            exponent1: UintRef::new(&blob.d_p)
+                .map_err(|e| der_err(e, "encoding the first CRT exponent"))?,
+            exponent2: UintRef::new(&blob.d_q)
+                .map_err(|e| der_err(e, "encoding the second CRT exponent"))?,
             coefficient: UintRef::new(&blob.crt_coefficient)
-                .map_err(|e| der_err(e, "encoding coefficient"))?,
+                .map_err(|e| der_err(e, "encoding the CRT coefficient"))?,
             other_prime_infos: None,
         };
         let pkcs1_der = pkcs1_key
             .to_der()
-            .map_err(|e| der_err(e, "encoding PKCS#1 RSA private key"))?;
+            .map_err(|e| der_err(e, "encoding the PKCS#1 RSA private key"))?;
 
         let pki = pkcs8::PrivateKeyInfoOwned {
             algorithm: AlgorithmIdentifierOwned {
@@ -91,11 +91,11 @@ impl RsaKeyPairInner {
                 parameters: Some(der::Any::null()),
             },
             private_key: OctetString::new(pkcs1_der)
-                .map_err(|e| der_err(e, "wrapping PKCS#1 in OCTET STRING"))?,
+                .map_err(|e| der_err(e, "wrapping the PKCS#1 key in an OCTET STRING"))?,
             public_key: None,
         };
         pki.to_der()
-            .map_err(|e| der_err(e, "encoding PKCS#8 PrivateKeyInfo"))
+            .map_err(|e| der_err(e, "encoding the PKCS#8 PrivateKeyInfo"))
     }
 
     pub fn oaep_decrypt(
@@ -105,7 +105,7 @@ impl RsaKeyPairInner {
     ) -> Result<Vec<u8>, RsaError> {
         self.0
             .oaep_decrypt(input, hash_algorithm.into(), &[])
-            .map_err(|e| err(e, "OAEP decryption"))
+            .map_err(|e| err(e, "decrypting with RSA-OAEP"))
     }
 
     pub fn pkcs1_sign(
@@ -119,7 +119,7 @@ impl RsaKeyPairInner {
         let digest = hash_algorithm.hash(data);
         self.0
             .pkcs1_sign(&digest, hash_algorithm.into())
-            .map_err(|e| err(e, "PKCS#1 signing"))
+            .map_err(|e| err(e, "computing the PKCS#1 v1.5 signature"))
     }
 
     pub fn pss_sign(
@@ -134,7 +134,7 @@ impl RsaKeyPairInner {
         let salt_length = digest.len();
         self.0
             .pss_sign(&digest, hash_algorithm.into(), salt_length)
-            .map_err(|e| err(e, "PSS signing"))
+            .map_err(|e| err(e, "computing the PSS signature"))
     }
 
     pub(crate) fn as_pub(&self) -> &RsaPublicKeyInner {
@@ -149,7 +149,7 @@ pub struct RsaPublicKeyInner(pub(crate) RsaKey);
 impl RsaPublicKeyInner {
     pub fn from_components(n: &[u8], e: &[u8]) -> Result<Self, RsaError> {
         let key = RsaKey::set_public_key(n, e, RsaKeyUsage::SignAndEncrypt)
-            .map_err(|e| err(e, "constructing RSA public key from components"))?;
+            .map_err(|e| err(e, "constructing the RSA public key from its components"))?;
         Ok(Self(key))
     }
 
@@ -160,7 +160,7 @@ impl RsaPublicKeyInner {
     ) -> Result<Vec<u8>, RsaError> {
         self.0
             .oaep_encrypt(input, hash_algorithm.into(), &[])
-            .map_err(|e| err(e, "OAEP encryption"))
+            .map_err(|e| err(e, "encrypting with RSA-OAEP"))
     }
 
     pub fn pkcs1_verify(
@@ -189,7 +189,7 @@ impl RsaPublicKeyInner {
                 symcrypt::errors::SymCryptError::SignatureVerificationFailure
                 | symcrypt::errors::SymCryptError::InvalidArgument,
             ) => Ok(false),
-            Err(e) => Err(err(e, "PKCS#1 signature verification")),
+            Err(e) => Err(err(e, "verifying the PKCS#1 v1.5 signature")),
         }
     }
 
@@ -214,7 +214,7 @@ impl RsaPublicKeyInner {
                 symcrypt::errors::SymCryptError::SignatureVerificationFailure
                 | symcrypt::errors::SymCryptError::InvalidArgument,
             ) => Ok(false),
-            Err(e) => Err(err(e, "PSS signature verification")),
+            Err(e) => Err(err(e, "verifying the PSS signature")),
         }
     }
 

--- a/support/crypto/src/rsa/win.rs
+++ b/support/crypto/src/rsa/win.rs
@@ -10,7 +10,6 @@ use crate::win::CryptAlloc;
 use crate::win::KeyHandle;
 use std::ffi::CStr;
 use std::ffi::c_void;
-use windows::Win32::Foundation::NTE_BAD_TYPE;
 use windows::Win32::Foundation::STATUS_INVALID_PARAMETER;
 use windows::Win32::Foundation::STATUS_INVALID_SIGNATURE;
 use windows::Win32::Security::Cryptography::BCRYPT_FLAGS;
@@ -47,7 +46,12 @@ use windows::Win32::Security::Cryptography::szOID_RSA_RSA;
 use windows::core::PSTR;
 
 fn err(err: windows_result::Error, op: &'static str) -> RsaError {
-    RsaError(crate::BackendError(err, op))
+    RsaError(crate::BackendError::Windows(err, op))
+}
+
+/// An error for input that decoded but is not valid or supported.
+fn invalid_err(reason: &'static str) -> RsaError {
+    RsaError(crate::BackendError::Invalid(reason))
 }
 
 #[repr(transparent)]
@@ -81,7 +85,7 @@ pub(crate) fn export_key(
         )
     }
     .ok()
-    .map_err(|e| err(e, "querying export size"))?;
+    .map_err(|e| err(e, "querying the key export size"))?;
     let mut out = vec![0u8; needed as usize];
     // SAFETY: out is sized per the previous query.
     unsafe {
@@ -95,7 +99,7 @@ pub(crate) fn export_key(
         )
     }
     .ok()
-    .map_err(|e| err(e, "exporting key"))?;
+    .map_err(|e| err(e, "exporting the key"))?;
     out.truncate(needed as usize);
     Ok(out)
 }
@@ -116,7 +120,7 @@ fn import_key(blob: &[u8], blob_type: windows::core::PCWSTR) -> Result<KeyHandle
         )
     }
     .ok()
-    .map_err(|e| err(e, "importing key"))?;
+    .map_err(|e| err(e, "importing the key"))?;
     Ok(KeyHandle(handle))
 }
 
@@ -134,12 +138,12 @@ impl RsaKeyPairInner {
             )
         }
         .ok()
-        .map_err(|e| err(e, "generating RSA key"))?;
+        .map_err(|e| err(e, "generating the RSA key"))?;
         let key = KeyHandle(handle);
         // SAFETY: handle is valid.
         unsafe { windows::Win32::Security::Cryptography::BCryptFinalizeKeyPair(key.0, 0) }
             .ok()
-            .map_err(|e| err(e, "finalizing RSA key"))?;
+            .map_err(|e| err(e, "finalizing the RSA key"))?;
         Ok(Self(key))
     }
 
@@ -163,29 +167,25 @@ impl RsaKeyPairInner {
                     &mut len,
                 )
             }
-            .map_err(|e| err(e, "decoding PKCS#8 PrivateKeyInfo"))?;
-            CryptAlloc::new(ptr, len).map_err(|e| err(e, "decoding PKCS#8 PrivateKeyInfo"))?
+            .map_err(|e| err(e, "decoding the PKCS#8 PrivateKeyInfo"))?;
+            CryptAlloc::new(ptr, len).map_err(|e| err(e, "decoding the PKCS#8 PrivateKeyInfo"))?
         };
         // SAFETY: Crypt32 was asked to decode a PKCS_PRIVATE_KEY_INFO, so
         // the buffer (when non-null and large enough, as validated by
         // as_struct) holds a CRYPT_PRIVATE_KEY_INFO.
         let pki = unsafe { pki_buf.as_struct::<CRYPT_PRIVATE_KEY_INFO>() }
-            .map_err(|e| err(e, "decoding PKCS#8 PrivateKeyInfo"))?;
+            .map_err(|e| err(e, "decoding the PKCS#8 PrivateKeyInfo"))?;
         // SAFETY: pszObjId is a NUL-terminated string owned by the same
         // Crypt32 allocation.
         let oid = unsafe { CStr::from_ptr(pki.Algorithm.pszObjId.0.cast()) };
         // SAFETY: szOID_RSA_RSA is a static NUL-terminated string constant.
         let rsa_oid = unsafe { CStr::from_ptr(szOID_RSA_RSA.0.cast()) };
         if oid != rsa_oid {
-            return Err(err(
-                windows_result::Error::from_hresult(NTE_BAD_TYPE),
-                "PKCS#8 algorithm is not rsaEncryption",
-            ));
+            return Err(invalid_err("PKCS#8 private key is not an RSA key"));
         }
         if pki.PrivateKey.pbData.is_null() || pki.PrivateKey.cbData == 0 {
-            return Err(err(
-                windows_result::Error::from_hresult(NTE_BAD_TYPE),
-                "PKCS#8 PrivateKey field is empty",
+            return Err(invalid_err(
+                "PKCS#8 PrivateKeyInfo has an empty privateKey field",
             ));
         }
         // SAFETY: PrivateKey describes a buffer of cbData bytes owned by
@@ -218,15 +218,12 @@ impl RsaKeyPairInner {
                     &mut len,
                 )
             }
-            .map_err(|e| err(e, "decoding PKCS#1 RSA private key"))?;
-            CryptAlloc::new(ptr, len).map_err(|e| err(e, "decoding PKCS#1 RSA private key"))?
+            .map_err(|e| err(e, "decoding the PKCS#1 RSA private key"))?;
+            CryptAlloc::new(ptr, len).map_err(|e| err(e, "decoding the PKCS#1 RSA private key"))?
         };
         let blob = blob_buf.as_bytes();
         if blob.len() < size_of::<BCRYPT_RSAKEY_BLOB>() {
-            return Err(err(
-                windows_result::Error::from_hresult(NTE_BAD_TYPE),
-                "decoded RSA private blob too small",
-            ));
+            return Err(invalid_err("decoded RSA private key blob is too small"));
         }
         // SAFETY: blob is at least header-sized and the header is POD.
         let magic =
@@ -239,9 +236,8 @@ impl RsaKeyPairInner {
                 BCRYPT_RSAPRIVATE_BLOB
             }
             _ => {
-                return Err(err(
-                    windows_result::Error::from_hresult(NTE_BAD_TYPE),
-                    "decoded RSA private blob has unexpected magic",
+                return Err(invalid_err(
+                    "decoded RSA private key blob has an unrecognized magic value",
                 ));
             }
         };
@@ -277,8 +273,8 @@ impl RsaKeyPairInner {
                     &mut len,
                 )
             }
-            .map_err(|e| err(e, "encoding PKCS#1 RSA private key"))?;
-            CryptAlloc::new(ptr, len).map_err(|e| err(e, "encoding PKCS#1 RSA private key"))?
+            .map_err(|e| err(e, "encoding the PKCS#1 RSA private key"))?;
+            CryptAlloc::new(ptr, len).map_err(|e| err(e, "encoding the PKCS#1 RSA private key"))?
         };
 
         // Step 3: wrap the PKCS#1 DER in a PKCS#8 PrivateKeyInfo with the
@@ -322,8 +318,8 @@ impl RsaKeyPairInner {
                     &mut len,
                 )
             }
-            .map_err(|e| err(e, "encoding PKCS#8 PrivateKeyInfo"))?;
-            CryptAlloc::new(ptr, len).map_err(|e| err(e, "encoding PKCS#8 PrivateKeyInfo"))?
+            .map_err(|e| err(e, "encoding the PKCS#8 PrivateKeyInfo"))?;
+            CryptAlloc::new(ptr, len).map_err(|e| err(e, "encoding the PKCS#8 PrivateKeyInfo"))?
         };
         Ok(pkcs8_buf.as_bytes().to_vec())
     }
@@ -354,7 +350,7 @@ impl RsaKeyPairInner {
             )
         }
         .ok()
-        .map_err(|e| err(e, "querying OAEP decrypt size"))?;
+        .map_err(|e| err(e, "querying the RSA-OAEP plaintext size"))?;
         let mut out = vec![0u8; needed as usize];
         // SAFETY: output buffer is sized to needed.
         unsafe {
@@ -369,7 +365,7 @@ impl RsaKeyPairInner {
             )
         }
         .ok()
-        .map_err(|e| err(e, "RSA-OAEP decrypt"))?;
+        .map_err(|e| err(e, "decrypting with RSA-OAEP"))?;
         out.truncate(needed as usize);
         Ok(out)
     }
@@ -435,7 +431,7 @@ fn sign_hash(
         )
     }
     .ok()
-    .map_err(|e| err(e, "querying signature size"))?;
+    .map_err(|e| err(e, "querying the signature size"))?;
     let mut sig = vec![0u8; needed as usize];
     // SAFETY: sig is sized per query.
     unsafe {
@@ -449,7 +445,7 @@ fn sign_hash(
         )
     }
     .ok()
-    .map_err(|e| err(e, "signing hash"))?;
+    .map_err(|e| err(e, "signing the message hash"))?;
     sig.truncate(needed as usize);
     Ok(sig)
 }
@@ -479,7 +475,7 @@ fn verify_hash(
         // the symcrypt backend.
         return Ok(false);
     }
-    status.ok().map_err(|e| err(e, "verifying signature"))?;
+    status.ok().map_err(|e| err(e, "verifying the signature"))?;
     Ok(true)
 }
 
@@ -557,7 +553,7 @@ impl RsaPublicKeyInner {
             )
         }
         .ok()
-        .map_err(|e| err(e, "querying OAEP encrypt size"))?;
+        .map_err(|e| err(e, "querying the RSA-OAEP ciphertext size"))?;
         let mut out = vec![0u8; needed as usize];
         // SAFETY: output sized to needed.
         unsafe {
@@ -572,7 +568,7 @@ impl RsaPublicKeyInner {
             )
         }
         .ok()
-        .map_err(|e| err(e, "RSA-OAEP encrypt"))?;
+        .map_err(|e| err(e, "encrypting with RSA-OAEP"))?;
         out.truncate(needed as usize);
         Ok(out)
     }

--- a/support/crypto/src/x509/mac.rs
+++ b/support/crypto/src/x509/mac.rs
@@ -71,12 +71,12 @@ pub struct X509CertificateInner {
 impl X509CertificateInner {
     pub fn from_der(data: &[u8]) -> Result<Self, X509Error> {
         let parsed =
-            Certificate::from_der(data).map_err(|e| der_err(e, "parsing DER certificate"))?;
-        let cf = cf_data(data, "CFDataCreate for certificate").map_err(err)?;
+            Certificate::from_der(data).map_err(|e| der_err(e, "parsing the DER certificate"))?;
+        let cf = cf_data(data, "creating a CFData for the certificate").map_err(err)?;
         // SAFETY: cf.0 is a valid CFDataRef.
         let cert = unsafe { SecCertificateCreateWithData(kCFAllocatorDefault, cf.0) };
         if cert.is_null() {
-            return Err(null_err("SecCertificateCreateWithData"));
+            return Err(null_err("creating the certificate"));
         }
         Ok(Self {
             cert: CfHandle(cert),
@@ -88,7 +88,7 @@ impl X509CertificateInner {
         // SAFETY: self.cert.0 is a valid SecCertificateRef.
         let key = unsafe { SecCertificateCopyKey(self.cert.0) };
         if key.is_null() {
-            return Err(null_err("SecCertificateCopyKey"));
+            return Err(null_err("copying the certificate public key"));
         }
         let key = CfHandle(key);
         let mut error: CFErrorRef = ptr::null();
@@ -97,14 +97,14 @@ impl X509CertificateInner {
         if data.is_null() {
             // SAFETY: error is null or a valid CFErrorRef.
             return Err(err(unsafe {
-                sec_err(error, "SecKeyCopyExternalRepresentation")
+                sec_err(error, "exporting the certificate public key")
             }));
         }
         let data = CfHandle(data);
         // SAFETY: data.0 is a valid CFDataRef.
         let pkcs1_der = unsafe { cf_data_to_vec(data.0) };
         let pk = pkcs1::RsaPublicKey::from_der(&pkcs1_der)
-            .map_err(|e| der_err(e, "parsing PKCS#1 RSA public key"))?;
+            .map_err(|e| der_err(e, "parsing the PKCS#1 RSA public key"))?;
         let rsa = crate::rsa::RsaPublicKey::from_components(
             pk.modulus.as_bytes(),
             pk.public_exponent.as_bytes(),
@@ -119,13 +119,13 @@ impl X509CertificateInner {
     ) -> Result<bool, crate::rsa::RsaError> {
         let oid = self.parsed.signature_algorithm().oid;
         let hash = crate::HashAlgorithm::try_from(oid)
-            .map_err(|e| rsa_der_err(e, "unrecognized signature algorithm OID"))?;
+            .map_err(|e| rsa_der_err(e, "reading the certificate signature algorithm"))?;
 
         let tbs_der = self
             .parsed
             .tbs_certificate()
             .to_der()
-            .map_err(|e| rsa_der_err(e, "encoding TBS certificate"))?;
+            .map_err(|e| rsa_der_err(e, "encoding the TBS certificate"))?;
         let signature = self.parsed.signature().raw_bytes();
         issuer_public_key.pkcs1_verify(&tbs_der, signature, hash)
     }
@@ -149,7 +149,7 @@ impl X509CertificateInner {
 
         if let Some((_crit, ku)) = issuer_tbs
             .get_extension::<KeyUsage>()
-            .map_err(|e| der_err(e, "parsing KeyUsage extension"))?
+            .map_err(|e| der_err(e, "parsing the KeyUsage extension"))?
             && !ku.key_cert_sign()
         {
             return Ok(false);
@@ -157,12 +157,12 @@ impl X509CertificateInner {
 
         if let Some((_crit, akid)) = subject_tbs
             .get_extension::<AuthorityKeyIdentifier>()
-            .map_err(|e| der_err(e, "parsing AuthorityKeyIdentifier extension"))?
+            .map_err(|e| der_err(e, "parsing the AuthorityKeyIdentifier extension"))?
         {
             if let Some(akid_key_id) = &akid.key_identifier {
                 let skid = issuer_tbs
                     .get_extension::<SubjectKeyIdentifier>()
-                    .map_err(|e| der_err(e, "parsing SubjectKeyIdentifier extension"))?;
+                    .map_err(|e| der_err(e, "parsing the SubjectKeyIdentifier extension"))?;
                 match skid {
                     Some((_crit, ski)) => {
                         if akid_key_id != &ski.0 {
@@ -198,7 +198,7 @@ impl X509CertificateInner {
     pub fn to_der(&self) -> Result<Vec<u8>, X509Error> {
         self.parsed
             .to_der()
-            .map_err(|e| der_err(e, "encoding certificate as DER"))
+            .map_err(|e| der_err(e, "encoding the certificate as DER"))
     }
 
     pub fn issuer_dn(&self) -> Result<String, X509Error> {
@@ -221,7 +221,7 @@ impl X509CertificateInner {
         if status.0 != 0 {
             return Err(err(crate::BackendError::OsStatus(
                 status,
-                "SecCertificateCopyCommonName",
+                "reading the subject common name",
             )));
         }
         if cn.is_null() {
@@ -267,9 +267,11 @@ fn copy_normalized(cert: SecCertificateRef, subject: bool) -> Result<Vec<u8>, X5
         }
     };
     if data.is_null() {
-        return Err(null_err(
-            "SecCertificateCopyNormalized{Subject,Issuer}Sequence",
-        ));
+        return Err(null_err(if subject {
+            "copying the normalized subject name"
+        } else {
+            "copying the normalized issuer name"
+        }));
     }
     let data = CfHandle(data);
     // SAFETY: data.0 is a valid CFDataRef.

--- a/support/crypto/src/x509/mod.rs
+++ b/support/crypto/src/x509/mod.rs
@@ -39,13 +39,13 @@ use thiserror::Error;
 /// An error for X.509 operations.
 #[cfg(not(rust))]
 #[derive(Clone, Debug, Error)]
-#[error("X.509 error")]
+#[error("X.509 operation failed")]
 pub struct X509Error(#[source] pub(crate) super::BackendError);
 
 /// An error for X.509 operations.
 #[cfg(rust)]
 #[derive(Clone, Debug, Error)]
-#[error("X.509 error during {1}")]
+#[error("X.509 operation failed while {1}")]
 pub struct X509Error(#[source] pub(crate) der::Error, pub(crate) &'static str);
 
 /// A public key extracted from an X.509 certificate.

--- a/support/crypto/src/x509/ossl.rs
+++ b/support/crypto/src/x509/ossl.rs
@@ -14,8 +14,8 @@ pub struct X509CertificateInner(pub(crate) openssl::x509::X509);
 
 impl X509CertificateInner {
     pub fn from_der(data: &[u8]) -> Result<Self, X509Error> {
-        let cert =
-            openssl::x509::X509::from_der(data).map_err(|e| err(e, "parsing DER certificate"))?;
+        let cert = openssl::x509::X509::from_der(data)
+            .map_err(|e| err(e, "parsing the DER certificate"))?;
         Ok(Self(cert))
     }
 
@@ -23,7 +23,7 @@ impl X509CertificateInner {
         let pkey = self
             .0
             .public_key()
-            .map_err(|e| err(e, "extracting public key"))?;
+            .map_err(|e| err(e, "extracting the certificate public key"))?;
         if pkey.rsa().is_ok() {
             Ok(X509PublicKey::Rsa(crate::rsa::RsaPublicKey(
                 crate::rsa::ossl::RsaPublicKeyInner(pkey),
@@ -37,7 +37,7 @@ impl X509CertificateInner {
         } else {
             Err(err(
                 openssl::error::ErrorStack::get(),
-                "unsupported certificate public key type",
+                "checking that the certificate public key algorithm is supported",
             ))
         }
     }
@@ -47,7 +47,10 @@ impl X509CertificateInner {
         issuer_public_key: &crate::rsa::RsaPublicKey,
     ) -> Result<bool, crate::rsa::RsaError> {
         self.0.verify(&issuer_public_key.0.0).map_err(|e| {
-            crate::rsa::RsaError(crate::BackendError(e, "verifying certificate signature"))
+            crate::rsa::RsaError(crate::BackendError(
+                e,
+                "verifying the certificate signature",
+            ))
         })
     }
 
@@ -63,7 +66,7 @@ impl X509CertificateInner {
     pub fn to_der(&self) -> Result<Vec<u8>, X509Error> {
         self.0
             .to_der()
-            .map_err(|e| err(e, "encoding certificate as DER"))
+            .map_err(|e| err(e, "encoding the certificate as DER"))
     }
 
     pub fn issuer_dn(&self) -> Result<String, X509Error> {
@@ -73,7 +76,7 @@ impl X509CertificateInner {
             let value = entry
                 .data()
                 .as_utf8()
-                .map_err(|e| err(e, "decoding issuer name entry"))?
+                .map_err(|e| err(e, "decoding an issuer name entry"))?
                 .to_string();
             parts.push(format!("{oid}={value}"));
         }
@@ -85,7 +88,7 @@ impl X509CertificateInner {
             .0
             .serial_number()
             .to_bn()
-            .map_err(|e| err(e, "converting serial number"))?;
+            .map_err(|e| err(e, "converting the serial number"))?;
         Ok(bn.to_vec())
     }
 
@@ -132,7 +135,7 @@ impl X509CertificateInner {
                 .data()
                 .as_utf8()
                 .map(|u| Some(u.to_string()))
-                .map_err(|e| err(e, "decoding subject name")),
+                .map_err(|e| err(e, "decoding the subject common name")),
         }
     }
 }

--- a/support/crypto/src/x509/symcrypt_rust.rs
+++ b/support/crypto/src/x509/symcrypt_rust.rs
@@ -41,7 +41,10 @@ fn rsa_to_x509(crate::rsa::RsaError(e): crate::rsa::RsaError) -> X509Error {
 /// test-only).
 #[cfg(rust)]
 fn rsa_to_x509(_e: crate::rsa::RsaError) -> X509Error {
-    der_err(der::ErrorKind::Failed.into(), "constructing RSA public key")
+    der_err(
+        der::ErrorKind::Failed.into(),
+        "constructing the RSA public key",
+    )
 }
 
 pub(crate) struct X509CertificateInner(pub(crate) Certificate);
@@ -49,7 +52,7 @@ pub(crate) struct X509CertificateInner(pub(crate) Certificate);
 impl X509CertificateInner {
     pub fn from_der(data: &[u8]) -> Result<Self, X509Error> {
         let cert =
-            Certificate::from_der(data).map_err(|e| der_err(e, "parsing DER certificate"))?;
+            Certificate::from_der(data).map_err(|e| der_err(e, "parsing the DER certificate"))?;
         Ok(Self(cert))
     }
 
@@ -64,7 +67,7 @@ impl X509CertificateInner {
 
         if spki.algorithm.oid == RSA_ENCRYPTION {
             let key = pkcs1::RsaPublicKey::from_der(spki.subject_public_key.raw_bytes())
-                .map_err(|e| der_err(e, "parsing PKCS#1 RSA public key"))?;
+                .map_err(|e| der_err(e, "parsing the PKCS#1 RSA public key"))?;
             let rsa = crate::rsa::RsaPublicKey::from_components(
                 key.modulus.as_bytes(),
                 key.public_exponent.as_bytes(),
@@ -83,7 +86,10 @@ impl X509CertificateInner {
             // the ECDSA parser, which validates the curve and imports the key.
             let point = spki.subject_public_key.raw_bytes();
             let qxqy = point.strip_prefix(&[0x04u8]).ok_or_else(|| {
-                der_err(der::ErrorKind::Failed.into(), "parsing EC public key point")
+                der_err(
+                    der::ErrorKind::Failed.into(),
+                    "parsing the EC public key point",
+                )
             })?;
             let key = crate::ecdsa::EcdsaPublicKey::from_public_key_bytes(
                 crate::ecdsa::EcdsaCurve::P384,
@@ -95,7 +101,7 @@ impl X509CertificateInner {
 
         Err(der_err(
             der::ErrorKind::Failed.into(),
-            "extracting certificate public key",
+            "extracting the certificate public key",
         ))
     }
 
@@ -105,13 +111,13 @@ impl X509CertificateInner {
     ) -> Result<bool, crate::rsa::RsaError> {
         let oid = self.0.signature_algorithm().oid;
         let hash = crate::HashAlgorithm::try_from(oid)
-            .map_err(|e| rsa_der_err(e, "unrecognized signature algorithm OID"))?;
+            .map_err(|e| rsa_der_err(e, "reading the certificate signature algorithm"))?;
 
         let tbs_der = self
             .0
             .tbs_certificate()
             .to_der()
-            .map_err(|e| rsa_der_err(e, "encoding TBS certificate"))?;
+            .map_err(|e| rsa_der_err(e, "encoding the TBS certificate"))?;
         let signature = self.0.signature().raw_bytes();
 
         issuer_public_key.pkcs1_verify(&tbs_der, signature, hash)
@@ -135,7 +141,7 @@ impl X509CertificateInner {
         // signing other certificates.
         let ku = issuer_tbs
             .get_extension::<KeyUsage>()
-            .map_err(|e| der_err(e, "parsing KeyUsage extension"))?;
+            .map_err(|e| der_err(e, "parsing the KeyUsage extension"))?;
         if let Some((_crit, ku)) = ku
             && !ku.key_cert_sign()
         {
@@ -146,12 +152,12 @@ impl X509CertificateInner {
         // populated fields against this certificate (the candidate issuer).
         let akid = subject_tbs
             .get_extension::<AuthorityKeyIdentifier>()
-            .map_err(|e| der_err(e, "parsing AuthorityKeyIdentifier extension"))?;
+            .map_err(|e| der_err(e, "parsing the AuthorityKeyIdentifier extension"))?;
         if let Some((_crit, akid)) = akid {
             if let Some(akid_key_id) = &akid.key_identifier {
                 let skid = issuer_tbs
                     .get_extension::<SubjectKeyIdentifier>()
-                    .map_err(|e| der_err(e, "parsing SubjectKeyIdentifier extension"))?;
+                    .map_err(|e| der_err(e, "parsing the SubjectKeyIdentifier extension"))?;
                 match skid {
                     Some((_crit, ski)) => {
                         if akid_key_id != &ski.0 {
@@ -187,7 +193,7 @@ impl X509CertificateInner {
     pub fn to_der(&self) -> Result<Vec<u8>, X509Error> {
         self.0
             .to_der()
-            .map_err(|e| der_err(e, "encoding certificate as DER"))
+            .map_err(|e| der_err(e, "encoding the certificate as DER"))
     }
 
     #[cfg(any(test, feature = "test_helpers"))]
@@ -236,7 +242,7 @@ impl X509CertificateInner {
             .tbs_certificate()
             .subject()
             .common_name()
-            .map_err(|e| der_err(e, "getting common_name"))?
+            .map_err(|e| der_err(e, "reading the subject common name"))?
             .map(|s| s.value().into_owned()))
     }
 }

--- a/support/crypto/src/x509/win.rs
+++ b/support/crypto/src/x509/win.rs
@@ -41,7 +41,7 @@ use windows::Win32::Security::Cryptography::szOID_SUBJECT_KEY_IDENTIFIER;
 use windows::core::PCSTR;
 
 fn err(err: windows_result::Error, op: &'static str) -> X509Error {
-    X509Error(crate::BackendError(err, op))
+    X509Error(crate::BackendError::Windows(err, op))
 }
 
 /// Extract the backend error from an [`X509Error`] produced by this backend,
@@ -50,8 +50,14 @@ pub(crate) fn backend_err(e: X509Error) -> crate::BackendError {
     e.0
 }
 
-fn rsa_err(err: windows_result::Error, op: &'static str) -> crate::rsa::RsaError {
-    crate::rsa::RsaError(crate::BackendError(err, op))
+/// An error for input that decoded but is not valid or supported.
+fn invalid_err(reason: &'static str) -> X509Error {
+    X509Error(crate::BackendError::Invalid(reason))
+}
+
+/// As [`invalid_err`], but for the RSA error type.
+fn rsa_invalid_err(reason: &'static str) -> crate::rsa::RsaError {
+    crate::rsa::RsaError(crate::BackendError::Invalid(reason))
 }
 
 fn last_err(op: &'static str) -> X509Error {
@@ -104,7 +110,7 @@ impl X509CertificateInner {
                 data,
             )
         };
-        let p = NonNull::new(p).ok_or_else(|| last_err("CertCreateCertificateContext"))?;
+        let p = NonNull::new(p).ok_or_else(|| last_err("parsing the DER certificate"))?;
         Ok(Self(CertContext(p)))
     }
 
@@ -137,7 +143,7 @@ impl X509CertificateInner {
                     &mut h,
                 )
             }
-            .map_err(|e| err(e, "CryptImportPublicKeyInfoEx2"))?;
+            .map_err(|e| err(e, "importing the certificate public key"))?;
             let key = KeyHandle(h);
             Ok(X509PublicKey::Rsa(crate::rsa::RsaPublicKey(
                 crate::rsa::win::RsaPublicKeyInner(key),
@@ -149,12 +155,8 @@ impl X509CertificateInner {
                 .map_err(|crate::ecdsa::EcdsaError(e)| X509Error(e))?;
             Ok(X509PublicKey::Ecdsa(crate::ecdsa::EcdsaPublicKey(inner)))
         } else {
-            Err(err(
-                windows::core::Error::new(
-                    windows::Win32::Foundation::E_NOTIMPL,
-                    "unsupported certificate public key type",
-                ),
-                "extracting public key",
+            Err(invalid_err(
+                "certificate public key algorithm is not supported",
             ))
         }
     }
@@ -183,20 +185,11 @@ impl X509CertificateInner {
         let hash =
             crate::HashAlgorithm::from_rsa_signature_oid(signed.value.SignatureAlgorithm.pszObjId)
                 .ok_or_else(|| {
-                    rsa_err(
-                        windows_result::Error::from_hresult(windows::core::HRESULT(
-                            windows::Win32::Foundation::E_NOTIMPL.0,
-                        )),
-                        "missing or unsupported signature algorithm OID",
-                    )
+                    rsa_invalid_err("certificate signature algorithm is missing or not supported")
                 })?;
 
-        let tbs = blob_as_slice(&signed.value.ToBeSigned).ok_or_else(|| {
-            rsa_err(
-                windows_result::Error::from_hresult(windows::core::HRESULT(-1)),
-                "malformed ToBeSigned blob",
-            )
-        })?;
+        let tbs = blob_as_slice(&signed.value.ToBeSigned)
+            .ok_or_else(|| rsa_invalid_err("malformed certificate ToBeSigned blob"))?;
         // Signature is a CRYPT_BIT_BLOB; reject empty/null defensively.
         let sig_bits = &signed.value.Signature;
         // For X.509 RSA signatures the BIT STRING must be byte-aligned;
@@ -368,7 +361,7 @@ impl X509CertificateInner {
             )
         };
         if written == 0 {
-            return Err(last_err("CertNameToStrW"));
+            return Err(last_err("formatting the issuer distinguished name"));
         }
         let len = buf.iter().position(|&c| c == 0).unwrap_or(buf.len());
         Ok(String::from_utf16_lossy(&buf[..len]))
@@ -402,7 +395,7 @@ impl X509CertificateInner {
         // 0 from the size query indicates a CryptoAPI failure; 1 (just the
         // NUL terminator) indicates the attribute is absent.
         if needed == 0 {
-            return Err(last_err("CertGetNameStringW (size query)"));
+            return Err(last_err("querying the length of the subject common name"));
         }
         if needed == 1 {
             return Ok(None);
@@ -419,7 +412,7 @@ impl X509CertificateInner {
             )
         };
         if written == 0 {
-            return Err(last_err("CertGetNameStringW"));
+            return Err(last_err("reading the subject common name"));
         }
         // Strip trailing NUL.
         let len = buf.iter().position(|&c| c == 0).unwrap_or(buf.len());
@@ -441,12 +434,12 @@ impl X509CertificateInner {
 
         // 1. Encode the subject (== issuer for self-signed) DN.
         let name_der = encode_x500_name(country, state, locality, organization, common_name)
-            .context("encoding X.500 name")?;
+            .context("encoding the X.500 name")?;
 
         // 2. Build the SubjectPublicKeyInfo DER.
         let components = key.to_components();
         let pkcs1_pub = encode_pkcs1_rsa_pubkey(&components.modulus, &components.public_exponent)
-            .context("encoding RSA public key")?;
+            .context("encoding the RSA public key")?;
 
         // 3. Build CERT_INFO and encode TBS.
         let mut serial_bytes: [u8; 1] = [1];
@@ -498,7 +491,7 @@ impl X509CertificateInner {
         };
 
         let tbs = encode_object(X509_CERT_TO_BE_SIGNED, &cert_info)
-            .context("encoding TBS certificate")?;
+            .context("encoding the TBS certificate")?;
 
         // 4. Sign the TBS.
         let signature = key.pkcs1_sign(&tbs, crate::HashAlgorithm::Sha256)?;
@@ -525,7 +518,8 @@ impl X509CertificateInner {
                 cUnusedBits: 0,
             },
         };
-        let cert_der = encode_object(X509_CERT, &signed).context("encoding X.509 certificate")?;
+        let cert_der =
+            encode_object(X509_CERT, &signed).context("encoding the X.509 certificate")?;
 
         Ok(Self::from_der(&cert_der)?)
     }
@@ -600,12 +594,8 @@ pub(crate) fn decode_object<T: Copy>(
 ) -> Result<Decoded<T>, X509Error> {
     use windows::Win32::Security::Cryptography::CRYPT_DECODE_ALLOC_FLAG;
 
-    let encoded = blob_as_slice(blob).ok_or_else(|| {
-        err(
-            windows_result::Error::from_hresult(windows::core::HRESULT(-1)),
-            "CryptDecodeObjectEx: input blob has null pbData with non-zero cbData",
-        )
-    })?;
+    let encoded = blob_as_slice(blob)
+        .ok_or_else(|| invalid_err("input blob has a null pointer with a non-zero length"))?;
     let mut raw: *mut c_void = std::ptr::null_mut();
     let mut size: u32 = 0;
     // SAFETY: We pass CRYPT_DECODE_ALLOC_FLAG so the API allocates the
@@ -621,13 +611,9 @@ pub(crate) fn decode_object<T: Copy>(
             &mut size,
         )
     }
-    .map_err(|e| err(e, "CryptDecodeObjectEx"))?;
-    let raw = NonNull::new(raw).ok_or_else(|| {
-        err(
-            windows_result::Error::from_hresult(windows::core::HRESULT(-1)),
-            "CryptDecodeObjectEx returned null",
-        )
-    })?;
+    .map_err(|e| err(e, "decoding an ASN.1 object"))?;
+    let raw = NonNull::new(raw)
+        .ok_or_else(|| invalid_err("CryptDecodeObjectEx succeeded but returned no buffer"))?;
     // Validate the API actually wrote a `T`-sized header before reading
     // it. A short buffer here would mean `read_unaligned` reads past the
     // allocation.
@@ -638,9 +624,8 @@ pub(crate) fn decode_object<T: Copy>(
                 windows::Win32::Foundation::HLOCAL(raw.as_ptr()),
             ));
         }
-        return Err(err(
-            windows_result::Error::from_hresult(windows::core::HRESULT(-1)),
-            "CryptDecodeObjectEx returned buffer smaller than expected struct",
+        return Err(invalid_err(
+            "CryptDecodeObjectEx returned a buffer smaller than the decoded structure",
         ));
     }
     // SAFETY: raw points to a `T` written by CryptoAPI (validated above to

--- a/support/crypto/src/xts_aes_256/mod.rs
+++ b/support/crypto/src/xts_aes_256/mod.rs
@@ -32,7 +32,7 @@ pub struct XtsAes256(sys::XtsAes256Inner);
 
 /// An error for XTS-AES-256 cryptographic operations.
 #[derive(Clone, Debug, Error)]
-#[error("XTS-AES-256 error")]
+#[error("XTS-AES-256 operation failed")]
 pub struct XtsAes256Error(#[source] super::BackendError);
 
 impl XtsAes256 {

--- a/support/crypto/src/xts_aes_256/ossl.rs
+++ b/support/crypto/src/xts_aes_256/ossl.rs
@@ -30,25 +30,25 @@ impl XtsAes256Inner {
 
     pub fn enc_ctx(&self) -> Result<XtsAes256EncCtxInner<'_>, XtsAes256Error> {
         let mut ctx = openssl::cipher_ctx::CipherCtx::new()
-            .map_err(|e| err(e, "creating encrypt context"))?;
+            .map_err(|e| err(e, "creating the encryption context"))?;
         ctx.encrypt_init(
             Some(openssl::cipher::Cipher::aes_256_xts()),
             Some(&self.key),
             None,
         )
-        .map_err(|e| err(e, "encrypt init"))?;
+        .map_err(|e| err(e, "initializing the encryption context"))?;
         Ok(XtsAes256EncCtxInner { ctx, _dummy: &() })
     }
 
     pub fn dec_ctx(&self) -> Result<XtsAes256DecCtxInner<'_>, XtsAes256Error> {
         let mut ctx = openssl::cipher_ctx::CipherCtx::new()
-            .map_err(|e| err(e, "creating decrypt context"))?;
+            .map_err(|e| err(e, "creating the decryption context"))?;
         ctx.decrypt_init(
             Some(openssl::cipher::Cipher::aes_256_xts()),
             Some(&self.key),
             None,
         )
-        .map_err(|e| err(e, "decrypt init"))?;
+        .map_err(|e| err(e, "initializing the decryption context"))?;
         Ok(XtsAes256DecCtxInner { ctx, _dummy: &() })
     }
 }
@@ -58,10 +58,10 @@ impl XtsAes256EncCtxInner<'_> {
         let iv = (tweak as u128).to_le_bytes();
         self.ctx
             .encrypt_init(None, None, Some(&iv))
-            .map_err(|e| err(e, "encryption"))?;
+            .map_err(|e| err(e, "setting the encryption tweak"))?;
         self.ctx
             .cipher_update_inplace(data, data.len())
-            .map_err(|e| err(e, "cipher update"))?;
+            .map_err(|e| err(e, "encrypting data"))?;
         Ok(())
     }
 }
@@ -71,10 +71,10 @@ impl XtsAes256DecCtxInner<'_> {
         let iv = (tweak as u128).to_le_bytes();
         self.ctx
             .decrypt_init(None, None, Some(&iv))
-            .map_err(|e| err(e, "decryption"))?;
+            .map_err(|e| err(e, "setting the decryption tweak"))?;
         self.ctx
             .cipher_update_inplace(data, data.len())
-            .map_err(|e| err(e, "cipher update"))?;
+            .map_err(|e| err(e, "decrypting data"))?;
         Ok(())
     }
 }

--- a/support/crypto/src/xts_aes_256/symcrypt.rs
+++ b/support/crypto/src/xts_aes_256/symcrypt.rs
@@ -26,7 +26,7 @@ fn err(e: symcrypt::errors::SymCryptError, op: &'static str) -> XtsAes256Error {
 
 impl XtsAes256Inner {
     pub fn new(key: &[u8; KEY_LEN], data_unit_size: u32) -> Result<Self, XtsAes256Error> {
-        let key = XtsAesKey::new(key).map_err(|e| err(e, "expanding xts key"))?;
+        let key = XtsAesKey::new(key).map_err(|e| err(e, "expanding the XTS-AES key"))?;
         Ok(Self {
             key,
             data_unit_size,
@@ -47,7 +47,7 @@ impl XtsAes256EncCtxInner<'_> {
         self.inner
             .key
             .encrypt_in_place(self.inner.data_unit_size as u64, tweak, data)
-            .map_err(|e| err(e, "xts encrypt"))
+            .map_err(|e| err(e, "encrypting data"))
     }
 }
 
@@ -56,6 +56,6 @@ impl XtsAes256DecCtxInner<'_> {
         self.inner
             .key
             .decrypt_in_place(self.inner.data_unit_size as u64, tweak, data)
-            .map_err(|e| err(e, "xts decrypt"))
+            .map_err(|e| err(e, "decrypting data"))
     }
 }

--- a/support/crypto/src/xts_aes_256/win.rs
+++ b/support/crypto/src/xts_aes_256/win.rs
@@ -24,11 +24,11 @@ static XTS_AES_256: LazyLock<Result<AlgHandle, XtsAes256Error>> = LazyLock::new(
     }
     .ok()
     .map(|()| AlgHandle(handle))
-    .map_err(|e| err(e, "open algorithm provider"))
+    .map_err(|e| err(e, "opening the XTS-AES algorithm provider"))
 });
 
 fn err(err: windows_result::Error, op: &'static str) -> XtsAes256Error {
-    XtsAes256Error(crate::BackendError(err, op))
+    XtsAes256Error(crate::BackendError::Windows(err, op))
 }
 
 pub struct XtsAes256Inner {
@@ -58,7 +58,7 @@ impl XtsAes256Inner {
         }
         .ok()
         .map(|()| KeyHandle(handle))
-        .map_err(|e| err(e, "generate symmetric key"))?;
+        .map_err(|e| err(e, "creating the XTS-AES key"))?;
 
         // SAFETY: the key handle is valid.
         unsafe {
@@ -70,7 +70,7 @@ impl XtsAes256Inner {
             )
         }
         .ok()
-        .map_err(|e| err(e, "set message block length"))?;
+        .map_err(|e| err(e, "setting the data unit size"))?;
 
         Ok(XtsAes256Inner { key })
     }
@@ -105,7 +105,7 @@ impl XtsAes256EncCtxInner<'_> {
                 windows::Win32::Security::Cryptography::BCRYPT_FLAGS(0),
             )
             .ok()
-            .map_err(|e| err(e, "encrypt"))
+            .map_err(|e| err(e, "encrypting data"))
         }?;
         assert_eq!(n as usize, data.len());
         Ok(())
@@ -133,7 +133,7 @@ impl XtsAes256DecCtxInner<'_> {
                 windows::Win32::Security::Cryptography::BCRYPT_FLAGS(0),
             )
             .ok()
-            .map_err(|e| err(e, "decrypt"))
+            .map_err(|e| err(e, "decrypting data"))
         }?;
         assert_eq!(n as usize, data.len());
         Ok(())


### PR DESCRIPTION
Backport of #4217 to `release/1.8.2607`.

Cherry-picked commit `15023ef4cdf291d0e52ee1db3f2518e139c43a46`. The cherry-pick applied cleanly with no conflicts and no manual edits.

This previously conflicted on `release/1.8.2607`; it now applies cleanly following the backport of its prerequisite #4108 (#4242).

---
_This pull request was created by an AI agent (GitHub Copilot) on behalf of @smalis-msft._