### PR TITLE
[release/1.8.2607] pipette: Report windows service as Running sooner

### DIFF
--- a/petri/pipette/src/winsvc.rs
+++ b/petri/pipette/src/winsvc.rs
@@ -81,11 +81,16 @@ async fn service_main_inner(
             .context("failed to set service status")
     };
 
-    set_status(service::ServiceState::StartPending)?;
+    // Report the service as running before connecting to the host.
+    //
+    // The SCM locks the service control database for as long as a service is
+    // initializing, which blocks every other `StartService` call in the guest.
+    // Connecting to the host is unbounded and host-paced, so treating it as
+    // initialization stalls unrelated guest service startup.
+    set_status(service::ServiceState::Running)?;
 
     let run = async {
         let agent = Agent::new(driver, transport).await?;
-        set_status(service::ServiceState::Running)?;
         agent.run().await
     };
 


### PR DESCRIPTION
Backport of #4245 to `release/1.8.2607`.

Cherry-picked commit `6ef8c9522f9915b582d43094a2363c35e834dd2f`. The cherry-pick applied cleanly with no conflicts and no manual edits.

---
_This pull request was created by an AI agent (GitHub Copilot) on behalf of @smalis-msft._