### PR TITLE
openhcl: add GET LoadFirmware request for hibernation firmware overload

### DIFF
--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -3699,7 +3699,12 @@ async fn new_underhill_vm(
     // firmware is overloaded (via the GET `LoadFirmware` host request) with the
     // hibernated version before it runs; on success that version becomes the
     // recorded token.
-    let current_hibernate_token = if !dps.general.hibernation_enabled {
+    let current_hibernate_token = if !dps.general.hibernation_enabled
+        || !matches!(firmware_type, FirmwareType::Uefi)
+    {
+        // Hibernation is disabled, or this isn't a UEFI guest. Firmware overload
+        // is UEFI-only (gen-1/PCAT can hibernate but can't reload firmware), so
+        // there's no firmware version to pin — don't track a token.
         None
     } else if is_restoring {
         // Older saved state may not carry hibernation state; treat as unknown.
@@ -3717,17 +3722,7 @@ async fn new_underhill_vm(
             Some(token @ hibernate::Token::Hibernated { .. })
                 if token != hibernate::Token::CURRENT =>
             {
-                if !matches!(load_kind, LoadKind::Uefi) {
-                    // Firmware overload is UEFI-only; a gen-1/PCAT guest can
-                    // hibernate but can't reload firmware, so resume as-is.
-                    tracing::warn!(
-                        CVM_ALLOWED,
-                        resume = %token,
-                        "firmware overload is only supported for UEFI; resuming \
-                         with the current firmware despite a hibernation token mismatch"
-                    );
-                    Some(hibernate::Token::CURRENT)
-                } else if !dps
+                if !dps
                     .general
                     .management_vtl_features
                     .load_firmware_supported()

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -2246,7 +2246,7 @@ async fn new_underhill_vm(
     );
 
     // Read measured config from VTL0 memory. When restoring, it is already gone.
-    let (firmware_type, measured_vtl0_info, load_kind) = {
+    let (firmware_type, mut measured_vtl0_info, load_kind) = {
         if let Some(firmware_type) = servicing_state.firmware_type {
             (firmware_type.into(), None, LoadKind::None)
         } else {
@@ -3694,6 +3694,11 @@ async fn new_underhill_vm(
     // cycle. On a servicing restore the VMGS token was already consumed at the
     // original cold boot, so recover it from saved state; otherwise read (and
     // consume) it from VMGS.
+    //
+    // When resuming under a firmware version other than the current one, VTL0's
+    // firmware is overloaded (via the GET `LoadFirmware` host request) with the
+    // hibernated version before it runs; on success that version becomes the
+    // recorded token.
     let current_hibernate_token = if !dps.general.hibernation_enabled {
         None
     } else if is_restoring {
@@ -3705,24 +3710,32 @@ async fn new_underhill_vm(
                 .map_or(hibernate::Token::UNKNOWN, |h| h.token.into()),
         )
     } else if let Some(vmgs_client) = vmgs_client.as_ref() {
-        if let Some(token @ hibernate::Token::Hibernated { .. }) =
-            hibernate::read_token(vmgs_client).await
-        {
-            // A resume under a different firmware version; warn but don't honor
-            // it yet.
-            if token != hibernate::Token::CURRENT {
-                tracing::warn!(
+        let resume_token = hibernate::read_token(vmgs_client).await;
+        // Consume any token, valid or corrupt, so it is not re-read next boot.
+        hibernate::delete_token(vmgs_client).await;
+        match resume_token {
+            Some(token @ hibernate::Token::Hibernated { .. })
+                if token != hibernate::Token::CURRENT =>
+            {
+                tracing::info!(
                     CVM_ALLOWED,
                     resume = %token,
                     current = %hibernate::Token::CURRENT,
-                    "hibernation resume token does not match the current firmware version"
+                    "hibernation resume under a different firmware version; requesting firmware overload"
                 );
+                // If the overload succeeds VTL0 now runs the hibernated
+                // version, so record it; otherwise fall back to the current one.
+                if overload_vtl0_firmware(&get_client, u64::from(token), &mut measured_vtl0_info)
+                    .await
+                {
+                    Some(token)
+                } else {
+                    Some(hibernate::Token::CURRENT)
+                }
             }
+            // Not hibernated, same version, or corrupt: use the current version.
+            _ => Some(hibernate::Token::CURRENT),
         }
-        // Consume any token, valid or corrupt, so it is not re-read next boot.
-        hibernate::delete_token(vmgs_client).await;
-        // No overload support yet; always use the current firmware version.
-        Some(hibernate::Token::CURRENT)
     } else {
         // Hibernation was requested but there is no VMGS to persist the token,
         // so it cannot survive a power transition.
@@ -4105,6 +4118,76 @@ async fn wait_for_flush_logs(control_send: &Arc<Mutex<Option<mesh::Sender<Contro
     if let Some(call) = call {
         call.await.ok();
     }
+}
+
+/// Ask the host to overwrite VTL0's firmware image in guest RAM with the version
+/// identified by `token` (used on a hibernation resume under a different firmware
+/// version). On success, updates the measured UEFI context so VTL0 starts at the
+/// overloaded image's entry point and returns `true`. Best-effort: on failure
+/// the cold-boot image is left in place and `false` is returned.
+async fn overload_vtl0_firmware(
+    get_client: &GuestEmulationTransportClient,
+    token: u64,
+    measured_vtl0_info: &mut Option<MeasuredVtl0Info>,
+) -> bool {
+    let offset = match get_client.load_firmware(token).await {
+        Ok(offset) => offset,
+        Err(err) => {
+            tracing::warn!(
+                CVM_ALLOWED,
+                error = &err as &dyn std::error::Error,
+                token,
+                "LoadFirmware host request for firmware overload failed"
+            );
+            return false;
+        }
+    };
+
+    tracing::info!(
+        CVM_ALLOWED,
+        token,
+        "overloaded VTL0 firmware via host LoadFirmware request"
+    );
+
+    // The overloaded image's entry point may differ from the cold-boot image's,
+    // so point the measured UEFI context's RIP at the host-computed offset;
+    // load_firmware later applies it to VTL0.
+    #[cfg(guest_arch = "x86_64")]
+    if let Some(uefi_info) = measured_vtl0_info
+        .as_mut()
+        .and_then(|info| info.supports_uefi.as_mut())
+    {
+        if offset != 0 {
+            let base = uefi_info.firmware_memory.start();
+            let crate::loader::VpContext::Vbs(registers) = &mut uefi_info.vp_context;
+            for reg in registers {
+                if let loader::importer::X86Register::Rip(rip) = reg {
+                    let new_rip = base + offset;
+                    if *rip != new_rip {
+                        tracing::info!(
+                            CVM_ALLOWED,
+                            old_rip = *rip,
+                            new_rip,
+                            "rebased VTL0 RIP for overloaded firmware"
+                        );
+                        *rip = new_rip;
+                    }
+                }
+            }
+        }
+    }
+    #[cfg(guest_arch = "aarch64")]
+    if offset != 0 {
+        // aarch64 has no entry-point offset; a non-zero value is a host
+        // protocol violation. Don't trust it, just surface it and ignore.
+        tracing::warn!(
+            CVM_ALLOWED,
+            offset,
+            "host returned a non-zero firmware entry-point offset on aarch64; ignoring"
+        );
+    }
+
+    true
 }
 
 async fn load_firmware(

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -3717,7 +3717,17 @@ async fn new_underhill_vm(
             Some(token @ hibernate::Token::Hibernated { .. })
                 if token != hibernate::Token::CURRENT =>
             {
-                if !dps
+                if !matches!(load_kind, LoadKind::Uefi) {
+                    // Firmware overload is UEFI-only; a gen-1/PCAT guest can
+                    // hibernate but can't reload firmware, so resume as-is.
+                    tracing::warn!(
+                        CVM_ALLOWED,
+                        resume = %token,
+                        "firmware overload is only supported for UEFI; resuming \
+                         with the current firmware despite a hibernation token mismatch"
+                    );
+                    Some(hibernate::Token::CURRENT)
+                } else if !dps
                     .general
                     .management_vtl_features
                     .load_firmware_supported()
@@ -3754,8 +3764,17 @@ async fn new_underhill_vm(
                     }
                 }
             }
-            // Not hibernated, same version, or corrupt: use the current version.
-            _ => Some(hibernate::Token::CURRENT),
+            Some(hibernate::Token::Hibernated { .. }) => {
+                // Guarded above: the token matches the current firmware version.
+                tracing::info!(
+                    CVM_ALLOWED,
+                    "hibernation resume under the current firmware version"
+                );
+                Some(hibernate::Token::CURRENT)
+            }
+            // Clean prior power-off, or no/unreadable token (e.g. first boot):
+            // a normal cold boot on the current firmware.
+            Some(hibernate::Token::NotHibernated) | None => Some(hibernate::Token::CURRENT),
         }
     } else {
         // Hibernation was requested but there is no VMGS to persist the token,
@@ -4183,10 +4202,22 @@ async fn overload_vtl0_firmware(
     {
         if offset != 0 {
             let base = uefi_info.firmware_memory.start();
+            let len = uefi_info.firmware_memory.len();
+            // `offset` is host-provided (untrusted): the entry point must land
+            // inside the measured firmware region and must not overflow.
+            let Some(new_rip) = base.checked_add(offset).filter(|_| offset < len) else {
+                tracing::warn!(
+                    CVM_ALLOWED,
+                    offset,
+                    firmware_len = len,
+                    "host returned an out-of-range firmware entry-point offset; \
+                     ignoring overload and resuming with the current firmware"
+                );
+                return false;
+            };
             let crate::loader::VpContext::Vbs(registers) = &mut uefi_info.vp_context;
             for reg in registers {
                 if let loader::importer::X86Register::Rip(rip) = reg {
-                    let new_rip = base + offset;
                     if *rip != new_rip {
                         tracing::info!(
                             CVM_ALLOWED,

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -3717,20 +3717,41 @@ async fn new_underhill_vm(
             Some(token @ hibernate::Token::Hibernated { .. })
                 if token != hibernate::Token::CURRENT =>
             {
-                tracing::info!(
-                    CVM_ALLOWED,
-                    resume = %token,
-                    current = %hibernate::Token::CURRENT,
-                    "hibernation resume under a different firmware version; requesting firmware overload"
-                );
-                // If the overload succeeds VTL0 now runs the hibernated
-                // version, so record it; otherwise fall back to the current one.
-                if overload_vtl0_firmware(&get_client, u64::from(token), &mut measured_vtl0_info)
-                    .await
+                if !dps
+                    .general
+                    .management_vtl_features
+                    .load_firmware_supported()
                 {
-                    Some(token)
-                } else {
+                    // The host must advertise LoadFirmware support; without it
+                    // we can't overload, so resume on the current firmware.
+                    tracing::warn!(
+                        CVM_ALLOWED,
+                        resume = %token,
+                        "host does not support firmware overload (LoadFirmware); \
+                         resuming with the current firmware version despite a \
+                         hibernation token mismatch"
+                    );
                     Some(hibernate::Token::CURRENT)
+                } else {
+                    tracing::info!(
+                        CVM_ALLOWED,
+                        resume = %token,
+                        current = %hibernate::Token::CURRENT,
+                        "hibernation resume under a different firmware version; requesting firmware overload"
+                    );
+                    // If the overload succeeds VTL0 now runs the hibernated
+                    // version, so record it; otherwise fall back to the current one.
+                    if overload_vtl0_firmware(
+                        &get_client,
+                        u64::from(token),
+                        &mut measured_vtl0_info,
+                    )
+                    .await
+                    {
+                        Some(token)
+                    } else {
+                        Some(hibernate::Token::CURRENT)
+                    }
                 }
             }
             // Not hibernated, same version, or corrupt: use the current version.
@@ -4125,26 +4146,14 @@ async fn wait_for_flush_logs(control_send: &Arc<Mutex<Option<mesh::Sender<Contro
 /// version). On success, updates the measured UEFI context so VTL0 starts at the
 /// overloaded image's entry point and returns `true`. Best-effort: on failure
 /// the cold-boot image is left in place and `false` is returned.
+///
+/// The caller must only invoke this when the host has advertised the
+/// `load_firmware_supported` bit in `ManagementVtlFeatures`.
 async fn overload_vtl0_firmware(
     get_client: &GuestEmulationTransportClient,
     token: u64,
     measured_vtl0_info: &mut Option<MeasuredVtl0Info>,
 ) -> bool {
-    // The LoadFirmware host request requires NICKEL_REV3. On older hosts we
-    // can't overload the firmware, so skip the request; warn, since the caller
-    // only reaches here when the resume token doesn't match the current version.
-    if get_client.version() < get_protocol::ProtocolVersion::NICKEL_REV3 {
-        tracing::warn!(
-            CVM_ALLOWED,
-            token,
-            version = ?get_client.version(),
-            "host does not support firmware overload (requires NICKEL_REV3); \
-             resuming with the current firmware version despite a hibernation \
-             token mismatch"
-        );
-        return false;
-    }
-
     let offset = match get_client.load_firmware(token).await {
         Ok(offset) => offset,
         Err(err) => {

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -4130,6 +4130,21 @@ async fn overload_vtl0_firmware(
     token: u64,
     measured_vtl0_info: &mut Option<MeasuredVtl0Info>,
 ) -> bool {
+    // The LoadFirmware host request requires NICKEL_REV3. On older hosts we
+    // can't overload the firmware, so skip the request; warn, since the caller
+    // only reaches here when the resume token doesn't match the current version.
+    if get_client.version() < get_protocol::ProtocolVersion::NICKEL_REV3 {
+        tracing::warn!(
+            CVM_ALLOWED,
+            token,
+            version = ?get_client.version(),
+            "host does not support firmware overload (requires NICKEL_REV3); \
+             resuming with the current firmware version despite a hibernation \
+             token mismatch"
+        );
+        return false;
+    }
+
     let offset = match get_client.load_firmware(token).await {
         Ok(offset) => offset,
         Err(err) => {

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -3707,7 +3707,16 @@ async fn new_underhill_vm(
         // there's no firmware version to pin — don't track a token.
         None
     } else if is_restoring {
-        // Older saved state may not carry hibernation state; treat as unknown.
+        // In the restore case, the VMGS token was already consumed at the
+        // original cold boot, so recover it from saved state.  Note that we must
+        // not attempt to overload the firmware here, because the firmware has
+        // already been loaded and is running.  If the firmware version has changed
+        // since the original cold boot, the firmware will have already been
+        // overloaded and the token in saved state will reflect that.  If the
+        // firmware version has not changed, the token in saved state will be the
+        // current firmware version (from the previous instance).  In either case,
+        // we can just use the token.
+        // N.B. Older saved state may not carry hibernation state; treat as unknown.
         Some(
             servicing_state
                 .hibernate

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -4192,14 +4192,18 @@ async fn overload_vtl0_firmware(
         }
     }
     #[cfg(guest_arch = "aarch64")]
-    if offset != 0 {
-        // aarch64 has no entry-point offset; a non-zero value is a host
-        // protocol violation. Don't trust it, just surface it and ignore.
-        tracing::warn!(
-            CVM_ALLOWED,
-            offset,
-            "host returned a non-zero firmware entry-point offset on aarch64; ignoring"
-        );
+    {
+        // `measured_vtl0_info` is only read on x86_64, to rebase VTL0's RIP.
+        let _ = measured_vtl0_info;
+        if offset != 0 {
+            // aarch64 has no entry-point offset; a non-zero value is a host
+            // protocol violation. Don't trust it, just surface it and ignore.
+            tracing::warn!(
+                CVM_ALLOWED,
+                offset,
+                "host returned a non-zero firmware entry-point offset on aarch64; ignoring"
+            );
+        }
     }
 
     true

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -3767,6 +3767,15 @@ async fn new_underhill_vm(
                 );
                 Some(hibernate::Token::CURRENT)
             }
+            Some(hibernate::Token::Other(raw)) => {
+                // An out-of-range/corrupt token value; ignore it.
+                tracing::warn!(
+                    CVM_ALLOWED,
+                    raw,
+                    "ignoring unrecognized hibernate token; using the current firmware version"
+                );
+                Some(hibernate::Token::CURRENT)
+            }
             // Clean prior power-off, or no/unreadable token (e.g. first boot):
             // a normal cold boot on the current firmware.
             Some(hibernate::Token::NotHibernated) | None => Some(hibernate::Token::CURRENT),

--- a/vm/devices/get/get_protocol/src/dps_json.rs
+++ b/vm/devices/get/get_protocol/src/dps_json.rs
@@ -177,7 +177,9 @@ pub enum HardwareSealingPolicy {
 #[serde(transparent)]
 pub struct ManagementVtlFeatures {
     pub strict_encryption_policy: bool,
-    pub _reserved1: bool,
+    /// The host supports the `LOAD_FIRMWARE` host request (VTL0 firmware
+    /// overload). Bit 1 (`0x00000002`).
+    pub load_firmware_supported: bool,
     pub control_ak_cert_provisioning: bool,
     pub attempt_ak_cert_callback: bool,
     pub tx_only_serial_port: bool,

--- a/vm/devices/get/get_protocol/src/lib.rs
+++ b/vm/devices/get/get_protocol/src/lib.rs
@@ -55,11 +55,6 @@ open_enum! {
         RS5 = make_version(1, 0),
         IRON = make_version(3, 0),
         NICKEL_REV2 = make_version(4, 2),
-        /// Adds the `LOAD_FIRMWARE` host request, allowing the guest/paravisor to
-        /// ask the host to (re)load a firmware image into VTL0 guest RAM at
-        /// runtime (e.g. to overload the cold-boot firmware on hibernation
-        /// resume).
-        NICKEL_REV3 = make_version(4, 3),
     }
 }
 
@@ -1906,8 +1901,9 @@ impl ResetRamGpaRangeResponse {
 }
 
 /// Requests that the host load a firmware image into VTL0 guest RAM (memory
-/// only; the guest/paravisor remains responsible for VP state). Introduced in
-/// [`ProtocolVersion::NICKEL_REV3`].
+/// only; the guest/paravisor remains responsible for VP state). Host support is
+/// advertised via the `load_firmware_supported` bit in
+/// [`dps_json::ManagementVtlFeatures`].
 #[repr(C, packed)]
 #[derive(Copy, Clone, Debug, IntoBytes, FromBytes, Immutable, KnownLayout)]
 pub struct LoadFirmwareRequest {

--- a/vm/devices/get/get_protocol/src/lib.rs
+++ b/vm/devices/get/get_protocol/src/lib.rs
@@ -158,7 +158,6 @@ open_enum! {
         DEVICE_PLATFORM_SETTINGS_V2_REV1 = 27, // wart: only sent back in *response* to DEVICE_PLATFORM_SETTINGS
         CREATE_RAM_GPA_RANGE             = 28,
         RESET_RAM_GPA_RANGE              = 29,
-        // --- NI_REV3 ---
         LOAD_FIRMWARE                    = 30,
 
         // --- Experimental (not yet in Hyper-V) ---

--- a/vm/devices/get/get_protocol/src/lib.rs
+++ b/vm/devices/get/get_protocol/src/lib.rs
@@ -55,6 +55,11 @@ open_enum! {
         RS5 = make_version(1, 0),
         IRON = make_version(3, 0),
         NICKEL_REV2 = make_version(4, 2),
+        /// Adds the `LOAD_FIRMWARE` host request, allowing the guest/paravisor to
+        /// ask the host to (re)load a firmware image into VTL0 guest RAM at
+        /// runtime (e.g. to overload the cold-boot firmware on hibernation
+        /// resume).
+        NICKEL_REV3 = make_version(4, 3),
     }
 }
 
@@ -158,6 +163,8 @@ open_enum! {
         DEVICE_PLATFORM_SETTINGS_V2_REV1 = 27, // wart: only sent back in *response* to DEVICE_PLATFORM_SETTINGS
         CREATE_RAM_GPA_RANGE             = 28,
         RESET_RAM_GPA_RANGE              = 29,
+        // --- NI_REV3 ---
+        LOAD_FIRMWARE                    = 30,
 
         // --- Experimental (not yet in Hyper-V) ---
         MAP_FRAMEBUFFER              = 0xFFFF,
@@ -1894,6 +1901,63 @@ impl ResetRamGpaRangeResponse {
     pub fn new() -> Self {
         Self {
             message_header: HeaderGeneric::new(HostRequests::RESET_RAM_GPA_RANGE),
+        }
+    }
+}
+
+/// Requests that the host load a firmware image into VTL0 guest RAM (memory
+/// only; the guest/paravisor remains responsible for VP state). Introduced in
+/// [`ProtocolVersion::NICKEL_REV3`].
+#[repr(C, packed)]
+#[derive(Copy, Clone, Debug, IntoBytes, FromBytes, Immutable, KnownLayout)]
+pub struct LoadFirmwareRequest {
+    pub message_header: HeaderHostRequest,
+    /// Opaque token identifying the firmware resource to load.
+    pub firmware_token: u64,
+}
+
+const_assert_eq!(12, size_of::<LoadFirmwareRequest>());
+
+impl LoadFirmwareRequest {
+    pub fn new(firmware_token: u64) -> Self {
+        Self {
+            message_header: HeaderGeneric::new(HostRequests::LOAD_FIRMWARE),
+            firmware_token,
+        }
+    }
+}
+
+open_enum! {
+    #[derive(IntoBytes, FromBytes, Immutable, KnownLayout)]
+    pub enum LoadFirmwareStatus: u32 {
+        SUCCESS = 0,
+        /// The supplied firmware token did not map to a known resource.
+        INVALID_TOKEN = 1,
+        /// The firmware image could not be loaded or written into guest RAM.
+        FAILED = 2,
+    }
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug, IntoBytes, FromBytes, Immutable, KnownLayout)]
+pub struct LoadFirmwareResponse {
+    pub message_header: HeaderHostResponse,
+    pub status: LoadFirmwareStatus,
+    /// Offset from the firmware image base to the firmware entry point (SEC
+    /// entry on x64), computed by the host. Valid only when `status` is
+    /// [`LoadFirmwareStatus::SUCCESS`]; the guest/paravisor programs VTL0's RIP
+    /// to `image_base + entry_point_image_offset`.
+    pub entry_point_image_offset: u64,
+}
+
+const_assert_eq!(16, size_of::<LoadFirmwareResponse>());
+
+impl LoadFirmwareResponse {
+    pub fn new(status: LoadFirmwareStatus, entry_point_image_offset: u64) -> Self {
+        Self {
+            message_header: HeaderGeneric::new(HostRequests::LOAD_FIRMWARE),
+            status,
+            entry_point_image_offset,
         }
     }
 }

--- a/vm/devices/get/guest_emulation_device/src/lib.rs
+++ b/vm/devices/get/guest_emulation_device/src/lib.rs
@@ -644,6 +644,7 @@ impl<T: RingMem + Unpin> GedChannel<T> {
             HostRequests::UNMAP_FRAMEBUFFER => self.handle_unmap_framebuffer(state).await?,
             HostRequests::CREATE_RAM_GPA_RANGE => self.handle_create_ram_gpa_range(message_buf)?,
             HostRequests::RESET_RAM_GPA_RANGE => self.handle_reset_ram_gpa_range(message_buf)?,
+            HostRequests::LOAD_FIRMWARE => self.handle_load_firmware(message_buf)?,
             _ => {
                 tracing::error!(message_id = ?header.message_id(), "unexpected message");
                 return Err(Error::InvalidSequence);
@@ -1057,6 +1058,26 @@ impl<T: RingMem + Unpin> GedChannel<T> {
             .map_err(|_| Error::MessageTooSmall)?
             .0; // TODO: zerocopy: map_err (https://github.com/microsoft/openvmm/issues/759)
         let response = get_protocol::ResetRamGpaRangeResponse::new();
+        self.channel
+            .try_send(response.as_bytes())
+            .map_err(Error::Vmbus)?;
+        Ok(())
+    }
+
+    fn handle_load_firmware(&mut self, message_buf: &[u8]) -> Result<(), Error> {
+        let request = get_protocol::LoadFirmwareRequest::read_from_prefix(message_buf)
+            .map_err(|_| Error::MessageTooSmall)?
+            .0; // TODO: zerocopy: map_err (https://github.com/microsoft/openvmm/issues/759)
+
+        let firmware_token = request.firmware_token;
+        tracing::info!(firmware_token, "load firmware request");
+
+        // This emulated host does not have a firmware image to write into guest
+        // RAM, so the request is simply acknowledged with a zero entry-point
+        // offset (leave VTL0's RIP unchanged). A real host loads the image
+        // identified by the token and returns the computed SEC entry offset.
+        let response =
+            get_protocol::LoadFirmwareResponse::new(get_protocol::LoadFirmwareStatus::SUCCESS, 0);
         self.channel
             .try_send(response.as_bytes())
             .map_err(Error::Vmbus)?;

--- a/vm/devices/get/guest_emulation_device/src/resolver.rs
+++ b/vm/devices/get/guest_emulation_device/src/resolver.rs
@@ -100,6 +100,7 @@ impl AsyncResolveResource<VmbusDeviceHandleKind, GuestEmulationDeviceHandle>
 
         let management_vtl_features = get_protocol::dps_json::ManagementVtlFeatures::new()
             .with_strict_encryption_policy(guest_state_encryption_policy.is_strict())
+            .with_load_firmware_supported(true)
             .with_tx_only_serial_port(resource.serial_tx_only);
 
         let guest_state_encryption_policy = match guest_state_encryption_policy {

--- a/vm/devices/get/guest_emulation_transport/src/client.rs
+++ b/vm/devices/get/guest_emulation_transport/src/client.rs
@@ -753,6 +753,32 @@ impl GuestEmulationTransportClient {
             .await;
     }
 
+    /// Asks the host to (re)load a firmware image into VTL0 guest RAM, keyed by
+    /// an opaque `firmware_token`. The host writes the image into guest memory
+    /// only; the guest/paravisor remains responsible for VP state.
+    ///
+    /// On success, returns the offset from the firmware image base to the
+    /// firmware entry point, which the caller programs into VTL0's RIP (RIP =
+    /// `image_base + offset`).
+    ///
+    /// Requires the host to have negotiated
+    /// [`get_protocol::ProtocolVersion::NICKEL_REV3`].
+    pub async fn load_firmware(
+        &self,
+        firmware_token: u64,
+    ) -> Result<u64, crate::error::LoadFirmwareError> {
+        let response = self
+            .control
+            .call(msg::Msg::LoadFirmware, firmware_token)
+            .await
+            .0;
+        if response.status != get_protocol::LoadFirmwareStatus::SUCCESS {
+            Err(crate::error::LoadFirmwareError(response.status))
+        } else {
+            Ok(response.entry_point_image_offset)
+        }
+    }
+
     /// Gets the saved state from the host. Returns immediately with whatever
     /// saved state existed at the time the call is processed, which may be None.
     pub async fn get_saved_state_from_host(

--- a/vm/devices/get/guest_emulation_transport/src/client.rs
+++ b/vm/devices/get/guest_emulation_transport/src/client.rs
@@ -761,17 +761,12 @@ impl GuestEmulationTransportClient {
     /// firmware entry point, which the caller programs into VTL0's RIP (RIP =
     /// `image_base + offset`).
     ///
-    /// Requires the host to have negotiated
-    /// [`get_protocol::ProtocolVersion::NICKEL_REV3`].
+    /// Only call this when the host has advertised support via the
+    /// `load_firmware_supported` bit in `ManagementVtlFeatures`.
     pub async fn load_firmware(
         &self,
         firmware_token: u64,
     ) -> Result<u64, crate::error::LoadFirmwareError> {
-        // The LoadFirmware host request was introduced in NICKEL_REV3; don't
-        // send it to hosts that negotiated an older protocol version.
-        if self.version < get_protocol::ProtocolVersion::NICKEL_REV3 {
-            return Err(crate::error::LoadFirmwareError::Unsupported(self.version));
-        }
         let response = self
             .control
             .call(msg::Msg::LoadFirmware, firmware_token)

--- a/vm/devices/get/guest_emulation_transport/src/client.rs
+++ b/vm/devices/get/guest_emulation_transport/src/client.rs
@@ -762,7 +762,7 @@ impl GuestEmulationTransportClient {
     /// `image_base + offset`).
     ///
     /// Only call this when the host has advertised support via the
-    /// `load_firmware_supported` bit in `ManagementVtlFeatures`.
+    /// `load_firmware_supported` bit in `ManagementVtlFeatures`, otherwise the GET may hang indefinitely.
     pub async fn load_firmware(
         &self,
         firmware_token: u64,

--- a/vm/devices/get/guest_emulation_transport/src/client.rs
+++ b/vm/devices/get/guest_emulation_transport/src/client.rs
@@ -773,7 +773,7 @@ impl GuestEmulationTransportClient {
             .await
             .0;
         if response.status != get_protocol::LoadFirmwareStatus::SUCCESS {
-            Err(crate::error::LoadFirmwareError::Status(response.status))
+            Err(crate::error::LoadFirmwareError(response.status))
         } else {
             Ok(response.entry_point_image_offset)
         }

--- a/vm/devices/get/guest_emulation_transport/src/client.rs
+++ b/vm/devices/get/guest_emulation_transport/src/client.rs
@@ -767,13 +767,18 @@ impl GuestEmulationTransportClient {
         &self,
         firmware_token: u64,
     ) -> Result<u64, crate::error::LoadFirmwareError> {
+        // The LoadFirmware host request was introduced in NICKEL_REV3; don't
+        // send it to hosts that negotiated an older protocol version.
+        if self.version < get_protocol::ProtocolVersion::NICKEL_REV3 {
+            return Err(crate::error::LoadFirmwareError::Unsupported(self.version));
+        }
         let response = self
             .control
             .call(msg::Msg::LoadFirmware, firmware_token)
             .await
             .0;
         if response.status != get_protocol::LoadFirmwareStatus::SUCCESS {
-            Err(crate::error::LoadFirmwareError(response.status))
+            Err(crate::error::LoadFirmwareError::Status(response.status))
         } else {
             Ok(response.entry_point_image_offset)
         }

--- a/vm/devices/get/guest_emulation_transport/src/error.rs
+++ b/vm/devices/get/guest_emulation_transport/src/error.rs
@@ -54,6 +54,11 @@ pub struct VpciControlError(pub(crate) get_protocol::VpciDeviceControlStatus);
 #[error("create ram GPA range error: {0:?}")]
 pub struct CreateRamGpaRangeError(pub(crate) get_protocol::CreateRamGpaRangeStatus);
 
+/// Error while invoking a LoadFirmwareRequest
+#[derive(Debug, Error)]
+#[error("load firmware error: {0:?}")]
+pub struct LoadFirmwareError(pub(crate) get_protocol::LoadFirmwareStatus);
+
 /// Error while invoking a GuestStateProtectionByIdRequest
 #[derive(Debug, Error)]
 #[error("malformed response - reported len > actual len: {0} > {1}")]

--- a/vm/devices/get/guest_emulation_transport/src/error.rs
+++ b/vm/devices/get/guest_emulation_transport/src/error.rs
@@ -56,8 +56,15 @@ pub struct CreateRamGpaRangeError(pub(crate) get_protocol::CreateRamGpaRangeStat
 
 /// Error while invoking a LoadFirmwareRequest
 #[derive(Debug, Error)]
-#[error("load firmware error: {0:?}")]
-pub struct LoadFirmwareError(pub(crate) get_protocol::LoadFirmwareStatus);
+pub enum LoadFirmwareError {
+    /// The negotiated protocol version does not support the `LoadFirmware` host
+    /// request, which requires [`get_protocol::ProtocolVersion::NICKEL_REV3`].
+    #[error("load firmware not supported by negotiated protocol version {0:?}")]
+    Unsupported(get_protocol::ProtocolVersion),
+    /// The host rejected the request with a non-success status.
+    #[error("load firmware error: {0:?}")]
+    Status(get_protocol::LoadFirmwareStatus),
+}
 
 /// Error while invoking a GuestStateProtectionByIdRequest
 #[derive(Debug, Error)]

--- a/vm/devices/get/guest_emulation_transport/src/error.rs
+++ b/vm/devices/get/guest_emulation_transport/src/error.rs
@@ -57,10 +57,6 @@ pub struct CreateRamGpaRangeError(pub(crate) get_protocol::CreateRamGpaRangeStat
 /// Error while invoking a LoadFirmwareRequest
 #[derive(Debug, Error)]
 pub enum LoadFirmwareError {
-    /// The negotiated protocol version does not support the `LoadFirmware` host
-    /// request, which requires [`get_protocol::ProtocolVersion::NICKEL_REV3`].
-    #[error("load firmware not supported by negotiated protocol version {0:?}")]
-    Unsupported(get_protocol::ProtocolVersion),
     /// The host rejected the request with a non-success status.
     #[error("load firmware error: {0:?}")]
     Status(get_protocol::LoadFirmwareStatus),

--- a/vm/devices/get/guest_emulation_transport/src/error.rs
+++ b/vm/devices/get/guest_emulation_transport/src/error.rs
@@ -54,13 +54,11 @@ pub struct VpciControlError(pub(crate) get_protocol::VpciDeviceControlStatus);
 #[error("create ram GPA range error: {0:?}")]
 pub struct CreateRamGpaRangeError(pub(crate) get_protocol::CreateRamGpaRangeStatus);
 
-/// Error while invoking a LoadFirmwareRequest
+/// Error while invoking a LoadFirmwareRequest: the host rejected it with a
+/// non-success status.
 #[derive(Debug, Error)]
-pub enum LoadFirmwareError {
-    /// The host rejected the request with a non-success status.
-    #[error("load firmware error: {0:?}")]
-    Status(get_protocol::LoadFirmwareStatus),
-}
+#[error("load firmware error: {0:?}")]
+pub struct LoadFirmwareError(pub(crate) get_protocol::LoadFirmwareStatus);
 
 /// Error while invoking a GuestStateProtectionByIdRequest
 #[derive(Debug, Error)]

--- a/vm/devices/get/guest_emulation_transport/src/lib.rs
+++ b/vm/devices/get/guest_emulation_transport/src/lib.rs
@@ -140,7 +140,7 @@ mod tests {
             vmbus_async::pipe::connected_message_pipes(get_protocol::MAX_MESSAGE_SIZE);
 
         let host_task = driver.spawn("host task", async move {
-            for protocol in [ProtocolVersion::NICKEL_REV2] {
+            for protocol in [ProtocolVersion::NICKEL_REV3, ProtocolVersion::NICKEL_REV2] {
                 let mut version_request = get_protocol::VersionRequest::new_zeroed();
                 let len = version_request.as_bytes().len();
                 assert_eq!(
@@ -776,5 +776,38 @@ mod tests {
             new_transport_pair(driver, None, ProtocolVersion::NICKEL_REV2, None, None).await;
 
         get.test_ged_client.test_save_guest_vtl2_state().await;
+    }
+
+    #[async_test]
+    async fn test_load_firmware_nickel_rev3(driver: DefaultDriver) {
+        // The plain GED accepts the guest's highest proposed version, so this
+        // negotiates NICKEL_REV3 and the LoadFirmware host request is allowed.
+        let get = new_transport_pair(driver, None, ProtocolVersion::NICKEL_REV3, None, None).await;
+        assert_eq!(get.client.version(), ProtocolVersion::NICKEL_REV3);
+
+        let entry_offset = get.client.load_firmware(0x0107).await.unwrap();
+        assert_eq!(entry_offset, 0);
+    }
+
+    #[async_test]
+    async fn test_load_firmware_unsupported_on_rev2(driver: DefaultDriver) {
+        // Force a NICKEL_REV2 negotiation via the exact-match TestGedChannel;
+        // the client must refuse to send LoadFirmware on the older version.
+        let get = new_transport_pair(
+            driver,
+            Some(Vec::new()),
+            ProtocolVersion::NICKEL_REV2,
+            None,
+            None,
+        )
+        .await;
+        assert_eq!(get.client.version(), ProtocolVersion::NICKEL_REV2);
+
+        assert!(matches!(
+            get.client.load_firmware(0x0107).await,
+            Err(crate::error::LoadFirmwareError::Unsupported(
+                ProtocolVersion::NICKEL_REV2
+            ))
+        ));
     }
 }

--- a/vm/devices/get/guest_emulation_transport/src/lib.rs
+++ b/vm/devices/get/guest_emulation_transport/src/lib.rs
@@ -140,7 +140,7 @@ mod tests {
             vmbus_async::pipe::connected_message_pipes(get_protocol::MAX_MESSAGE_SIZE);
 
         let host_task = driver.spawn("host task", async move {
-            for protocol in [ProtocolVersion::NICKEL_REV3, ProtocolVersion::NICKEL_REV2] {
+            for protocol in [ProtocolVersion::NICKEL_REV2] {
                 let mut version_request = get_protocol::VersionRequest::new_zeroed();
                 let len = version_request.as_bytes().len();
                 assert_eq!(
@@ -779,35 +779,13 @@ mod tests {
     }
 
     #[async_test]
-    async fn test_load_firmware_nickel_rev3(driver: DefaultDriver) {
-        // The plain GED accepts the guest's highest proposed version, so this
-        // negotiates NICKEL_REV3 and the LoadFirmware host request is allowed.
-        let get = new_transport_pair(driver, None, ProtocolVersion::NICKEL_REV3, None, None).await;
-        assert_eq!(get.client.version(), ProtocolVersion::NICKEL_REV3);
+    async fn test_load_firmware(driver: DefaultDriver) {
+        // LoadFirmware is a REV2 host request whose availability the host
+        // advertises via the `load_firmware_supported` DPS feature bit; the
+        // transport itself just issues the request and returns the entry offset.
+        let get = new_transport_pair(driver, None, ProtocolVersion::NICKEL_REV2, None, None).await;
 
         let entry_offset = get.client.load_firmware(0x0107).await.unwrap();
         assert_eq!(entry_offset, 0);
-    }
-
-    #[async_test]
-    async fn test_load_firmware_unsupported_on_rev2(driver: DefaultDriver) {
-        // Force a NICKEL_REV2 negotiation via the exact-match TestGedChannel;
-        // the client must refuse to send LoadFirmware on the older version.
-        let get = new_transport_pair(
-            driver,
-            Some(Vec::new()),
-            ProtocolVersion::NICKEL_REV2,
-            None,
-            None,
-        )
-        .await;
-        assert_eq!(get.client.version(), ProtocolVersion::NICKEL_REV2);
-
-        assert!(matches!(
-            get.client.load_firmware(0x0107).await,
-            Err(crate::error::LoadFirmwareError::Unsupported(
-                ProtocolVersion::NICKEL_REV2
-            ))
-        ));
     }
 }

--- a/vm/devices/get/guest_emulation_transport/src/process_loop.rs
+++ b/vm/devices/get/guest_emulation_transport/src/process_loop.rs
@@ -298,6 +298,11 @@ pub(crate) mod msg {
         /// CVM NOTE: The returned value should not be relied on for security purposes.
         /// It is expected that the guest will use NTP (or some other time source) after boot.
         HostTime(Rpc<(), Protocol<get_protocol::TimeResponse>>),
+        /// Ask the host to (re)load a firmware image into VTL0 guest RAM,
+        /// keyed by an opaque firmware token.
+        ///
+        /// Introduced in [`get_protocol::ProtocolVersion::NICKEL_REV3`].
+        LoadFirmware(Rpc<u64, Protocol<get_protocol::LoadFirmwareResponse>>),
         /// Send an attestation request.
         IgvmAttest(Rpc<Box<IgvmAttestRequestData>, Result<Vec<u8>, crate::error::IgvmAttestError>>),
         /// Tell the host the location of the framebuffer.
@@ -1246,6 +1251,11 @@ impl<T: RingMem> ProcessLoop<T> {
             Msg::ResetRamGpaRange(req) => {
                 self.push_basic_host_request_handler(req, |input| {
                     get_protocol::ResetRamGpaRangeRequest::new(input)
+                });
+            }
+            Msg::LoadFirmware(req) => {
+                self.push_basic_host_request_handler(req, |token| {
+                    get_protocol::LoadFirmwareRequest::new(token)
                 });
             }
             Msg::SendServicingState(req) => self.push_primary_host_request_handler(move |access| {

--- a/vm/devices/get/guest_emulation_transport/src/process_loop.rs
+++ b/vm/devices/get/guest_emulation_transport/src/process_loop.rs
@@ -300,8 +300,6 @@ pub(crate) mod msg {
         HostTime(Rpc<(), Protocol<get_protocol::TimeResponse>>),
         /// Ask the host to (re)load a firmware image into VTL0 guest RAM,
         /// keyed by an opaque firmware token.
-        ///
-        /// Introduced in [`get_protocol::ProtocolVersion::NICKEL_REV3`].
         LoadFirmware(Rpc<u64, Protocol<get_protocol::LoadFirmwareResponse>>),
         /// Send an attestation request.
         IgvmAttest(Rpc<Box<IgvmAttestRequestData>, Result<Vec<u8>, crate::error::IgvmAttestError>>),
@@ -778,12 +776,7 @@ impl<T: RingMem> ProcessLoop<T> {
         // self.run() isn't running yet to take requests, so we must send requests
         // manually.
 
-        // Negotiate the protocol, preferring the newest version and falling
-        // back to older ones the host may support.
-        for protocol in [
-            get_protocol::ProtocolVersion::NICKEL_REV3,
-            get_protocol::ProtocolVersion::NICKEL_REV2,
-        ] {
+        for protocol in [get_protocol::ProtocolVersion::NICKEL_REV2] {
             let version_request = get_protocol::VersionRequest::new(protocol);
 
             self.pipe

--- a/vm/devices/get/guest_emulation_transport/src/process_loop.rs
+++ b/vm/devices/get/guest_emulation_transport/src/process_loop.rs
@@ -778,8 +778,12 @@ impl<T: RingMem> ProcessLoop<T> {
         // self.run() isn't running yet to take requests, so we must send requests
         // manually.
 
-        // Negotiate the protocol.
-        for protocol in [get_protocol::ProtocolVersion::NICKEL_REV2] {
+        // Negotiate the protocol, preferring the newest version and falling
+        // back to older ones the host may support.
+        for protocol in [
+            get_protocol::ProtocolVersion::NICKEL_REV3,
+            get_protocol::ProtocolVersion::NICKEL_REV2,
+        ] {
             let version_request = get_protocol::VersionRequest::new(protocol);
 
             self.pipe

--- a/vm/devices/get/guest_emulation_transport/src/process_loop.rs
+++ b/vm/devices/get/guest_emulation_transport/src/process_loop.rs
@@ -776,6 +776,7 @@ impl<T: RingMem> ProcessLoop<T> {
         // self.run() isn't running yet to take requests, so we must send requests
         // manually.
 
+        // Negotiate the protocol.
         for protocol in [get_protocol::ProtocolVersion::NICKEL_REV2] {
             let version_request = get_protocol::VersionRequest::new(protocol);
 


### PR DESCRIPTION
Adds a GET `LoadFirmware` host request (protocol version NICKEL_REV3) that lets OpenHCL ask the host to overwrite VTL0's firmware image in guest RAM at runtime, keyed by an opaque firmware token, along with the guest transport client method and an emulated-host handler.

On a hibernation resume under a different firmware version, underhill_core issues the request before the UEFI config is written so VTL0 runs the hibernated firmware version, rebases VTL0's RIP (x86_64) to the overloaded image's entry point, and records that version as the hibernate token.

Ported from the legacy HCL implementation (ADO PR 16206952).