### PR TITLE
flowey: fix build-igvm test invoking `rustup run` with no toolchain

### DIFF
--- a/flowey/flowey_lib_hvlite/src/_jobs/test_local_flowey_build_igvm.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/test_local_flowey_build_igvm.rs
@@ -45,10 +45,13 @@ impl SimpleFlowNode for Node {
                     let rust_toolchain = rt.read(rust_toolchain);
                     let base_recipe = base_recipe.non_production_tag();
                     rt.sh.change_dir(hvlite_repo);
-                    let mut cmd = flowey::shell_cmd!(
-                        rt,
-                        "rustup run {rust_toolchain...} cargo xflowey build-igvm {base_recipe} --install-missing-deps"
-                    )
+                    let mut cmd = if let Some(rust_toolchain) = &rust_toolchain {
+                        flowey::shell_cmd!(rt, "rustup run {rust_toolchain} cargo")
+                    } else {
+                        flowey::shell_cmd!(rt, "cargo")
+                    }
+                    .args(["xflowey", "build-igvm", &base_recipe])
+                    .arg("--install-missing-deps")
                     .env("I_HAVE_A_GOOD_REASON_TO_RUN_BUILD_IGVM_IN_CI", "true");
                     if let Some(gh_token) = gh_token {
                         cmd = cmd.env("GITHUB_TOKEN", gh_token);


### PR DESCRIPTION
`test_local_flowey_build_igvm` built its command as:

```
"rustup run {rust_toolchain...} cargo xflowey build-igvm ..."
```

`rust_toolchain` is an `Option<String>`, and xshell's `{x...}` splat iterates the value. `Option` is `IntoIterator`, so `None` contributes **zero** tokens rather than the intended "no toolchain" form, collapsing the command to:

```
rustup run cargo xflowey build-igvm ...
```

where rustup parses `cargo` as the toolchain name and fails. `None` is precisely the case where rustup isn't available at all, so it is also the case where `rustup` must not appear in the argv.

This switches to the same explicit if/else shape the other cargo call sites use (e.g. `run_cargo_clippy`), so the `None` case runs plain `cargo`.

Latent in practice: CI always pins a toolchain, so `GetRustupToolchain` has never yielded `None` on this path.

No generated YAML churn — the change is inside an `emit_rust_step` runtime closure.