### PR TITLE
virt_kvm: split SNP and memory errors

### DIFF
--- a/vmm_core/virt_kvm/src/arch/x86_64/mod.rs
+++ b/vmm_core/virt_kvm/src/arch/x86_64/mod.rs
@@ -377,7 +377,7 @@ impl virt::Hypervisor for Kvm {
                     .read(true)
                     .write(true)
                     .open("/dev/sev")
-                    .map_err(KvmError::OpenSev)?,
+                    .map_err(crate::snp::SnpError::OpenSev)?,
             ),
             virt::IsolationType::None => None,
             virt::IsolationType::Vbs | virt::IsolationType::Tdx | virt::IsolationType::Cca => {

--- a/vmm_core/virt_kvm/src/arch/x86_64/snp.rs
+++ b/vmm_core/virt_kvm/src/arch/x86_64/snp.rs
@@ -3,7 +3,7 @@
 
 //! x86-specific translation of loader imports to KVM SNP page types.
 
-use crate::KvmError;
+use crate::snp::SnpError;
 use virt::InitialPageImportType;
 
 /// Returns the KVM SNP launch page type for a loader import.
@@ -12,7 +12,7 @@ use virt::InitialPageImportType;
 /// than being measured with an unintended page type.
 pub fn snp_launch_page_type(
     import_type: InitialPageImportType,
-) -> Result<kvm::SevSnpPageType, KvmError> {
+) -> Result<kvm::SevSnpPageType, SnpError> {
     match import_type {
         // KVM owns its runtime VMSA and has no SNP launch-update VMSA page
         // type. This reserved guest page carries loader state to OpenVMM only;
@@ -24,7 +24,7 @@ pub fn snp_launch_page_type(
         InitialPageImportType::Secrets => Ok(kvm::SevSnpPageType::Secrets),
         InitialPageImportType::Cpuid => Ok(kvm::SevSnpPageType::Cpuid),
         InitialPageImportType::Shared | InitialPageImportType::CpuidExtendedState => {
-            Err(KvmError::UnsupportedSnpPageImportType(import_type))
+            Err(SnpError::UnsupportedPageImportType(import_type))
         }
     }
 }
@@ -66,7 +66,7 @@ mod tests {
         ] {
             assert!(matches!(
                 snp_launch_page_type(import_type),
-                Err(KvmError::UnsupportedSnpPageImportType(actual)) if actual == import_type
+                Err(SnpError::UnsupportedPageImportType(actual)) if actual == import_type
             ));
         }
     }

--- a/vmm_core/virt_kvm/src/lib.rs
+++ b/vmm_core/virt_kvm/src/lib.rs
@@ -16,6 +16,9 @@ mod memory;
 mod snp;
 
 pub use arch::Kvm;
+pub use memory::MemoryError;
+#[cfg(guest_arch = "x86_64")]
+pub use snp::SnpError;
 
 use guestmem::GuestMemory;
 use inspect::Inspect;
@@ -40,7 +43,6 @@ use arch::KvmVpInner;
 #[cfg(guest_arch = "x86_64")]
 use snp::SnpLaunchState;
 use std::sync::atomic::Ordering;
-use virt::InitialPageImportType;
 use virt::VpIndex;
 use vmcore::vmtime::VmTimeAccess;
 
@@ -52,20 +54,13 @@ pub enum KvmError {
     Vtl2NotSupported,
     #[error("isolation is not supported on this hypervisor")]
     IsolationNotSupported,
-    #[error("failed to open /dev/sev")]
-    OpenSev(#[source] std::io::Error),
-    #[error("unsupported SNP launch page import type: {0:?}")]
-    UnsupportedSnpPageImportType(InitialPageImportType),
-    #[error("missing SNP VMSA import")]
-    MissingSnpVmsa,
-    #[error("multiple SNP VMSA imports")]
-    MultipleSnpVmsa,
-    #[error("invalid SNP VMSA")]
-    InvalidSnpVmsa(#[source] virt::x86::snp::SnpVmsaError),
-    #[error("failed to access SNP VMSA memory")]
-    SnpVmsaMemory(#[source] guestmem::GuestMemoryError),
     #[error("kvm error")]
     Kvm(#[from] kvm::Error),
+    #[error(transparent)]
+    Memory(#[from] MemoryError),
+    #[cfg(guest_arch = "x86_64")]
+    #[error(transparent)]
+    Snp(#[from] SnpError),
     #[error("failed to stat /dev/kvm")]
     AvailableCheck(#[source] std::io::Error),
     #[error(transparent)]
@@ -74,28 +69,6 @@ pub enum KvmError {
     InvalidState(&'static str),
     #[error("unsupported isolation configuration: {0}")]
     UnsupportedIsolationConfiguration(&'static str),
-    #[error("cannot resize KVM guest_memfd memory slot")]
-    CannotResizeGuestMemfdSlot,
-    #[error("private memory range is not contained in guest_memfd private memory")]
-    InvalidPrivateMemoryRange,
-    #[error("SNP launch range is not page aligned")]
-    UnalignedSnpLaunchRange,
-    #[error("SNP launch range is not contained in guestmemfd private memory")]
-    InvalidSnpLaunchRange,
-    #[error("too many CPUID entries for SNP launch page: {0}")]
-    TooManySnpCpuidEntries(usize),
-    #[error("invalid KVM_HC_MAP_GPA_RANGE request")]
-    InvalidMapGpaRange,
-    #[error("unsupported KVM_HC_MAP_GPA_RANGE attributes: {0:#x}")]
-    UnsupportedMapGpaRangeAttributes(u64),
-    #[error("failed to discard shared backing after private conversion")]
-    DiscardSharedBacking(#[source] std::io::Error),
-    #[error("failed to discard private backing after shared conversion")]
-    DiscardPrivateBacking(#[source] std::io::Error),
-    #[error("SNP launch is already in progress")]
-    SnpLaunchInProgress,
-    #[error("SNP launch previously failed")]
-    SnpLaunchFailed,
     #[error("misaligned gic base address")]
     Misaligned,
     #[error("host does not support GICv2 or GICv3")]

--- a/vmm_core/virt_kvm/src/memory.rs
+++ b/vmm_core/virt_kvm/src/memory.rs
@@ -8,7 +8,6 @@
 //! selects the appropriate backing when a range is mapped, validates private
 //! launch ranges, and discards stale contents when ownership changes.
 
-use crate::KvmError;
 use crate::KvmPartition;
 use crate::KvmPartitionInner;
 use inspect::Inspect;
@@ -18,6 +17,27 @@ use std::fs::File;
 #[cfg(guest_arch = "x86_64")]
 use std::os::fd::AsRawFd;
 use std::sync::Arc;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum MemoryError {
+    #[error("kvm memory operation failed")]
+    Kvm(#[from] kvm::Error),
+    #[error("cannot resize KVM guest_memfd memory slot")]
+    CannotResizeGuestMemfdSlot,
+    #[error("private memory range is not contained in guest_memfd private memory")]
+    InvalidPrivateMemoryRange,
+    #[error("invalid KVM_HC_MAP_GPA_RANGE request")]
+    InvalidMapGpaRange,
+    #[error("unsupported KVM_HC_MAP_GPA_RANGE attributes: {0:#x}")]
+    UnsupportedMapGpaRangeAttributes(u64),
+    #[error("failed to discard shared backing after private conversion")]
+    DiscardSharedBacking(#[source] std::io::Error),
+    #[error("failed to discard private backing after shared conversion")]
+    DiscardPrivateBacking(#[source] std::io::Error),
+    #[error("unsupported isolation configuration: {0}")]
+    UnsupportedIsolationConfiguration(&'static str),
+}
 
 #[derive(Debug, Inspect)]
 /// A registered KVM memory slot and its confidential-memory metadata.
@@ -112,7 +132,7 @@ impl KvmMemoryBackingMode {
         kvm: &kvm::Partition,
         ram_ranges: impl IntoIterator<Item = MemoryRange>,
         initial_private: bool,
-    ) -> Result<Self, KvmError> {
+    ) -> Result<Self, MemoryError> {
         check_private_memory_extensions(kvm)?;
 
         let mut file_size = 0u64;
@@ -171,7 +191,7 @@ impl KvmPartitionInner {
             if existing_range.guest_memfd_offset.is_some()
                 && existing_range.range.len() != size as u64
             {
-                return Err(KvmError::CannotResizeGuestMemfdSlot.into());
+                return Err(MemoryError::CannotResizeGuestMemfdSlot.into());
             }
             if existing_range.private_attributes_set {
                 self.kvm.set_memory_attributes(
@@ -247,7 +267,7 @@ impl KvmPartitionInner {
     }
 
     #[cfg(guest_arch = "x86_64")]
-    fn memory_backing(&self, range: MemoryRange) -> Result<KvmMemoryBacking<'_>, KvmError> {
+    fn memory_backing(&self, range: MemoryRange) -> Result<KvmMemoryBacking<'_>, MemoryError> {
         match &self.memory_backing_mode {
             KvmMemoryBackingMode::Userspace => Ok(KvmMemoryBacking::Userspace),
             KvmMemoryBackingMode::GuestMemfd(backing) => {
@@ -264,7 +284,7 @@ impl KvmPartitionInner {
     }
 
     #[cfg(guest_arch = "aarch64")]
-    fn memory_backing(&self, _range: MemoryRange) -> Result<KvmMemoryBacking, KvmError> {
+    fn memory_backing(&self, _range: MemoryRange) -> Result<KvmMemoryBacking, MemoryError> {
         Ok(KvmMemoryBacking::Userspace)
     }
 
@@ -311,26 +331,34 @@ impl KvmPartitionInner {
         gpa: u64,
         page_count: u64,
         map_attributes: u64,
-    ) -> Result<(), KvmError> {
+    ) -> Result<(), MemoryError> {
         const KVM_MAP_GPA_RANGE_PAGE_SIZE_MASK: u64 = 0x3;
         const KVM_MAP_GPA_RANGE_ENC_STATUS_MASK: u64 = 0xf << 4;
 
         let size = page_count
             .checked_mul(hvdef::HV_PAGE_SIZE)
-            .ok_or(KvmError::InvalidMapGpaRange)?;
-        let end = gpa.checked_add(size).ok_or(KvmError::InvalidMapGpaRange)?;
+            .ok_or(MemoryError::InvalidMapGpaRange)?;
+        let end = gpa
+            .checked_add(size)
+            .ok_or(MemoryError::InvalidMapGpaRange)?;
         if !gpa.is_multiple_of(hvdef::HV_PAGE_SIZE) || size == 0 {
-            return Err(KvmError::InvalidMapGpaRange);
+            return Err(MemoryError::InvalidMapGpaRange);
         }
         let unsupported_attributes = map_attributes
             & !(KVM_MAP_GPA_RANGE_PAGE_SIZE_MASK | KVM_MAP_GPA_RANGE_ENC_STATUS_MASK);
         if unsupported_attributes != 0 {
-            return Err(KvmError::UnsupportedMapGpaRangeAttributes(map_attributes));
+            return Err(MemoryError::UnsupportedMapGpaRangeAttributes(
+                map_attributes,
+            ));
         }
         let private = match map_attributes & KVM_MAP_GPA_RANGE_ENC_STATUS_MASK {
             kvm::KVM_MAP_GPA_RANGE_DECRYPTED_UAPI => false,
             kvm::KVM_MAP_GPA_RANGE_ENCRYPTED_UAPI => true,
-            _ => return Err(KvmError::UnsupportedMapGpaRangeAttributes(map_attributes)),
+            _ => {
+                return Err(MemoryError::UnsupportedMapGpaRangeAttributes(
+                    map_attributes,
+                ));
+            }
         };
 
         let range = MemoryRange::new(gpa..end);
@@ -368,7 +396,7 @@ impl KvmPartitionInner {
         segments: &[KvmMemoryRangeSegment],
         private: bool,
         isolation_name: &'static str,
-    ) -> Result<(), KvmError> {
+    ) -> Result<(), MemoryError> {
         if private {
             for segment in segments {
                 tracing::debug!(
@@ -386,14 +414,14 @@ impl KvmPartitionInner {
                     )
                 };
                 if ret != 0 {
-                    return Err(KvmError::DiscardSharedBacking(
+                    return Err(MemoryError::DiscardSharedBacking(
                         std::io::Error::last_os_error(),
                     ));
                 }
             }
         } else {
             let KvmMemoryBackingMode::GuestMemfd(backing) = &self.memory_backing_mode else {
-                return Err(KvmError::InvalidMapGpaRange);
+                return Err(MemoryError::InvalidMapGpaRange);
             };
             for segment in segments {
                 tracing::debug!(
@@ -412,7 +440,7 @@ impl KvmPartitionInner {
                     )
                 };
                 if ret != 0 {
-                    return Err(KvmError::DiscardPrivateBacking(
+                    return Err(MemoryError::DiscardPrivateBacking(
                         std::io::Error::last_os_error(),
                     ));
                 }
@@ -426,7 +454,7 @@ impl KvmPartitionInner {
 fn guest_memfd_range_segments(
     range: MemoryRange,
     slots: &[Option<KvmMemoryRange>],
-) -> Result<Vec<KvmMemoryRangeSegment>, KvmError> {
+) -> Result<Vec<KvmMemoryRangeSegment>, MemoryError> {
     let mut segments = slots
         .iter()
         .flatten()
@@ -449,12 +477,12 @@ fn guest_memfd_range_segments(
     let mut cursor = range.start();
     for segment in &segments {
         if segment.range.start() != cursor {
-            return Err(KvmError::InvalidMapGpaRange);
+            return Err(MemoryError::InvalidMapGpaRange);
         }
         cursor = segment.range.end();
     }
     if cursor != range.end() {
-        return Err(KvmError::InvalidMapGpaRange);
+        return Err(MemoryError::InvalidMapGpaRange);
     }
 
     Ok(segments)
@@ -468,15 +496,15 @@ fn guest_memfd_range_segments(
 pub(crate) fn private_memory_range_from_slots(
     range: MemoryRange,
     slots: &[Option<KvmMemoryRange>],
-) -> Result<KvmPrivateMemoryRange, KvmError> {
+) -> Result<KvmPrivateMemoryRange, MemoryError> {
     let slot = slots
         .iter()
         .flatten()
         .find(|slot| slot.range.contains(&range))
-        .ok_or(KvmError::InvalidPrivateMemoryRange)?;
+        .ok_or(MemoryError::InvalidPrivateMemoryRange)?;
 
     if slot.guest_memfd_offset.is_none() || !slot.private_attributes_set {
-        return Err(KvmError::InvalidPrivateMemoryRange);
+        return Err(MemoryError::InvalidPrivateMemoryRange);
     }
 
     let offset = range.start() - slot.range.start();
@@ -488,7 +516,7 @@ pub(crate) fn private_memory_range_from_slots(
 
 #[cfg(guest_arch = "x86_64")]
 /// Verifies the KVM capabilities required for guestmemfd private memory.
-fn check_private_memory_extensions(kvm: &kvm::Partition) -> Result<(), KvmError> {
+fn check_private_memory_extensions(kvm: &kvm::Partition) -> Result<(), MemoryError> {
     require_kvm_extension(kvm, kvm::KVM_CAP_USER_MEMORY2, "KVM_CAP_USER_MEMORY2")?;
     require_kvm_extension(kvm, kvm::KVM_CAP_GUEST_MEMFD, "KVM_CAP_GUEST_MEMFD")?;
     let memory_attributes = require_kvm_extension(
@@ -510,7 +538,7 @@ fn require_kvm_extension(
     kvm: &kvm::Partition,
     extension: u32,
     capability: &'static str,
-) -> Result<i32, KvmError> {
+) -> Result<i32, MemoryError> {
     let value = kvm
         .check_extension(extension)
         .map_err(kvm::Error::CheckExtension)?;
@@ -524,13 +552,13 @@ fn require_kvm_extension(
 fn classify_guest_memfd_backing(
     range: MemoryRange,
     ram_ranges: &[KvmGuestMemfdRange],
-) -> Result<Option<u64>, KvmError> {
+) -> Result<Option<u64>, MemoryError> {
     let mut containing_ranges = ram_ranges
         .iter()
         .filter(|ram_range| ram_range.range.contains(&range));
     if let Some(ram_range) = containing_ranges.next() {
         if containing_ranges.next().is_some() {
-            return Err(KvmError::UnsupportedIsolationConfiguration(
+            return Err(MemoryError::UnsupportedIsolationConfiguration(
                 "KVM guest_memfd mappings must be contained in exactly one RAM range",
             ));
         }
@@ -543,7 +571,7 @@ fn classify_guest_memfd_backing(
         .iter()
         .any(|ram_range| ram_range.range.overlaps(&range))
     {
-        return Err(KvmError::UnsupportedIsolationConfiguration(
+        return Err(MemoryError::UnsupportedIsolationConfiguration(
             "KVM guest_memfd mappings must be fully contained in one RAM range",
         ));
     }
@@ -634,15 +662,15 @@ mod tests {
     fn private_memory_range_from_slots(
         range: MemoryRange,
         slots: &[Option<KvmMemoryRange>],
-    ) -> Result<KvmPrivateMemoryRange, KvmError> {
+    ) -> Result<KvmPrivateMemoryRange, MemoryError> {
         let slot = slots
             .iter()
             .flatten()
             .find(|slot| slot.range.contains(&range))
-            .ok_or(KvmError::InvalidPrivateMemoryRange)?;
+            .ok_or(MemoryError::InvalidPrivateMemoryRange)?;
 
         if slot.guest_memfd_offset.is_none() || !slot.private_attributes_set {
-            return Err(KvmError::InvalidPrivateMemoryRange);
+            return Err(MemoryError::InvalidPrivateMemoryRange);
         }
 
         let offset = range.start() - slot.range.start();
@@ -685,7 +713,7 @@ mod tests {
 
         assert!(matches!(
             classify_guest_memfd_backing(range(0x8000, 0xa000), &ram_ranges),
-            Err(KvmError::UnsupportedIsolationConfiguration(_))
+            Err(MemoryError::UnsupportedIsolationConfiguration(_))
         ));
     }
 
@@ -696,7 +724,7 @@ mod tests {
 
         assert!(matches!(
             classify_guest_memfd_backing(range(0x2000, 0x4000), &ram_ranges),
-            Err(KvmError::UnsupportedIsolationConfiguration(_))
+            Err(MemoryError::UnsupportedIsolationConfiguration(_))
         ));
     }
 
@@ -707,7 +735,7 @@ mod tests {
 
         assert!(matches!(
             classify_guest_memfd_backing(range(0x2000, 0x4000), &ram_ranges),
-            Err(KvmError::UnsupportedIsolationConfiguration(_))
+            Err(MemoryError::UnsupportedIsolationConfiguration(_))
         ));
     }
 
@@ -740,7 +768,7 @@ mod tests {
         })];
         assert!(matches!(
             private_memory_range_from_slots(range(0x1000, 0x2000), &userspace_slots),
-            Err(KvmError::InvalidPrivateMemoryRange)
+            Err(MemoryError::InvalidPrivateMemoryRange)
         ));
 
         let shared_slots = [Some(KvmMemoryRange {
@@ -751,7 +779,7 @@ mod tests {
         })];
         assert!(matches!(
             private_memory_range_from_slots(range(0x1000, 0x2000), &shared_slots),
-            Err(KvmError::InvalidPrivateMemoryRange)
+            Err(MemoryError::InvalidPrivateMemoryRange)
         ));
     }
 
@@ -817,7 +845,7 @@ mod tests {
         ];
         assert!(matches!(
             guest_memfd_range_segments(range(0x1000, 0x4000), &gapped_slots),
-            Err(KvmError::InvalidMapGpaRange)
+            Err(MemoryError::InvalidMapGpaRange)
         ));
 
         let userspace_slot = [Some(KvmMemoryRange {
@@ -828,7 +856,7 @@ mod tests {
         })];
         assert!(matches!(
             guest_memfd_range_segments(range(0x1000, 0x4000), &userspace_slot),
-            Err(KvmError::InvalidMapGpaRange)
+            Err(MemoryError::InvalidMapGpaRange)
         ));
     }
 
@@ -854,7 +882,7 @@ mod tests {
 
         assert!(matches!(
             guest_memfd_range_segments(range(0x1000, 0x4000), &slots),
-            Err(KvmError::InvalidMapGpaRange)
+            Err(MemoryError::InvalidMapGpaRange)
         ));
     }
 }

--- a/vmm_core/virt_kvm/src/snp.rs
+++ b/vmm_core/virt_kvm/src/snp.rs
@@ -13,9 +13,43 @@
 use crate::KvmError;
 use crate::KvmPartition;
 use crate::KvmPartitionInner;
+use crate::memory::MemoryError;
 use crate::memory::private_memory_range_from_slots;
 use std::os::fd::AsFd;
+use thiserror::Error;
 use virt::InitialPageImportType;
+
+#[derive(Debug, Error)]
+pub enum SnpError {
+    #[error("SNP isolation is not configured")]
+    IsolationNotSupported,
+    #[error("failed to open /dev/sev")]
+    OpenSev(#[source] std::io::Error),
+    #[error("unsupported SNP launch page import type: {0:?}")]
+    UnsupportedPageImportType(InitialPageImportType),
+    #[error("missing SNP VMSA import")]
+    MissingVmsa,
+    #[error("multiple SNP VMSA imports")]
+    MultipleVmsa,
+    #[error("invalid SNP VMSA")]
+    InvalidVmsa(#[source] virt::x86::snp::SnpVmsaError),
+    #[error("failed to access SNP VMSA memory")]
+    VmsaMemory(#[source] guestmem::GuestMemoryError),
+    #[error("invalid SNP launch range")]
+    InvalidLaunchRange,
+    #[error("too many CPUID entries for SNP launch page: {0}")]
+    TooManyCpuidEntries(usize),
+    #[error("SNP launch is already in progress")]
+    LaunchInProgress,
+    #[error("SNP launch previously failed")]
+    LaunchFailed,
+    #[error("invalid SNP BSP state: {0}")]
+    InvalidBspState(&'static str),
+    #[error("KVM SNP operation failed")]
+    Kvm(#[from] kvm::Error),
+    #[error(transparent)]
+    Memory(#[from] MemoryError),
+}
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 /// Progress of the one-shot SNP launch sequence.
@@ -34,20 +68,21 @@ impl virt::AcceptInitialPages for KvmPartition {
     type Error = KvmError;
 
     fn accept_initial_pages(&self, pages: &[virt::InitialPageImport]) -> Result<(), Self::Error> {
-        self.inner.snp_launch_initial_pages(pages)
+        self.inner.snp_launch_initial_pages(pages)?;
+        Ok(())
     }
 }
 
 impl KvmPartitionInner {
     /// Runs the SNP launch sequence once and records its terminal state.
-    fn snp_launch_initial_pages(&self, pages: &[virt::InitialPageImport]) -> Result<(), KvmError> {
+    fn snp_launch_initial_pages(&self, pages: &[virt::InitialPageImport]) -> Result<(), SnpError> {
         {
             let mut state = self.snp_launch_state.lock();
             match *state {
                 SnpLaunchState::NotStarted => *state = SnpLaunchState::Started,
-                SnpLaunchState::Started => return Err(KvmError::SnpLaunchInProgress),
+                SnpLaunchState::Started => return Err(SnpError::LaunchInProgress),
                 SnpLaunchState::Finished => return Ok(()),
-                SnpLaunchState::Failed => return Err(KvmError::SnpLaunchFailed),
+                SnpLaunchState::Failed => return Err(SnpError::LaunchFailed),
             }
         }
 
@@ -70,8 +105,8 @@ impl KvmPartitionInner {
     fn snp_launch_initial_pages_inner(
         &self,
         pages: &[virt::InitialPageImport],
-    ) -> Result<(), KvmError> {
-        let sev = self.sev.as_ref().ok_or(KvmError::IsolationNotSupported)?;
+    ) -> Result<(), SnpError> {
+        let sev = self.sev.as_ref().ok_or(SnpError::IsolationNotSupported)?;
         self.apply_snp_vmsa(pages)?;
         self.kvm.check_sev_snp_launch_extensions()?;
         let mut launch_start = kvm::kvm_sev_snp_launch_start {
@@ -128,23 +163,23 @@ impl KvmPartitionInner {
 
     // TODO: Remove this register translation once KVM supports importing a
     // loader-provided VMSA directly.
-    fn apply_snp_vmsa(&self, pages: &[virt::InitialPageImport]) -> Result<(), KvmError> {
+    fn apply_snp_vmsa(&self, pages: &[virt::InitialPageImport]) -> Result<(), SnpError> {
         let mut vmsa_pages = pages
             .iter()
             .filter(|page| page.import_type == InitialPageImportType::VpContext);
-        let page = vmsa_pages.next().ok_or(KvmError::MissingSnpVmsa)?;
+        let page = vmsa_pages.next().ok_or(SnpError::MissingVmsa)?;
         if vmsa_pages.next().is_some() {
-            return Err(KvmError::MultipleSnpVmsa);
+            return Err(SnpError::MultipleVmsa);
         }
         if page.range.len() != hvdef::HV_PAGE_SIZE {
-            return Err(KvmError::InvalidSnpLaunchRange);
+            return Err(SnpError::InvalidLaunchRange);
         }
 
         let vmsa = self
             .gm
             .read_plain::<x86defs::snp::SevVmsa>(page.range.start())
-            .map_err(KvmError::SnpVmsaMemory)?;
-        let state = virt::x86::snp::state_from_vmsa(&vmsa).map_err(KvmError::InvalidSnpVmsa)?;
+            .map_err(SnpError::VmsaMemory)?;
+        let state = virt::x86::snp::state_from_vmsa(&vmsa).map_err(SnpError::InvalidVmsa)?;
         let kvm_vp = self.vp_kvm(virt::VpIndex::BSP);
         let registers = state.registers;
         let regs = kvm::kvm_regs {
@@ -206,7 +241,7 @@ impl KvmPartitionInner {
     ///
     /// AP register state is not validated here because SNP APs are started
     /// later through GHCB AP creation with guest-provided VMSAs.
-    fn prepare_snp_vmsa_register_state(&self) -> Result<(), KvmError> {
+    fn prepare_snp_vmsa_register_state(&self) -> Result<(), SnpError> {
         for vp in &self.vps {
             let vp_info = vp.vp_info();
             let kvm_vp = self.kvm.vp(vp_info.apic_id);
@@ -234,29 +269,29 @@ impl KvmPartitionInner {
 fn validate_snp_bsp_register_state(
     regs: &kvm::kvm_regs,
     sregs: &kvm::kvm_sregs,
-) -> Result<(), KvmError> {
+) -> Result<(), SnpError> {
     const REQUIRED_CR0: u64 = x86defs::X64_CR0_PE | x86defs::X64_CR0_PG;
     const REQUIRED_CR4: u64 = x86defs::X64_CR4_PAE;
     const REQUIRED_EFER: u64 =
         x86defs::X64_EFER_LME | x86defs::X64_EFER_LMA | x86defs::X64_EFER_NXE;
 
     if sregs.cr0 & REQUIRED_CR0 != REQUIRED_CR0 {
-        return Err(KvmError::InvalidState("invalid SNP BSP CR0"));
+        return Err(SnpError::InvalidBspState("CR0"));
     }
     if sregs.cr3 == 0 {
-        return Err(KvmError::InvalidState("invalid SNP BSP CR3"));
+        return Err(SnpError::InvalidBspState("CR3"));
     }
     if sregs.cr4 & REQUIRED_CR4 != REQUIRED_CR4 {
-        return Err(KvmError::InvalidState("invalid SNP BSP CR4"));
+        return Err(SnpError::InvalidBspState("CR4"));
     }
     if sregs.efer & REQUIRED_EFER != REQUIRED_EFER {
-        return Err(KvmError::InvalidState("invalid SNP BSP EFER"));
+        return Err(SnpError::InvalidBspState("EFER"));
     }
     if sregs.cs.present == 0 || sregs.cs.l == 0 {
-        return Err(KvmError::InvalidState("invalid SNP BSP CS"));
+        return Err(SnpError::InvalidBspState("CS"));
     }
     if regs.rip == 0 {
-        return Err(KvmError::InvalidState("invalid SNP BSP RIP"));
+        return Err(SnpError::InvalidBspState("RIP"));
     }
 
     tracing::debug!(
@@ -293,9 +328,9 @@ fn write_snp_cpuid_page(
     page: *mut u8,
     page_len: u64,
     cpuid: &[kvm::kvm_cpuid_entry2],
-) -> Result<(), KvmError> {
+) -> Result<(), SnpError> {
     if page_len < (SNP_CPUID_TABLE_HEADER_SIZE + SNP_CPUID_COUNT_MAX * SNP_CPUID_FN_SIZE) as u64 {
-        return Err(KvmError::InvalidSnpLaunchRange);
+        return Err(SnpError::InvalidLaunchRange);
     }
 
     let cpuid = cpuid
@@ -307,7 +342,7 @@ fn write_snp_cpuid_page(
         })
         .collect::<Vec<_>>();
     if cpuid.len() > SNP_CPUID_COUNT_MAX {
-        return Err(KvmError::TooManySnpCpuidEntries(cpuid.len()));
+        return Err(SnpError::TooManyCpuidEntries(cpuid.len()));
     }
 
     let page = unsafe { std::slice::from_raw_parts_mut(page, page_len as usize) };
@@ -359,10 +394,10 @@ fn sanitize_snp_cpuid_entry(entry: &mut kvm::kvm_cpuid_entry2) {
 }
 
 /// Converts a generic private-slot lookup failure into the SNP launch error.
-fn map_snp_private_range_error(err: KvmError) -> KvmError {
+fn map_snp_private_range_error(err: MemoryError) -> SnpError {
     match err {
-        KvmError::InvalidPrivateMemoryRange => KvmError::InvalidSnpLaunchRange,
-        err => err,
+        MemoryError::InvalidPrivateMemoryRange => SnpError::InvalidLaunchRange,
+        err => SnpError::Memory(err),
     }
 }
 
@@ -468,7 +503,7 @@ mod tests {
         cpuid.last_mut().unwrap().eax = 1;
         assert!(matches!(
             write_snp_cpuid_page(page.as_mut_ptr(), page.len() as u64, &cpuid),
-            Err(KvmError::TooManySnpCpuidEntries(count)) if count == SNP_CPUID_COUNT_MAX + 1
+            Err(SnpError::TooManyCpuidEntries(count)) if count == SNP_CPUID_COUNT_MAX + 1
         ));
     }
 }


### PR DESCRIPTION
Move SNP launch and guestmemfd memory failures into subsystem-specific error enums so internal functions expose only the failures relevant to their operation. Keep KvmError as the public aggregation boundary for virt trait implementations and partition construction.

This is a follow-up to the error-organization feedback on microsoft/openvmm#4233.