### PR TITLE
tdx: enable hardware sealing

### DIFF
--- a/.github/workflows/openvmm-ci.yaml
+++ b/.github/workflows/openvmm-ci.yaml
@@ -4273,6 +4273,7 @@ jobs:
     - Windows
     - X64
     - TDX
+    - GNR
     - Baremetal
     permissions:
       contents: read

--- a/.github/workflows/openvmm-pr-release.yaml
+++ b/.github/workflows/openvmm-pr-release.yaml
@@ -4046,6 +4046,7 @@ jobs:
     - Windows
     - X64
     - TDX
+    - GNR
     - Baremetal
     permissions:
       contents: read

--- a/.github/workflows/openvmm-pr.yaml
+++ b/.github/workflows/openvmm-pr.yaml
@@ -4459,6 +4459,7 @@ jobs:
     - Windows
     - X64
     - TDX
+    - GNR
     - Baremetal
     permissions:
       contents: read

--- a/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
+++ b/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
@@ -1581,7 +1581,7 @@ impl IntoPipeline for CheckinGatesCli {
             VmmTestJobParams {
                 platform: FlowPlatform::Windows,
                 arch: FlowArch::X86_64,
-                gh_pool: gh_pools::windows_tdx_self_hosted_baremetal(),
+                gh_pool: gh_pools::windows_tdx_gnr_self_hosted_baremetal(),
                 ado_pool: None,
                 label: "x64-windows-intel-tdx",
                 target: CommonTriple::X86_64_WINDOWS_MSVC,

--- a/flowey/flowey_hvlite/src/pipelines_shared/gh_pools.rs
+++ b/flowey/flowey_hvlite/src/pipelines_shared/gh_pools.rs
@@ -83,12 +83,13 @@ pub fn windows_arm_self_hosted_baremetal() -> GhRunner {
     ])
 }
 
-pub fn windows_tdx_self_hosted_baremetal() -> GhRunner {
+pub fn windows_tdx_gnr_self_hosted_baremetal() -> GhRunner {
     GhRunner::SelfHosted(vec![
         "self-hosted".to_string(),
         "Windows".to_string(),
         "X64".to_string(),
         "TDX".to_string(),
+        "GNR".to_string(),
         "Baremetal".to_string(),
     ])
 }

--- a/openhcl/hcl/src/ioctl.rs
+++ b/openhcl/hcl/src/ioctl.rs
@@ -2509,6 +2509,30 @@ impl Hcl {
         value
     }
 
+    /// Attempts to opt this TD into hardware-bound seal keys by setting
+    /// `TD_CTLS.ENABLE_HW_SEAL_KEYS` via `TDG.VM.WR`.
+    ///
+    /// Returns `Ok(true)` if the bit is set after the operation (the
+    /// `TDG.MR.KEY.GET` TDCALL is available), `Ok(false)` if the TDX module
+    /// does not support sealing, or an error if the write itself was rejected.
+    ///
+    /// Only valid on TDX-isolated partitions.
+    pub fn tdx_enable_hw_seal_keys(&self) -> Result<bool, x86defs::tdx::TdCallResult> {
+        self.mshv_vtl.tdx_enable_hw_seal_keys()
+    }
+
+    /// Reads the global-scope `TDX_FEATURES0` metadata field via `TDG.SYS.RD`,
+    /// enumerating optional TDX module features (including hardware-bound
+    /// sealing support).
+    ///
+    /// Returns an error if the module does not support `TDG.SYS.RD` or rejects
+    /// the field. Only valid on TDX-isolated partitions.
+    pub fn tdx_read_features0(
+        &self,
+    ) -> Result<x86defs::tdx::TdxFeatures0, x86defs::tdx::TdCallResult> {
+        self.mshv_vtl.tdx_read_features0()
+    }
+
     /// Invokes the HvCallRetargetDeviceInterrupt hypercall.
     /// `target_processors` must be sorted in ascending order.
     pub fn retarget_device_interrupt(

--- a/openhcl/hcl/src/ioctl/tdx.rs
+++ b/openhcl/hcl/src/ioctl/tdx.rs
@@ -25,7 +25,9 @@ use std::cell::UnsafeCell;
 use std::os::fd::AsRawFd;
 use tdcall::Tdcall;
 use tdcall::TdgPageReleaseError;
+use tdcall::tdcall_sys_rd;
 use tdcall::tdcall_vm_rd;
+use tdcall::tdcall_vm_wr;
 use tdcall::tdcall_vp_invgla;
 use tdcall::tdcall_vp_rd;
 use tdcall::tdcall_vp_wr;
@@ -93,6 +95,54 @@ impl MshvVtl {
             .expect("TDG.VM.RD should not fail for CONFIG_FLAGS");
 
         TdConfigFlags::from_bits(res)
+    }
+
+    /// Reads the global-scope `TDX_FEATURES0` metadata field via the
+    /// `TDG.SYS.RD` TDCALL, which enumerates optional TDX module features
+    /// (including hardware-bound sealing support).
+    ///
+    /// Returns an error if the module does not support `TDG.SYS.RD` (older
+    /// modules) or rejects the field.
+    pub fn tdx_read_features0(&self) -> Result<x86defs::tdx::TdxFeatures0, TdCallResult> {
+        let value = tdcall_sys_rd(
+            &mut MshvVtlTdcall(self),
+            x86defs::tdx::TDX_FIELD_ID_TDX_FEATURES0,
+        )?;
+        Ok(x86defs::tdx::TdxFeatures0::from(value))
+    }
+
+    /// Attempts to opt this TD into hardware-bound seal keys by setting
+    /// `TD_CTLS.ENABLE_HW_SEAL_KEYS`, enabling the `TDG.MR.KEY.GET` TDCALL that
+    /// backs VMGS hardware key sealing.
+    ///
+    /// Returns `Ok(true)` if the bit is set after the operation (sealing keys
+    /// are available), or `Ok(false)` if the TDX module does not support
+    /// sealing.
+    ///
+    /// A TDX module that does not implement sealing treats
+    /// `ENABLE_HW_SEAL_KEYS` as a reserved bit and may *silently ignore* the
+    /// masked write while still returning success. The write status alone is
+    /// therefore not sufficient, so this reads `TD_CTLS` back and reports
+    /// whether the bit actually stuck.
+    pub fn tdx_enable_hw_seal_keys(&self) -> Result<bool, TdCallResult> {
+        let enable = x86defs::tdx::TdCtls::new().with_enable_hw_seal_keys(true);
+
+        // Masked write: only touch the ENABLE_HW_SEAL_KEYS bit.
+        tdcall_vm_wr(
+            &mut MshvVtlTdcall(self),
+            x86defs::tdx::TDX_FIELD_CODE_TD_CTLS,
+            enable.into(),
+            enable.into(),
+        )?;
+
+        // Read back to confirm the bit actually took effect, since an
+        // unsupporting module may have ignored the write.
+        let controls = x86defs::tdx::TdCtls::from(tdcall_vm_rd(
+            &mut MshvVtlTdcall(self),
+            x86defs::tdx::TDX_FIELD_CODE_TD_CTLS,
+        )?);
+
+        Ok(controls.enable_hw_seal_keys())
     }
 }
 

--- a/openhcl/openhcl_attestation_protocol/src/vmgs.rs
+++ b/openhcl/openhcl_attestation_protocol/src/vmgs.rs
@@ -81,10 +81,31 @@ pub struct SecurityProfile {
 /// Version 2 or newer is forward-compatible if header.mix_measurement is not set.
 pub const HW_KEY_PROTECTOR_VERSION_1: u32 = 1;
 pub const HW_KEY_PROTECTOR_VERSION_2: u32 = 2;
-pub const HW_KEY_PROTECTOR_CURRENT_VERSION: u32 = HW_KEY_PROTECTOR_VERSION_2;
+/// Version 3 is a unified, TEE-tagged format used for all newly-created
+/// protectors (SNP and TDX). It records the raw report SVNs so the derived key
+/// can bind every SVN the TEE mixes in (for TDX, both `TEE_TCB_SVN` and
+/// `CPU_SVN`) rather than a lossy `u64`. v2 is retained read-only for legacy SNP
+/// protectors.
+pub const HW_KEY_PROTECTOR_VERSION_3: u32 = 3;
+pub const HW_KEY_PROTECTOR_CURRENT_VERSION: u32 = HW_KEY_PROTECTOR_VERSION_3;
+
+/// TEE tag stored in [`HardwareKeyProtectorHeaderV3::tee_type`].
+pub const HW_KEY_PROTECTOR_TEE_TYPE_SNP: u32 = 0;
+/// TEE tag stored in [`HardwareKeyProtectorHeaderV3::tee_type`].
+pub const HW_KEY_PROTECTOR_TEE_TYPE_TDX: u32 = 1;
 
 /// The size of the `FileId::HW_KEY_PROTECTOR` entry in the VMGS file.
 pub const HW_KEY_PROTECTOR_SIZE: usize = size_of::<HardwareKeyProtector>();
+
+/// The size of a version-3 `FileId::HW_KEY_PROTECTOR` entry.
+pub const HW_KEY_PROTECTOR_V3_SIZE: usize = size_of::<HardwareKeyProtectorV3>();
+
+// Readers dispatch on the entry size to tell the legacy layout apart from v3,
+// so the two must never collide.
+const _: () = assert!(HW_KEY_PROTECTOR_SIZE != HW_KEY_PROTECTOR_V3_SIZE);
+
+/// Size of the TEE-specific SVN blob in [`HardwareKeyProtectorHeaderV3`].
+pub const HW_KEY_PROTECTOR_SVN_SIZE: usize = 32;
 
 /// AES-GCM key size
 pub const AES_GCM_KEY_LENGTH: usize = 32;
@@ -134,6 +155,65 @@ impl HardwareKeyProtectorHeader {
 pub struct HardwareKeyProtector {
     /// Header
     pub header: HardwareKeyProtectorHeader,
+    /// Random IV for AES-CBC
+    pub iv: [u8; AES_CBC_IV_LENGTH],
+    /// Encrypted key
+    pub ciphertext: [u8; AES_GCM_KEY_LENGTH],
+    /// HMAC-SHA-256 of [header, iv, ciphertext]
+    pub hmac: [u8; HMAC_SHA_256_KEY_LENGTH],
+}
+
+/// Version-3 header. Shares the `version`/`length` prefix with
+/// [`HardwareKeyProtectorHeader`] so the version can be read first, then carries
+/// a TEE-tagged SVN blob bound into the derived key.
+///
+/// `svn` layout by `tee_type`:
+/// - [`HW_KEY_PROTECTOR_TEE_TYPE_SNP`]: `reported_tcb` (u64, little-endian) in
+///   bytes `0..8`; bytes `8..32` zero.
+/// - [`HW_KEY_PROTECTOR_TEE_TYPE_TDX`]: `TEE_TCB_SVN` in bytes `0..16` and
+///   `CPU_SVN` in bytes `16..32`.
+#[repr(C)]
+#[derive(Debug, IntoBytes, Immutable, KnownLayout, FromBytes)]
+pub struct HardwareKeyProtectorHeaderV3 {
+    /// Version of the format (== [`HW_KEY_PROTECTOR_VERSION_3`]).
+    pub version: u32,
+    /// Size of the [`HardwareKeyProtectorV3`] data blob.
+    pub length: u32,
+    /// TEE that produced the SVNs (see `HW_KEY_PROTECTOR_TEE_TYPE_*`).
+    pub tee_type: u32,
+    /// TEE-specific SVN material recorded at seal time.
+    pub svn: [u8; HW_KEY_PROTECTOR_SVN_SIZE],
+    /// Whether to mix the measurement in hardware key derivation.
+    pub mix_measurement: u8,
+    /// Reserved bytes for future use.
+    pub _reserved: [u8; 3],
+}
+
+impl HardwareKeyProtectorHeaderV3 {
+    /// Create a `HardwareKeyProtectorHeaderV3` instance.
+    pub fn new(
+        length: u32,
+        tee_type: u32,
+        svn: [u8; HW_KEY_PROTECTOR_SVN_SIZE],
+        mix_measurement: u8,
+    ) -> Self {
+        Self {
+            version: HW_KEY_PROTECTOR_VERSION_3,
+            length,
+            tee_type,
+            svn,
+            mix_measurement,
+            _reserved: [0; 3],
+        }
+    }
+}
+
+/// Version-3 data format of the `FileId::HW_KEY_PROTECTOR` entry.
+#[repr(C)]
+#[derive(Debug, IntoBytes, Immutable, KnownLayout, FromBytes)]
+pub struct HardwareKeyProtectorV3 {
+    /// Header
+    pub header: HardwareKeyProtectorHeaderV3,
     /// Random IV for AES-CBC
     pub iv: [u8; AES_CBC_IV_LENGTH],
     /// Encrypted key

--- a/openhcl/tee_call/src/lib.rs
+++ b/openhcl/tee_call/src/lib.rs
@@ -27,6 +27,15 @@ pub enum Error {
     OpenDevTdxGuest(#[source] tdx_guest_device::Error),
     #[error("failed to get a TDX report via /dev/tdx_guest")]
     GetTdxReport(#[source] tdx_guest_device::Error),
+    #[error("failed to get a TDX derived key via /dev/tdx_guest")]
+    GetTdxDerivedKey(#[source] tdx_guest_device::Error),
+    #[error(
+        "TDX signer-based hardware sealing is not supported: TDX has no signer identity register \
+         to bind a measurement-independent key to, so refusing to derive an under-bound key"
+    )]
+    TdxSignerPolicyUnsupported,
+    #[error("key derivation SVN does not match the TEE type")]
+    KeyDerivationSvnMismatch,
     #[error("failed to open VBS guest device")]
     OpenDevVbsGuest(#[source] hcl::ioctl::Error),
     #[error("failed to get a VBS report via VBS guest device")]
@@ -46,6 +55,13 @@ static_assertions::const_assert_eq!(
     x86defs::tdx::TDX_REPORT_DATA_SIZE
 );
 
+// TDX and SNP derived key size are equal so we can return either of them as
+// [`HW_DERIVED_KEY_LENGTH`].
+static_assertions::const_assert_eq!(
+    x86defs::snp::SNP_DERIVED_KEY_SIZE,
+    x86defs::tdx::TDX_DERIVED_KEY_SIZE
+);
+
 /// Type of the TEE
 #[derive(Debug)]
 pub enum TeeType {
@@ -59,19 +75,39 @@ pub enum TeeType {
     Vbs,
 }
 
+/// TEE-specific SVN material bound into the hardware-derived key for
+/// anti-rollback. Each variant carries exactly the fields its TEE mixes into
+/// key derivation and maps 1:1 to a `HardwareKeyProtector` header version.
+#[derive(Debug, Clone, Copy)]
+pub enum KeyDerivationSvn {
+    /// SNP reported TCB version (`HW_KEY_PROTECTOR` v2).
+    Snp {
+        /// `reported_tcb` from the SNP attestation report.
+        tcb_version: u64,
+    },
+    /// TDX report SVNs, both bound into the key (`HW_KEY_PROTECTOR` v3).
+    Tdx {
+        /// Module `TEE_TCB_SVN` (16 bytes, verbatim from the report).
+        tee_tcb_svn: [u8; 16],
+        /// Platform `CPU_SVN` (16 bytes, verbatim from the report).
+        cpu_svn: [u8; 16],
+    },
+}
+
 /// The result of the `get_attestation_report`.
 pub struct GetAttestationReportResult {
     /// The report in raw bytes
     pub report: Vec<u8>,
-    /// The optional tcb version
-    pub tcb_version: Option<u64>,
+    /// SVN material for hardware key derivation; `None` for TEEs that don't
+    /// derive keys.
+    pub key_derivation_svn: Option<KeyDerivationSvn>,
 }
 
 /// Key derivation policy
 #[derive(Debug, Clone, Copy)]
 pub struct KeyDerivationPolicy {
-    /// The TCB version to use for key derivation.
-    pub tcb_version: u64,
+    /// TEE-specific SVN material bound into the derived key.
+    pub svn: KeyDerivationSvn,
     /// Whether to mix measurement into the key derivation.
     pub mix_measurement: bool,
 }
@@ -125,7 +161,9 @@ impl TeeCall for SnpCall {
 
         Ok(GetAttestationReportResult {
             report: report.as_bytes().to_vec(),
-            tcb_version: Some(report.reported_tcb),
+            key_derivation_svn: Some(KeyDerivationSvn::Snp {
+                tcb_version: report.reported_tcb,
+            }),
         })
     }
 
@@ -146,6 +184,10 @@ impl TeeCallGetDerivedKey for SnpCall {
         &self,
         policy: KeyDerivationPolicy,
     ) -> Result<[u8; HW_DERIVED_KEY_LENGTH], Error> {
+        let KeyDerivationSvn::Snp { tcb_version } = policy.svn else {
+            return Err(Error::KeyDerivationSvnMismatch);
+        };
+
         let dev = sev_guest_device::SevGuestDevice::open().map_err(Error::OpenDevSevGuest)?;
 
         // Derive a key mixing in following data:
@@ -163,7 +205,7 @@ impl TeeCallGetDerivedKey for SnpCall {
                 guest_field_select.into(),
                 0, // VMPL 0
                 0, // default guest svn to 0
-                policy.tcb_version,
+                tcb_version,
             )
             .map_err(Error::GetSnpDerivedKey)?;
 
@@ -176,7 +218,26 @@ impl TeeCallGetDerivedKey for SnpCall {
 }
 
 /// Implementation of [`TeeCall`] for TDX
-pub struct TdxCall;
+pub struct TdxCall {
+    /// Whether `TD_CTLS.ENABLE_HW_SEAL_KEYS` was successfully set for this TD
+    /// this boot. Unlike SNP (where key derivation is always available), TDX
+    /// hardware-bound seal keys are opt-in at runtime and depend on TDX module
+    /// support, so this is captured at enable time and used to gate
+    /// [`TeeCall::supports_get_derived_key`].
+    hw_seal_keys_enabled: bool,
+}
+
+impl TdxCall {
+    /// Creates a new [`TdxCall`].
+    ///
+    /// * `hw_seal_keys_enabled` - whether `TD_CTLS.ENABLE_HW_SEAL_KEYS` was
+    ///   successfully enabled for this TD, making `TDG.MR.KEY.GET` available.
+    pub fn new(hw_seal_keys_enabled: bool) -> Self {
+        Self {
+            hw_seal_keys_enabled,
+        }
+    }
+}
 
 impl TeeCall for TdxCall {
     fn get_attestation_report(
@@ -188,21 +249,123 @@ impl TeeCall for TdxCall {
             .get_report(*report_data, 0)
             .map_err(Error::GetTdxReport)?;
 
+        let mut tee_tcb_svn = [0u8; 16];
+        tee_tcb_svn.copy_from_slice(report.tee_tcb_info.tee_tcb_svn.as_bytes());
+
         Ok(GetAttestationReportResult {
             report: report.as_bytes().to_vec(),
-            // Only needed by key derivation, return None for now
-            tcb_version: None,
+            key_derivation_svn: Some(KeyDerivationSvn::Tdx {
+                tee_tcb_svn,
+                cpu_svn: report.report_mac_struct.cpu_svn,
+            }),
         })
     }
 
-    /// Key derivation is currently not supported by TDX
+    /// Key derivation is supported by TDX via `TDG.MR.KEY.GET`, but only when
+    /// hardware-bound seal keys were successfully enabled for this TD.
     fn supports_get_derived_key(&self) -> Option<&dyn TeeCallGetDerivedKey> {
-        None
+        self.hw_seal_keys_enabled
+            .then_some(self as &dyn TeeCallGetDerivedKey)
     }
 
     /// Return TeeType::Tdx.
     fn tee_type(&self) -> TeeType {
         TeeType::Tdx
+    }
+}
+
+impl TeeCallGetDerivedKey for TdxCall {
+    /// Get the derived key from /dev/tdx_guest via the `TDG.MR.KEY.GET` TDCALL.
+    fn get_derived_key(
+        &self,
+        policy: KeyDerivationPolicy,
+    ) -> Result<[u8; HW_DERIVED_KEY_LENGTH], Error> {
+        let KeyDerivationSvn::Tdx {
+            tee_tcb_svn,
+            cpu_svn,
+        } = policy.svn
+        else {
+            return Err(Error::KeyDerivationSvnMismatch);
+        };
+
+        // Fail safe for the signer sealing policy on TDX.
+        //
+        // `mix_measurement == false` corresponds to the signer policy, which
+        // asks for a key that is *independent* of the OpenHCL measurement (so it
+        // survives servicing). On SNP this still binds the key to the guest
+        // policy and TCB, but TDX's `TDKEYPOLICY` has no signer/identity
+        // register to substitute for `MRTD`: clearing `MRTD` would leave the key
+        // bound to nothing TD-specific (only the platform seal secret, the
+        // module `TEE_TCB_SVN`, the `CPU_SVN`, and a fixed salt), so any
+        // co-located TD on the same platform+TCB could derive the identical key
+        // and unseal the VMGS DEK. Refuse rather than seal with an under-bound
+        // key; the caller skips
+        // hardware sealing (or fails closed if it is the required source). The
+        // rejection is logged by the higher-level guard in `underhill_attestation`.
+        if !policy.mix_measurement {
+            return Err(Error::TdxSignerPolicyUnsupported);
+        }
+
+        let dev = tdx_guest_device::TdxGuestDevice::open().map_err(Error::OpenDevTdxGuest)?;
+
+        // Build a `TDKEYREQUEST` that binds the derived key to the TD's identity
+        // so that the key is deterministic across boots but unique per-TD. This
+        // mirrors the SNP key derivation, which mixes in the guest measurement
+        // and TCB version.
+        //
+        // - `MRTD` (the build-time measurement) is selected via the key policy;
+        //   the TDX module reads it from the TD's own measurement state.
+        // - `TEE_TCB_SVN` and `CPU_SVN` are the values recorded at seal time
+        //   (verbatim 16-byte report fields). The module requires a valid TCB
+        //   SVN and rejects an all-zero `TEE_TCB_SVN`; supplying the recorded
+        //   values satisfies that check and provides anti-rollback binding on
+        //   both the module and CPU/microcode TCB. Using the recorded values
+        //   (rather than the current report) keeps the derived key stable so a
+        //   previously sealed DEK can still be unsealed.
+        //
+        // The `salt` carries a fixed label so the derived key is domain
+        // separated from any other use of `TDG.MR.KEY.GET`.
+        let mut salt = [0u8; 32];
+        let label = b"TDXHWSEAL";
+        salt[..label.len()].copy_from_slice(label);
+
+        let key_request = x86defs::tdx::TdKeyRequest {
+            key_name: x86defs::tdx::TDX_KEY_NAME_SEAL,
+            sw_key_name: 0,
+            // Request a 256-bit key. `TDX_FEATURES0.SEALKEY_128` enumerates
+            // whether a 128-bit key is *available*; when it is clear, only the
+            // 256-bit key size is valid, so request 256-bit (which also matches
+            // `HW_DERIVED_KEY_LENGTH`).
+            key_size: x86defs::tdx::TDX_KEY_SIZE_256,
+            _reserved0: [0u8; 4],
+            // Always select `MRTD` so the derived key is bound to the TD's
+            // build-time measurement (the analog of SNP mixing in the launch
+            // measurement). Only the hash policy (`mix_measurement == true`)
+            // reaches here; the signer policy is rejected above because TDX has
+            // no identity register to bind to when `MRTD` is cleared.
+            key_policy: x86defs::tdx::TdxKeyPolicy::new().with_mr_td(true),
+            attributes_mask: 0,
+            xfam_mask: 0,
+            // `CPU_SVN` and `TEE_TCB_SVN` recorded at seal time bind the key to
+            // both the CPU/microcode and module TCB for anti-rollback.
+            cpu_svn,
+            tee_tcb_svn,
+            isv_svn: 0,
+            mr_config_svn: 0,
+            mr_owner_config_svn: 0,
+            salt,
+            _reserved1: [0u8; 26],
+        };
+
+        let derived_key = dev
+            .get_derived_key(&key_request)
+            .map_err(Error::GetTdxDerivedKey)?;
+
+        if derived_key.iter().all(|&x| x == 0) {
+            Err(Error::AllZeroKey)?
+        }
+
+        Ok(derived_key)
     }
 }
 
@@ -223,7 +386,7 @@ impl TeeCall for VbsCall {
         Ok(GetAttestationReportResult {
             report: report[..hvdef::vbs::VBS_REPORT_SIZE].to_vec(),
             // Only needed by key derivation, return None for now
-            tcb_version: None,
+            key_derivation_svn: None,
         })
     }
 

--- a/openhcl/underhill_attestation/src/hardware_key_sealing.rs
+++ b/openhcl/underhill_attestation/src/hardware_key_sealing.rs
@@ -9,6 +9,7 @@ use cvm_tracing::CVM_ALLOWED;
 use openhcl_attestation_protocol::igvm_attest;
 use openhcl_attestation_protocol::vmgs;
 use openhcl_attestation_protocol::vmgs::HardwareKeyProtector;
+use openhcl_attestation_protocol::vmgs::HardwareKeyProtectorV3;
 use thiserror::Error;
 use zerocopy::IntoBytes;
 
@@ -102,6 +103,13 @@ impl HardwareDerivedKeys {
         aes_key.copy_from_slice(&output[..vmgs::AES_CBC_KEY_LENGTH]);
         hmac_key.copy_from_slice(&output[vmgs::AES_CBC_KEY_LENGTH..]);
 
+        tracing::info!(
+            CVM_ALLOWED,
+            svn = ?policy.svn,
+            mix_measurement = policy.mix_measurement,
+            "derived hardware AES and HMAC keys for VMGS key sealing"
+        );
+
         Ok(Self {
             policy,
             aes_key,
@@ -110,14 +118,204 @@ impl HardwareDerivedKeys {
     }
 }
 
-/// Extension trait of [`HardwareKeyProtector`].
-pub trait HardwareKeyProtectorExt: Sized {
-    /// Seal the `egress_key` with encrypt-then-mac.
-    fn seal_key(
-        hardware_derived_keys: &HardwareDerivedKeys,
-        egress_key: &[u8],
-    ) -> Result<Self, HardwareKeySealingError>;
+/// Serialize a [`KeyDerivationSvn`] into the on-disk `(tee_type, svn)` v3 header
+/// representation.
+fn key_derivation_svn_to_header(
+    svn: tee_call::KeyDerivationSvn,
+) -> (u32, [u8; vmgs::HW_KEY_PROTECTOR_SVN_SIZE]) {
+    let mut bytes = [0u8; vmgs::HW_KEY_PROTECTOR_SVN_SIZE];
+    match svn {
+        tee_call::KeyDerivationSvn::Snp { tcb_version } => {
+            bytes[..8].copy_from_slice(&tcb_version.to_le_bytes());
+            (vmgs::HW_KEY_PROTECTOR_TEE_TYPE_SNP, bytes)
+        }
+        tee_call::KeyDerivationSvn::Tdx {
+            tee_tcb_svn,
+            cpu_svn,
+        } => {
+            bytes[..16].copy_from_slice(&tee_tcb_svn);
+            bytes[16..].copy_from_slice(&cpu_svn);
+            (vmgs::HW_KEY_PROTECTOR_TEE_TYPE_TDX, bytes)
+        }
+    }
+}
 
+/// Inverse of [`key_derivation_svn_to_header`].
+fn key_derivation_svn_from_header(
+    tee_type: u32,
+    svn: [u8; vmgs::HW_KEY_PROTECTOR_SVN_SIZE],
+) -> Option<tee_call::KeyDerivationSvn> {
+    match tee_type {
+        vmgs::HW_KEY_PROTECTOR_TEE_TYPE_SNP => {
+            let mut tcb = [0u8; 8];
+            tcb.copy_from_slice(&svn[..8]);
+            Some(tee_call::KeyDerivationSvn::Snp {
+                tcb_version: u64::from_le_bytes(tcb),
+            })
+        }
+        vmgs::HW_KEY_PROTECTOR_TEE_TYPE_TDX => {
+            let mut tee_tcb_svn = [0u8; 16];
+            let mut cpu_svn = [0u8; 16];
+            tee_tcb_svn.copy_from_slice(&svn[..16]);
+            cpu_svn.copy_from_slice(&svn[16..]);
+            Some(tee_call::KeyDerivationSvn::Tdx {
+                tee_tcb_svn,
+                cpu_svn,
+            })
+        }
+        _ => None,
+    }
+}
+
+/// Verify the HMAC over `signed_bytes` and decrypt `iv`/`ciphertext` into the
+/// ingress key. Shared by the v2 (legacy) and v3 protector layouts.
+fn unseal_key_bytes(
+    hardware_derived_keys: &HardwareDerivedKeys,
+    signed_bytes: &[u8],
+    stored_hmac: &[u8; vmgs::HMAC_SHA_256_KEY_LENGTH],
+    iv: &[u8; vmgs::AES_CBC_IV_LENGTH],
+    ciphertext: &[u8; vmgs::AES_GCM_KEY_LENGTH],
+) -> Result<[u8; vmgs::AES_GCM_KEY_LENGTH], HardwareKeySealingError> {
+    let hmac = crypto::hmac_sha_256::hmac_sha_256(&hardware_derived_keys.hmac_key, signed_bytes)
+        .map_err(HardwareKeySealingError::HmacBeforeDecrypt)?;
+
+    if !constant_time_eq::constant_time_eq_32(&hmac, stored_hmac) {
+        Err(HardwareKeySealingError::HardwareKeyProtectorHmacVerificationFailed)?
+    }
+
+    let mut decrypted_ingress_key = [0u8; vmgs::AES_GCM_KEY_LENGTH];
+    let output = crypto::aes_256_cbc::Aes256Cbc::new(&hardware_derived_keys.aes_key)
+        .and_then(|aes| aes.decrypt()?.cipher(iv, ciphertext))
+        .map_err(HardwareKeySealingError::DecryptIngressKey)?;
+    if output.len() != vmgs::AES_GCM_KEY_LENGTH {
+        Err(HardwareKeySealingError::InvalidIngressKeyDecryptionSize(
+            output.len(),
+            vmgs::AES_GCM_KEY_LENGTH,
+        ))?
+    }
+    decrypted_ingress_key.copy_from_slice(&output[..vmgs::AES_GCM_KEY_LENGTH]);
+
+    tracing::info!(
+        CVM_ALLOWED,
+        "decrypt ingress_key using hardware derived key"
+    );
+
+    Ok(decrypted_ingress_key)
+}
+
+/// A hardware key protector read from the VMGS, either the legacy v1/v2 layout
+/// (SNP) or the current v3 layout.
+#[derive(Debug)]
+pub enum HwKeyProtector {
+    /// v1/v2 layout ([`HardwareKeyProtector`]); the `version` field distinguishes.
+    Legacy(HardwareKeyProtector),
+    /// v3 layout ([`HardwareKeyProtectorV3`]).
+    V3(HardwareKeyProtectorV3),
+}
+
+impl HwKeyProtector {
+    /// The key derivation policy recorded in the protector, or `None` if the
+    /// format is not compatible with this OpenHCL (e.g. v1, which always mixes
+    /// the measurement, or an unknown version/tee-type).
+    pub fn key_derivation_policy(&self) -> Option<tee_call::KeyDerivationPolicy> {
+        match self {
+            HwKeyProtector::Legacy(p) => match p.header.version {
+                vmgs::HW_KEY_PROTECTOR_VERSION_2 => Some(tee_call::KeyDerivationPolicy {
+                    svn: tee_call::KeyDerivationSvn::Snp {
+                        tcb_version: p.header.tcb_version,
+                    },
+                    mix_measurement: p.header.mix_measurement != 0,
+                }),
+                _ => None,
+            },
+            HwKeyProtector::V3(p) => {
+                key_derivation_svn_from_header(p.header.tee_type, p.header.svn).map(|svn| {
+                    tee_call::KeyDerivationPolicy {
+                        svn,
+                        mix_measurement: p.header.mix_measurement != 0,
+                    }
+                })
+            }
+        }
+    }
+
+    /// Format version of the protector.
+    pub fn version(&self) -> u32 {
+        match self {
+            HwKeyProtector::Legacy(p) => p.header.version,
+            HwKeyProtector::V3(p) => p.header.version,
+        }
+    }
+
+    /// Unseal the `ingress_key` with verify-mac-then-decrypt.
+    pub fn unseal_key(
+        &self,
+        hardware_derived_keys: &HardwareDerivedKeys,
+    ) -> Result<[u8; vmgs::AES_GCM_KEY_LENGTH], HardwareKeySealingError> {
+        match self {
+            HwKeyProtector::Legacy(p) => {
+                let offset = std::mem::offset_of!(HardwareKeyProtector, hmac);
+                unseal_key_bytes(
+                    hardware_derived_keys,
+                    &p.as_bytes()[..offset],
+                    &p.hmac,
+                    &p.iv,
+                    &p.ciphertext,
+                )
+            }
+            HwKeyProtector::V3(p) => p.unseal_key(hardware_derived_keys),
+        }
+    }
+}
+
+/// Seal the `egress_key` into a v3 [`HardwareKeyProtector`] with encrypt-then-mac.
+pub fn seal_key(
+    hardware_derived_keys: &HardwareDerivedKeys,
+    egress_key: &[u8],
+) -> Result<HardwareKeyProtectorV3, HardwareKeySealingError> {
+    let (tee_type, svn) = key_derivation_svn_to_header(hardware_derived_keys.policy.svn);
+    let header = vmgs::HardwareKeyProtectorHeaderV3::new(
+        vmgs::HW_KEY_PROTECTOR_V3_SIZE as u32,
+        tee_type,
+        svn,
+        hardware_derived_keys.policy.mix_measurement as u8,
+    );
+
+    let mut iv = [0u8; vmgs::AES_CBC_IV_LENGTH];
+    getrandom::fill(&mut iv).expect("rng failure");
+
+    let mut encrypted_egress_key = [0u8; vmgs::AES_GCM_KEY_LENGTH];
+    let output = crypto::aes_256_cbc::Aes256Cbc::new(&hardware_derived_keys.aes_key)
+        .and_then(|aes| aes.encrypt()?.cipher(&iv, egress_key))
+        .map_err(HardwareKeySealingError::EncryptEgressKey)?;
+    if output.len() != vmgs::AES_GCM_KEY_LENGTH {
+        Err(HardwareKeySealingError::InvalidEgressKeyEncryptionSize(
+            output.len(),
+            vmgs::AES_GCM_KEY_LENGTH,
+        ))?
+    }
+    encrypted_egress_key.copy_from_slice(&output[..vmgs::AES_GCM_KEY_LENGTH]);
+
+    let mut hardware_key_protector = HardwareKeyProtectorV3 {
+        header,
+        iv,
+        ciphertext: encrypted_egress_key,
+        hmac: [0u8; vmgs::HMAC_SHA_256_KEY_LENGTH],
+    };
+    let offset = std::mem::offset_of!(HardwareKeyProtectorV3, hmac);
+    hardware_key_protector.hmac = crypto::hmac_sha_256::hmac_sha_256(
+        &hardware_derived_keys.hmac_key,
+        &hardware_key_protector.as_bytes()[..offset],
+    )
+    .map_err(HardwareKeySealingError::HmacAfterEncrypt)?;
+
+    tracing::info!(CVM_ALLOWED, "encrypt egress_key using hardware derived key");
+
+    Ok(hardware_key_protector)
+}
+
+/// Extension trait to unseal a v3 protector directly.
+pub trait HardwareKeyProtectorV3Ext {
     /// Unseal the `ingress_key` with verify-mac-then-decrypt.
     fn unseal_key(
         &self,
@@ -125,84 +323,19 @@ pub trait HardwareKeyProtectorExt: Sized {
     ) -> Result<[u8; vmgs::AES_GCM_KEY_LENGTH], HardwareKeySealingError>;
 }
 
-impl HardwareKeyProtectorExt for HardwareKeyProtector {
-    fn seal_key(
-        hardware_derived_keys: &HardwareDerivedKeys,
-        egress_key: &[u8],
-    ) -> Result<Self, HardwareKeySealingError> {
-        let header = vmgs::HardwareKeyProtectorHeader::new(
-            vmgs::HW_KEY_PROTECTOR_CURRENT_VERSION,
-            vmgs::HW_KEY_PROTECTOR_SIZE as u32,
-            hardware_derived_keys.policy.tcb_version,
-            hardware_derived_keys.policy.mix_measurement as u8,
-        );
-
-        let mut iv = [0u8; vmgs::AES_CBC_IV_LENGTH];
-        getrandom::fill(&mut iv).expect("rng failure");
-
-        let mut encrypted_egress_key = [0u8; vmgs::AES_GCM_KEY_LENGTH];
-        let output = crypto::aes_256_cbc::Aes256Cbc::new(&hardware_derived_keys.aes_key)
-            .and_then(|aes| aes.encrypt()?.cipher(&iv, egress_key))
-            .map_err(HardwareKeySealingError::EncryptEgressKey)?;
-        if output.len() != vmgs::AES_GCM_KEY_LENGTH {
-            Err(HardwareKeySealingError::InvalidEgressKeyEncryptionSize(
-                output.len(),
-                vmgs::AES_GCM_KEY_LENGTH,
-            ))?
-        }
-        encrypted_egress_key.copy_from_slice(&output[..vmgs::AES_GCM_KEY_LENGTH]);
-
-        let mut hardware_key_protector = Self {
-            header,
-            iv,
-            ciphertext: encrypted_egress_key,
-            hmac: [0u8; vmgs::HMAC_SHA_256_KEY_LENGTH],
-        };
-        let offset = std::mem::offset_of!(Self, hmac);
-        hardware_key_protector.hmac = crypto::hmac_sha_256::hmac_sha_256(
-            &hardware_derived_keys.hmac_key,
-            &hardware_key_protector.as_bytes()[..offset],
-        )
-        .map_err(HardwareKeySealingError::HmacAfterEncrypt)?;
-
-        tracing::info!(CVM_ALLOWED, "encrypt egress_key using hardware derived key");
-
-        Ok(hardware_key_protector)
-    }
-
+impl HardwareKeyProtectorV3Ext for HardwareKeyProtectorV3 {
     fn unseal_key(
         &self,
         hardware_derived_keys: &HardwareDerivedKeys,
     ) -> Result<[u8; vmgs::AES_GCM_KEY_LENGTH], HardwareKeySealingError> {
-        let offset = std::mem::offset_of!(HardwareKeyProtector, hmac);
-        let hmac = crypto::hmac_sha_256::hmac_sha_256(
-            &hardware_derived_keys.hmac_key,
+        let offset = std::mem::offset_of!(HardwareKeyProtectorV3, hmac);
+        unseal_key_bytes(
+            hardware_derived_keys,
             &self.as_bytes()[..offset],
+            &self.hmac,
+            &self.iv,
+            &self.ciphertext,
         )
-        .map_err(HardwareKeySealingError::HmacBeforeDecrypt)?;
-
-        if !constant_time_eq::constant_time_eq_32(&hmac, &self.hmac) {
-            Err(HardwareKeySealingError::HardwareKeyProtectorHmacVerificationFailed)?
-        }
-
-        let mut decrypted_ingress_key = [0u8; vmgs::AES_GCM_KEY_LENGTH];
-        let output = crypto::aes_256_cbc::Aes256Cbc::new(&hardware_derived_keys.aes_key)
-            .and_then(|aes| aes.decrypt()?.cipher(&self.iv, &self.ciphertext))
-            .map_err(HardwareKeySealingError::DecryptIngressKey)?;
-        if output.len() != vmgs::AES_GCM_KEY_LENGTH {
-            Err(HardwareKeySealingError::InvalidIngressKeyDecryptionSize(
-                output.len(),
-                vmgs::AES_GCM_KEY_LENGTH,
-            ))?
-        }
-        decrypted_ingress_key.copy_from_slice(&output[..vmgs::AES_GCM_KEY_LENGTH]);
-
-        tracing::info!(
-            CVM_ALLOWED,
-            "decrypt ingress_key using hardware derived key"
-        );
-
-        Ok(decrypted_ingress_key)
     }
 }
 
@@ -243,14 +376,16 @@ mod tests {
             mock_get_derived_key_call,
             &vm_config,
             tee_call::KeyDerivationPolicy {
-                tcb_version: 0x7308000000000003,
+                svn: tee_call::KeyDerivationSvn::Snp {
+                    tcb_version: 0x7308000000000003,
+                },
                 mix_measurement: true,
             },
         )
         .unwrap();
 
-        let output = HardwareKeyProtector::seal_key(&hardware_derived_keys, &PLAINTEXT).unwrap();
-        let hardware_key_protector = HardwareKeyProtector::read_from_prefix(output.as_bytes())
+        let output = seal_key(&hardware_derived_keys, &PLAINTEXT).unwrap();
+        let hardware_key_protector = HardwareKeyProtectorV3::read_from_prefix(output.as_bytes())
             .unwrap()
             .0;
         let plaintext = hardware_key_protector
@@ -268,13 +403,15 @@ mod tests {
             mock_get_derived_key_call,
             &vm_config,
             tee_call::KeyDerivationPolicy {
-                tcb_version: 0x7308000000000003,
+                svn: tee_call::KeyDerivationSvn::Snp {
+                    tcb_version: 0x7308000000000003,
+                },
                 mix_measurement: false,
             },
         )
         .unwrap();
-        let output = HardwareKeyProtector::seal_key(&k1, &PLAINTEXT).unwrap();
-        let hardware_key_protector = HardwareKeyProtector::read_from_prefix(output.as_bytes())
+        let output = seal_key(&k1, &PLAINTEXT).unwrap();
+        let hardware_key_protector = HardwareKeyProtectorV3::read_from_prefix(output.as_bytes())
             .unwrap()
             .0;
 
@@ -285,7 +422,9 @@ mod tests {
             mock_get_derived_key_call,
             &vm_config,
             tee_call::KeyDerivationPolicy {
-                tcb_version: 0x7308000000000003,
+                svn: tee_call::KeyDerivationSvn::Snp {
+                    tcb_version: 0x7308000000000003,
+                },
                 mix_measurement: false,
             },
         )
@@ -306,7 +445,9 @@ mod tests {
                 mock_get_derived_key_call,
                 &vm_config,
                 tee_call::KeyDerivationPolicy {
-                    tcb_version: 0x7308000000000003,
+                    svn: tee_call::KeyDerivationSvn::Snp {
+                        tcb_version: 0x7308000000000003,
+                    },
                     mix_measurement: false,
                 },
             );
@@ -328,7 +469,9 @@ mod tests {
                 mock_get_derived_key_call,
                 &vm_config,
                 tee_call::KeyDerivationPolicy {
-                    tcb_version: 0x7308000000000003,
+                    svn: tee_call::KeyDerivationSvn::Snp {
+                        tcb_version: 0x7308000000000003,
+                    },
                     mix_measurement: true,
                 },
             );
@@ -347,16 +490,20 @@ mod tests {
         let mock_tee_call = Box::new(MockTeeCall::new([0x7au8; 32])) as Box<dyn tee_call::TeeCall>;
         let mock_get_derived_key_call = mock_tee_call.supports_get_derived_key().unwrap();
         let policy = tee_call::KeyDerivationPolicy {
-            tcb_version: 0xDEAD_BEEF,
+            svn: tee_call::KeyDerivationSvn::Snp {
+                tcb_version: 0xDEAD_BEEF,
+            },
             mix_measurement: false,
         };
         let k =
             HardwareDerivedKeys::derive_key(mock_get_derived_key_call, &vm_config, policy).unwrap();
-        let hwkp = HardwareKeyProtector::seal_key(&k, &PLAINTEXT).unwrap();
+        let hwkp = seal_key(&k, &PLAINTEXT).unwrap();
 
-        assert_eq!(hwkp.header.tcb_version, policy.tcb_version);
+        let (tee_type, svn) = key_derivation_svn_to_header(policy.svn);
+        assert_eq!(hwkp.header.tee_type, tee_type);
+        assert_eq!(hwkp.header.svn, svn);
         assert_eq!(hwkp.header.mix_measurement, policy.mix_measurement as u8);
-        assert_eq!(hwkp.header.length as usize, vmgs::HW_KEY_PROTECTOR_SIZE);
+        assert_eq!(hwkp.header.length as usize, vmgs::HW_KEY_PROTECTOR_V3_SIZE);
         assert_eq!(hwkp.header.version, vmgs::HW_KEY_PROTECTOR_CURRENT_VERSION);
     }
 
@@ -370,14 +517,14 @@ mod tests {
             mock_get_derived_key_call,
             &vm_config,
             tee_call::KeyDerivationPolicy {
-                tcb_version: 2,
+                svn: tee_call::KeyDerivationSvn::Snp { tcb_version: 2 },
                 mix_measurement: true,
             },
         )
         .unwrap();
 
         let plaintext = [0x7Au8; 20];
-        let err = HardwareKeyProtector::seal_key(&k, &plaintext)
+        let err = seal_key(&k, &plaintext)
             .expect_err("expected seal to fail for non-block-multiple length");
         assert!(matches!(err, HardwareKeySealingError::EncryptEgressKey(_)));
     }
@@ -391,13 +538,15 @@ mod tests {
             mock_get_derived_key_call,
             &vm_config,
             tee_call::KeyDerivationPolicy {
-                tcb_version: 0x7308000000000003,
+                svn: tee_call::KeyDerivationSvn::Snp {
+                    tcb_version: 0x7308000000000003,
+                },
                 mix_measurement: true,
             },
         )
         .unwrap();
 
-        let mut hwkp = HardwareKeyProtector::seal_key(&hardware_derived_keys, &PLAINTEXT).unwrap();
+        let mut hwkp = seal_key(&hardware_derived_keys, &PLAINTEXT).unwrap();
 
         // Corrupt the HMAC to force verification failure
         hwkp.hmac[0] ^= 0xFF;
@@ -422,19 +571,19 @@ mod tests {
             mock_get_derived_key_call,
             &vm_config,
             tee_call::KeyDerivationPolicy {
-                tcb_version: 0x1,
+                svn: tee_call::KeyDerivationSvn::Snp { tcb_version: 0x1 },
                 mix_measurement: true,
             },
         )
         .unwrap();
-        let hwkp = HardwareKeyProtector::seal_key(&k1, &PLAINTEXT).unwrap();
+        let hwkp = seal_key(&k1, &PLAINTEXT).unwrap();
 
         let vm_config = create_test_vm_config(HardwareSealingPolicy::Signer);
         let k2 = HardwareDerivedKeys::derive_key(
             mock_get_derived_key_call,
             &vm_config,
             tee_call::KeyDerivationPolicy {
-                tcb_version: 0x1,
+                svn: tee_call::KeyDerivationSvn::Snp { tcb_version: 0x1 },
                 mix_measurement: false,
             },
         )
@@ -459,18 +608,22 @@ mod tests {
             mock_get_derived_key_call,
             &vm_config,
             tee_call::KeyDerivationPolicy {
-                tcb_version: 0xAAAAAAAAAAAAAAAA,
+                svn: tee_call::KeyDerivationSvn::Snp {
+                    tcb_version: 0xAAAAAAAAAAAAAAAA,
+                },
                 mix_measurement: true,
             },
         )
         .unwrap();
-        let hwkp = HardwareKeyProtector::seal_key(&k1, &PLAINTEXT).unwrap();
+        let hwkp = seal_key(&k1, &PLAINTEXT).unwrap();
 
         let k2 = HardwareDerivedKeys::derive_key(
             mock_get_derived_key_call,
             &vm_config,
             tee_call::KeyDerivationPolicy {
-                tcb_version: 0xBBBBBBBBBBBBBBBB,
+                svn: tee_call::KeyDerivationSvn::Snp {
+                    tcb_version: 0xBBBBBBBBBBBBBBBB,
+                },
                 mix_measurement: true,
             },
         )
@@ -495,12 +648,14 @@ mod tests {
             mock_get_derived_key_call,
             &vm_config,
             tee_call::KeyDerivationPolicy {
-                tcb_version: 0xAAAAAAAAAAAAAAAA,
+                svn: tee_call::KeyDerivationSvn::Snp {
+                    tcb_version: 0xAAAAAAAAAAAAAAAA,
+                },
                 mix_measurement: true,
             },
         )
         .unwrap();
-        let hwkp = HardwareKeyProtector::seal_key(&k1, &PLAINTEXT).unwrap();
+        let hwkp = seal_key(&k1, &PLAINTEXT).unwrap();
 
         let mock_tee_call = Box::new(MockTeeCall::new([0x8bu8; 32])) as Box<dyn tee_call::TeeCall>;
         let mock_get_derived_key_call = mock_tee_call.supports_get_derived_key().unwrap();
@@ -508,7 +663,9 @@ mod tests {
             mock_get_derived_key_call,
             &vm_config,
             tee_call::KeyDerivationPolicy {
-                tcb_version: 0xAAAAAAAAAAAAAAAA,
+                svn: tee_call::KeyDerivationSvn::Snp {
+                    tcb_version: 0xAAAAAAAAAAAAAAAA,
+                },
                 mix_measurement: true,
             },
         )

--- a/openhcl/underhill_attestation/src/lib.rs
+++ b/openhcl/underhill_attestation/src/lib.rs
@@ -39,7 +39,6 @@ use guest_emulation_transport::api::GuestStateProtection;
 use guest_emulation_transport::api::GuestStateProtectionById;
 use guid::Guid;
 use hardware_key_sealing::HardwareDerivedKeys;
-use hardware_key_sealing::HardwareKeyProtectorExt as _;
 use key_protector::GetKeysFromKeyProtectorError;
 use key_protector::KeyProtectorExt as _;
 use mesh::MeshPayload;
@@ -49,9 +48,7 @@ use openhcl_attestation_protocol::igvm_attest::get::runtime_claims::VmgsProvisio
 use openhcl_attestation_protocol::vmgs::AES_GCM_KEY_LENGTH;
 use openhcl_attestation_protocol::vmgs::AGENT_DATA_MAX_SIZE;
 use openhcl_attestation_protocol::vmgs::HW_KEY_PROTECTOR_CURRENT_VERSION;
-use openhcl_attestation_protocol::vmgs::HW_KEY_PROTECTOR_VERSION_1;
-use openhcl_attestation_protocol::vmgs::HW_KEY_PROTECTOR_VERSION_2;
-use openhcl_attestation_protocol::vmgs::HardwareKeyProtector;
+use openhcl_attestation_protocol::vmgs::HardwareKeyProtectorV3;
 use openhcl_attestation_protocol::vmgs::KeyProtector;
 use openhcl_attestation_protocol::vmgs::SecurityProfile;
 use pal_async::local::LocalDriver;
@@ -63,6 +60,7 @@ use std::fmt::Debug;
 use tee_call::KeyDerivationPolicy;
 use tee_call::REPORT_DATA_SIZE;
 use tee_call::TeeCall;
+use tee_call::TeeType;
 use thiserror::Error;
 use zerocopy::FromZeros;
 use zerocopy::IntoBytes;
@@ -280,7 +278,7 @@ struct DerivedKeyResult {
     /// The instance of [`GspExtendedStatusFlags`] returned by GSP.
     gsp_extended_status_flags: GspExtendedStatusFlags,
     /// Optional hardware key protector.
-    hardware_key_protector: Option<HardwareKeyProtector>,
+    hardware_key_protector: Option<HardwareKeyProtectorV3>,
 }
 
 /// The return values of [`initialize_platform_security`].
@@ -349,7 +347,7 @@ async fn try_unlock_vmgs(
             Ok(VmgsEncryptionKeys {
                 ingress_rsa_kek: None,
                 wrapped_des_key: None,
-                tcb_version: report.tcb_version,
+                key_derivation_svn: report.key_derivation_svn,
             })
         }
     } else {
@@ -382,7 +380,7 @@ async fn try_unlock_vmgs(
     let VmgsEncryptionKeys {
         ingress_rsa_kek,
         wrapped_des_key,
-        tcb_version,
+        key_derivation_svn,
     } = match skr_response {
         Ok(k) => {
             tracing::info!(CVM_ALLOWED, "Successfully retrieved key-encryption key");
@@ -437,8 +435,8 @@ async fn try_unlock_vmgs(
         HardwareSealingPolicy::Hash
     );
 
-    let key_derivation_policy = tcb_version.map(|tcb_version| KeyDerivationPolicy {
-        tcb_version,
+    let key_derivation_policy = key_derivation_svn.map(|svn| KeyDerivationPolicy {
+        svn,
         mix_measurement,
     });
 
@@ -586,6 +584,37 @@ pub async fn initialize_platform_security(
             attestation_vm_config.hardware_sealing_policy,
             HardwareSealingPolicy::None
         );
+
+    // TDX has no signer/identity key-policy register to substitute for `MRTD`
+    // when deriving a measurement-independent key, so signer-based hardware
+    // sealing can never succeed on TDX. Reject the unsupported combination here,
+    // where both the sealing policy and the TEE type are known, so we can fail
+    // closed with a precise diagnostic instead of only tripping the low-level
+    // guard deep in `TdxCall::get_derived_key` (kept as defense in depth).
+    if matches!(tee_call.map(|tee| tee.tee_type()), Some(TeeType::Tdx))
+        && matches!(
+            attestation_vm_config.hardware_sealing_policy,
+            HardwareSealingPolicy::Signer
+        )
+    {
+        tracing::error!(
+            CVM_ALLOWED,
+            "signer-based hardware sealing is not supported on TDX; TDX has no \
+             identity key-policy register to bind a measurement-independent key to"
+        );
+        // Exclusive (stateless) hardware sealing is the only encryption source,
+        // so fail closed. In the stateful (backup) case the error log above
+        // suffices; the low-level `tee_call` guard skips the backup seal.
+        if require_hardware_sealing {
+            return Err(
+                AttestationErrorInner::HardwareSealingRequestedButNotAvailable {
+                    tee_available: tee_call.is_some(),
+                    hardware_sealing_policy: attestation_vm_config.hardware_sealing_policy,
+                }
+                .into(),
+            );
+        }
+    }
 
     // A stateful (`!suppress_attestation`) request for `HardwareSealing` breaks
     // the invariant above. We don't fail closed because the normal attestation
@@ -766,7 +795,7 @@ async fn unlock_vmgs_data_store(
     vmgs_encrypted: bool,
     key_protector: &mut KeyProtector,
     key_protector_by_id: &mut KeyProtectorById,
-    hardware_key_protector: Option<HardwareKeyProtector>,
+    hardware_key_protector: Option<HardwareKeyProtectorV3>,
     derived_keys: Option<Keys>,
     key_protector_settings: KeyProtectorSettings,
     bios_guid: Guid,
@@ -1102,37 +1131,17 @@ async fn get_derived_keys(
 
             let hardware_derived_keys = tee_call.supports_get_derived_key().and_then(|tee_call| {
                 if let Some(hardware_key_protector) = &hardware_key_protector {
-                    let policy = match hardware_key_protector.header.version {
-                        HW_KEY_PROTECTOR_VERSION_1 => {
-                            // Version 1 is not forward compatible with other versions because it always mixes the OpenHCL
-                            // measurement into the hardware key derivation function (KDF). This means that any version
-                            // change implying an OpenHCL measurement change will result in a different hardware sealing key,
-                            // causing the unsealing process to fail. To prevent this issue, we return None here and log
-                            // the appropriate information.
-                            //
-                            // NOTE: In future implementations, we should handle version 2 and above differently.
-                            // These versions support forward compatibility when using signer-based sealing policy that
-                            // does not mix the OpenHCL measurement into the hardware KDF.
-                            tracing::error!(
-                                CVM_ALLOWED,
-                                current_version = HW_KEY_PROTECTOR_CURRENT_VERSION,
-                                "HW_KEY_PROTECTOR version 1 is incompatible with newer versions. Skip VMGS DEK unsealing with hardware key protector."
-                            );
-                            return None;
-                        }
-                        HW_KEY_PROTECTOR_VERSION_2 => KeyDerivationPolicy {
-                            tcb_version: hardware_key_protector.header.tcb_version,
-                            mix_measurement: hardware_key_protector.header.mix_measurement != 0,
-                        },
-                        unsupported_version => {
-                            // unsupported version
-                            tracing::warn!(
-                                CVM_ALLOWED,
-                                unsupported_version,
-                                "unsupported HW_KEY_PROTECTOR version",
-                            );
-                            return None;
-                        }
+                    // `key_derivation_policy` returns `None` for formats that
+                    // cannot be re-derived by this OpenHCL (v1, which always
+                    // mixes the measurement, or an unknown version/tee-type).
+                    let Some(policy) = hardware_key_protector.key_derivation_policy() else {
+                        tracing::error!(
+                            CVM_ALLOWED,
+                            version = hardware_key_protector.version(),
+                            current_version = HW_KEY_PROTECTOR_CURRENT_VERSION,
+                            "incompatible HW_KEY_PROTECTOR; skip VMGS DEK unsealing with hardware key protector."
+                        );
+                        return None;
                     };
 
                     match HardwareDerivedKeys::derive_key(tee_call, attestation_vm_config, policy) {
@@ -1142,8 +1151,7 @@ async fn get_derived_keys(
                             tracing::warn!(
                                 CVM_ALLOWED,
                                 error = &e as &dyn std::error::Error,
-                                tcb_version = hardware_key_protector.header.tcb_version,
-                                mix_measurement = hardware_key_protector.header.mix_measurement,
+                                version = hardware_key_protector.version(),
                                 "failed to derive hardware keys using HW_KEY_PROTECTOR",
                             );
                             None
@@ -1222,7 +1230,7 @@ async fn get_derived_keys(
                 getrandom::fill(&mut new_dek).expect("rng failure");
 
                 let updated_hardware_key_protector =
-                    HardwareKeyProtector::seal_key(&hardware_derived_keys, &new_dek)
+                    hardware_key_sealing::seal_key(&hardware_derived_keys, &new_dek)
                         .map_err(GetDerivedKeysError::SealEgressKeyUsingHardwareDerivedKeys)?;
 
                 derived_keys.encrypt_egress = new_dek;
@@ -1243,8 +1251,10 @@ async fn get_derived_keys(
                     "Using hardware-derived key to recover VMGS DEK"
                 );
 
-                // Use the same key protector in the VMGS DEK backup scenario
-                hardware_key_protector
+                // Re-seal the recovered DEK as a v3 protector (also migrates a
+                // legacy v2 protector to the current format).
+                hardware_key_sealing::seal_key(&hardware_derived_keys, &derived_keys.ingress)
+                    .map_err(GetDerivedKeysError::SealEgressKeyUsingHardwareDerivedKeys)?
             };
 
             key_protector_settings.should_write_kp = false;
@@ -1321,7 +1331,7 @@ async fn get_derived_keys(
         getrandom::fill(&mut new_dek).expect("rng failure");
 
         let hardware_key_protector =
-            match HardwareKeyProtector::seal_key(&hardware_derived_keys, &new_dek) {
+            match hardware_key_sealing::seal_key(&hardware_derived_keys, &new_dek) {
                 Ok(hardware_key_protector) => hardware_key_protector,
                 Err(e) => {
                     get.event_log_fatal(
@@ -1385,7 +1395,7 @@ async fn get_derived_keys(
         derived_keys.encrypt_egress = encrypt_egress_key;
 
         if let Some(hardware_derived_keys) = hardware_derived_keys {
-            let hardware_key_protector = HardwareKeyProtector::seal_key(
+            let hardware_key_protector = hardware_key_sealing::seal_key(
                 &hardware_derived_keys,
                 &derived_keys.encrypt_egress,
             )
@@ -1564,7 +1574,7 @@ async fn get_derived_keys(
         key_protector.gsp[egress_idx].gsp_length = gsp_response.encrypted_gsp.length;
 
         if let Some(hardware_derived_keys) = hardware_derived_keys {
-            let hardware_key_protector = HardwareKeyProtector::seal_key(
+            let hardware_key_protector = hardware_key_sealing::seal_key(
                 &hardware_derived_keys,
                 &derived_keys.encrypt_egress,
             )
@@ -1694,7 +1704,7 @@ async fn persist_all_key_protectors(
     vmgs: &mut Vmgs,
     key_protector: &mut KeyProtector,
     key_protector_by_id: &mut KeyProtectorById,
-    hardware_key_protector: Option<&HardwareKeyProtector>,
+    hardware_key_protector: Option<&HardwareKeyProtectorV3>,
     bios_guid: Guid,
     key_protector_settings: KeyProtectorSettings,
 ) -> Result<(), PersistAllKeyProtectorsError> {
@@ -1880,7 +1890,9 @@ pub mod test_utils {
 
             Ok(GetAttestationReportResult {
                 report: report.to_vec(),
-                tcb_version: Some(self.tcb_version),
+                key_derivation_svn: Some(tee_call::KeyDerivationSvn::Snp {
+                    tcb_version: self.tcb_version,
+                }),
             })
         }
 
@@ -1902,8 +1914,12 @@ pub mod test_utils {
             // Base test key; mix in policy so different policies yield different derived secrets
             let mut key: [u8; HW_DERIVED_KEY_LENGTH] = [0xab; HW_DERIVED_KEY_LENGTH];
 
-            // Use mutation to simulate the policy
-            let tcb = policy.tcb_version.to_le_bytes();
+            // Mock is SNP; mix in the recorded TCB version.
+            let tcb_version = match policy.svn {
+                tee_call::KeyDerivationSvn::Snp { tcb_version } => tcb_version,
+                tee_call::KeyDerivationSvn::Tdx { .. } => 0,
+            };
+            let tcb = tcb_version.to_le_bytes();
             for (i, b) in key.iter_mut().enumerate() {
                 if policy.mix_measurement {
                     *b ^= self.measurement[i] ^ tcb[i % tcb.len()];
@@ -1930,7 +1946,7 @@ pub mod test_utils {
 
             Ok(GetAttestationReportResult {
                 report: report.to_vec(),
-                tcb_version: None,
+                key_derivation_svn: None,
             })
         }
 
@@ -2639,7 +2655,7 @@ mod tests {
             &mut vmgs,
             &mut key_protector,
             &mut key_protector_by_id,
-            Some(&HardwareKeyProtector::new_zeroed()),
+            Some(&HardwareKeyProtectorV3::new_zeroed()),
             bios_guid,
             key_protector_settings,
         )
@@ -2699,7 +2715,9 @@ mod tests {
             None,
             None,
             Some(KeyDerivationPolicy {
-                tcb_version: 0x1234,
+                svn: tee_call::KeyDerivationSvn::Snp {
+                    tcb_version: 0x1234,
+                },
                 mix_measurement: true,
             }),
             GuestStateEncryptionPolicy::HardwareSealing,
@@ -2773,12 +2791,14 @@ mod tests {
                 vmgs_provisioner: None,
             },
             KeyDerivationPolicy {
-                tcb_version: 0x1234,
+                svn: tee_call::KeyDerivationSvn::Snp {
+                    tcb_version: 0x1234,
+                },
                 mix_measurement: true,
             },
         )
         .unwrap();
-        let hwkp = HardwareKeyProtector::seal_key(&hdk, &bootstrap).unwrap();
+        let hwkp = hardware_key_sealing::seal_key(&hdk, &bootstrap).unwrap();
         vmgs::write_hardware_key_protector(&hwkp, &mut vmgs)
             .await
             .unwrap();
@@ -2818,7 +2838,9 @@ mod tests {
             None,
             None,
             Some(KeyDerivationPolicy {
-                tcb_version: 0x1234,
+                svn: tee_call::KeyDerivationSvn::Snp {
+                    tcb_version: 0x1234,
+                },
                 mix_measurement: true,
             }),
             GuestStateEncryptionPolicy::HardwareSealing,
@@ -2886,7 +2908,9 @@ mod tests {
             None,
             None,
             Some(KeyDerivationPolicy {
-                tcb_version: 0x1234,
+                svn: tee_call::KeyDerivationSvn::Snp {
+                    tcb_version: 0x1234,
+                },
                 mix_measurement: true,
             }),
             GuestStateEncryptionPolicy::HardwareSealing,
@@ -3093,7 +3117,7 @@ mod tests {
             &mut vmgs,
             &mut key_protector,
             &mut key_protector_by_id,
-            Some(&HardwareKeyProtector::new_zeroed()),
+            Some(&HardwareKeyProtectorV3::new_zeroed()),
             bios_guid,
             key_protector_settings,
         )

--- a/openhcl/underhill_attestation/src/secure_key_release.rs
+++ b/openhcl/underhill_attestation/src/secure_key_release.rs
@@ -134,8 +134,8 @@ pub struct VmgsEncryptionKeys {
     pub ingress_rsa_kek: Option<RsaKeyPair>,
     /// Optional DiskEncryptionSettings key used by key rotation.
     pub wrapped_des_key: Option<Vec<u8>>,
-    /// Optional TCB version used by hardware key sealing.
-    pub tcb_version: Option<u64>,
+    /// Optional SVN material used by hardware key sealing.
+    pub key_derivation_svn: Option<tee_call::KeyDerivationSvn>,
 }
 
 /// Request the VMGS encryption keys via host call-outs with optional retry logic.
@@ -207,7 +207,7 @@ pub async fn request_vmgs_encryption_keys(
             Ok(VmgsEncryptionKeys {
                 ingress_rsa_kek: Some(ingress_rsa_kek),
                 wrapped_des_key,
-                tcb_version: result.tcb_version,
+                key_derivation_svn: result.key_derivation_svn,
             })
         }
         Err(

--- a/openhcl/underhill_attestation/src/vmgs.rs
+++ b/openhcl/underhill_attestation/src/vmgs.rs
@@ -3,11 +3,13 @@
 
 //! Implementation of the helper functions for accessing VMGS entries.
 
+use crate::hardware_key_sealing::HwKeyProtector;
 use guid::Guid;
 use openhcl_attestation_protocol::vmgs::AGENT_DATA_MAX_SIZE;
 use openhcl_attestation_protocol::vmgs::GUEST_SECRET_KEY_MAX_SIZE;
 use openhcl_attestation_protocol::vmgs::GuestSecretKey;
 use openhcl_attestation_protocol::vmgs::HardwareKeyProtector;
+use openhcl_attestation_protocol::vmgs::HardwareKeyProtectorV3;
 use openhcl_attestation_protocol::vmgs::KeyProtector;
 use openhcl_attestation_protocol::vmgs::KeyProtectorById;
 use openhcl_attestation_protocol::vmgs::SecurityProfile;
@@ -205,8 +207,9 @@ pub async fn read_security_profile(vmgs: &mut Vmgs) -> Result<SecurityProfile, R
 /// Read the hardware key protector from the VMGS file.
 pub async fn read_hardware_key_protector(
     vmgs: &mut Vmgs,
-) -> Result<HardwareKeyProtector, ReadFromVmgsError> {
+) -> Result<HwKeyProtector, ReadFromVmgsError> {
     use openhcl_attestation_protocol::vmgs::HW_KEY_PROTECTOR_SIZE;
+    use openhcl_attestation_protocol::vmgs::HW_KEY_PROTECTOR_V3_SIZE;
 
     let file_id = FileId::HW_KEY_PROTECTOR;
     let data = match vmgs.read_file(file_id).await {
@@ -219,22 +222,26 @@ pub async fn read_hardware_key_protector(
         }
     };
 
-    if data.len() != HW_KEY_PROTECTOR_SIZE {
-        Err(ReadFromVmgsError::EntrySizeUnexpected {
+    // Dispatch by blob size: the legacy v1/v2 layout and the current v3 layout
+    // have distinct sizes.
+    match data.len() {
+        HW_KEY_PROTECTOR_SIZE => HardwareKeyProtector::read_from_prefix(&data)
+            .map(|k| HwKeyProtector::Legacy(k.0)) // TODO: zerocopy: map_err (https://github.com/microsoft/openvmm/issues/759)
+            .map_err(|_| ReadFromVmgsError::InvalidFormat(file_id)),
+        HW_KEY_PROTECTOR_V3_SIZE => HardwareKeyProtectorV3::read_from_prefix(&data)
+            .map(|k| HwKeyProtector::V3(k.0)) // TODO: zerocopy: map_err (https://github.com/microsoft/openvmm/issues/759)
+            .map_err(|_| ReadFromVmgsError::InvalidFormat(file_id)),
+        size => Err(ReadFromVmgsError::EntrySizeUnexpected {
             file_id,
-            size: data.len(),
-            expected_size: HW_KEY_PROTECTOR_SIZE,
-        })?
+            size,
+            expected_size: HW_KEY_PROTECTOR_V3_SIZE,
+        }),
     }
-
-    HardwareKeyProtector::read_from_prefix(&data)
-        .map_err(|_| ReadFromVmgsError::InvalidFormat(file_id))
-        .map(|k| k.0) // TODO: zerocopy: map_err (https://github.com/microsoft/openvmm/issues/759)
 }
 
 /// Write Key Protector Id (current Id) to the VMGS file.
 pub async fn write_hardware_key_protector(
-    hardware_key_protector: &HardwareKeyProtector,
+    hardware_key_protector: &HardwareKeyProtectorV3,
     vmgs: &mut Vmgs,
 ) -> Result<(), WriteToVmgsError> {
     let file_id = FileId::HW_KEY_PROTECTOR;
@@ -287,9 +294,10 @@ mod tests {
     use openhcl_attestation_protocol::vmgs::GSP_BUFFER_SIZE;
     use openhcl_attestation_protocol::vmgs::GspKp;
     use openhcl_attestation_protocol::vmgs::HMAC_SHA_256_KEY_LENGTH;
-    use openhcl_attestation_protocol::vmgs::HW_KEY_PROTECTOR_CURRENT_VERSION;
-    use openhcl_attestation_protocol::vmgs::HW_KEY_PROTECTOR_SIZE;
-    use openhcl_attestation_protocol::vmgs::HardwareKeyProtectorHeader;
+    use openhcl_attestation_protocol::vmgs::HW_KEY_PROTECTOR_SVN_SIZE;
+    use openhcl_attestation_protocol::vmgs::HW_KEY_PROTECTOR_TEE_TYPE_SNP;
+    use openhcl_attestation_protocol::vmgs::HW_KEY_PROTECTOR_V3_SIZE;
+    use openhcl_attestation_protocol::vmgs::HardwareKeyProtectorHeaderV3;
     use openhcl_attestation_protocol::vmgs::KEY_PROTECTOR_SIZE;
     use openhcl_attestation_protocol::vmgs::KeyProtector;
     use openhcl_attestation_protocol::vmgs::KeyProtectorById;
@@ -308,18 +316,18 @@ mod tests {
         Vmgs::format_new(disk, None).await.unwrap()
     }
 
-    fn new_hardware_key_protector() -> HardwareKeyProtector {
-        let header = HardwareKeyProtectorHeader::new(
-            HW_KEY_PROTECTOR_CURRENT_VERSION,
-            HW_KEY_PROTECTOR_SIZE as u32,
-            2,
+    fn new_hardware_key_protector() -> HardwareKeyProtectorV3 {
+        let header = HardwareKeyProtectorHeaderV3::new(
+            HW_KEY_PROTECTOR_V3_SIZE as u32,
+            HW_KEY_PROTECTOR_TEE_TYPE_SNP,
+            [2; HW_KEY_PROTECTOR_SVN_SIZE],
             1,
         );
         let iv = [3; AES_CBC_IV_LENGTH];
         let ciphertext = [4; AES_GCM_KEY_LENGTH];
         let hmac = [5; HMAC_SHA_256_KEY_LENGTH];
 
-        HardwareKeyProtector {
+        HardwareKeyProtectorV3 {
             header,
             iv,
             ciphertext,
@@ -543,6 +551,9 @@ mod tests {
             .unwrap();
 
         let found_hardware_key_protector = read_hardware_key_protector(&mut vmgs).await.unwrap();
+        let HwKeyProtector::V3(found_hardware_key_protector) = found_hardware_key_protector else {
+            panic!("expected a v3 hardware key protector");
+        };
 
         assert_eq!(
             found_hardware_key_protector.header.as_bytes(),
@@ -558,8 +569,8 @@ mod tests {
             hardware_key_protector.hmac
         );
 
-        // Write and then fail to read a hardware key protector larger than the expected size to the VMGS
-        let oversized_hardware_key_protector = [8u8; HW_KEY_PROTECTOR_SIZE + 1];
+        // Write and then fail to read a hardware key protector with an unexpected size to the VMGS
+        let oversized_hardware_key_protector = [8u8; HW_KEY_PROTECTOR_V3_SIZE + 1];
         vmgs.write_file(FileId::HW_KEY_PROTECTOR, &oversized_hardware_key_protector)
             .await
             .unwrap();
@@ -567,7 +578,11 @@ mod tests {
         assert!(found_hardware_key_protector_result.is_err());
         assert_eq!(
             found_hardware_key_protector_result.unwrap_err().to_string(),
-            "HW_KEY_PROTECTOR valid bytes 105, expected 104"
+            format!(
+                "HW_KEY_PROTECTOR valid bytes {}, expected {}",
+                HW_KEY_PROTECTOR_V3_SIZE + 1,
+                HW_KEY_PROTECTOR_V3_SIZE
+            )
         );
     }
 

--- a/openhcl/underhill_core/src/emuplat/tpm.rs
+++ b/openhcl/underhill_core/src/emuplat/tpm.rs
@@ -227,7 +227,10 @@ pub mod resources {
 
             let tee_call: Option<Arc<dyn tee_call::TeeCall>> = match handle.attestation_type {
                 AttestationType::Snp => Some(Arc::new(tee_call::SnpCall)),
-                AttestationType::Tdx => Some(Arc::new(tee_call::TdxCall)),
+                // The AK cert request path only issues `get_attestation_report`
+                // and never derives hardware keys, so hardware-bound seal key
+                // enablement is irrelevant here.
+                AttestationType::Tdx => Some(Arc::new(tee_call::TdxCall::new(false))),
                 AttestationType::Vbs => Some(Arc::new(tee_call::VbsCall)),
                 AttestationType::Cca => {
                     tracing::warn!("CCA: resolve: tee_call is not implemented yet");

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -2142,7 +2142,9 @@ async fn new_underhill_vm(
 
     let tee_call: Option<Box<dyn tee_call::TeeCall>> = match isolation {
         virt::IsolationType::Snp => Some(Box::new(tee_call::SnpCall)),
-        virt::IsolationType::Tdx => Some(Box::new(tee_call::TdxCall)),
+        virt::IsolationType::Tdx => Some(Box::new(tee_call::TdxCall::new(
+            proto_partition.tdx_hw_seal_keys_enabled(),
+        ))),
         virt::IsolationType::Vbs => Some(Box::new(tee_call::VbsCall)),
         virt::IsolationType::Cca => {
             tracing::warn!("CCA: new_underhill_vm: tee_call is not implemented yet");

--- a/openhcl/virt_mshv_vtl/src/lib.rs
+++ b/openhcl/virt_mshv_vtl/src/lib.rs
@@ -1654,6 +1654,7 @@ pub struct UhProtoPartition<'a> {
     hcl: Hcl,
     guest_vsm_available: bool,
     create_partition_available: bool,
+    tdx_hw_seal_keys_enabled: bool,
     #[cfg(guest_arch = "x86_64")]
     cpuid: virt::CpuidLeafSet,
 }
@@ -1716,6 +1717,70 @@ impl<'a> UhProtoPartition<'a> {
 
         set_vtl2_vsm_partition_config(&hcl)?;
 
+        // For TDX, opt this TD into hardware-bound seal keys as early as
+        // possible (before attestation runs `TDG.MR.KEY.GET` to seal/unseal the
+        // VMGS DEK). `TD_CTLS.ENABLE_HW_SEAL_KEYS` is a prerequisite for
+        // `TDG.MR.KEY.GET`, so it must be set before
+        // `initialize_platform_security`, which runs before the partition
+        // backing (and individual VPs) are created. This is best-effort: it is
+        // a no-op on TDX modules that do not implement sealing, in which case
+        // attestation falls back to other key-protection schemes.
+        //
+        // The result is recorded so that the `tee_call` used by attestation can
+        // accurately report whether `TDG.MR.KEY.GET` is available this boot,
+        // instead of optimistically assuming support.
+        let tdx_hw_seal_keys_enabled = if params.isolation == IsolationType::Tdx {
+            // Read `TDX_FEATURES0` purely for diagnostics: it surfaces whether
+            // the module advertises sealing support so a field failure can be
+            // triaged as "module doesn't implement sealing" vs. "enable didn't
+            // stick". It does NOT gate enablement below; the authoritative check
+            // is the read-back verify inside `tdx_enable_hw_seal_keys`, since
+            // `ENABLE_HW_SEAL_KEYS` can work even when the feature bit is clear.
+            // Best-effort: older modules may not support `TDG.SYS.RD`.
+            match hcl.tdx_read_features0() {
+                Ok(features0) => {
+                    tracing::info!(
+                        CVM_ALLOWED,
+                        sealing = features0.sealing(),
+                        td_signing_and_svn = features0.td_signing_and_svn(),
+                        sealkey_128 = features0.sealkey_128(),
+                        "TDX_FEATURES0 sealing capability"
+                    );
+                }
+                Err(err) => {
+                    tracing::warn!(
+                        CVM_ALLOWED,
+                        error = u64::from(err),
+                        "failed to read TDX_FEATURES0 (TDG.SYS.RD unsupported?)"
+                    );
+                }
+            }
+
+            match hcl.tdx_enable_hw_seal_keys() {
+                Ok(true) => {
+                    tracing::info!(CVM_ALLOWED, "TDX hardware-bound seal keys enabled");
+                    true
+                }
+                Ok(false) => {
+                    tracing::info!(
+                        CVM_ALLOWED,
+                        "TDX hardware-bound seal keys not supported by the TDX module"
+                    );
+                    false
+                }
+                Err(err) => {
+                    tracing::warn!(
+                        CVM_ALLOWED,
+                        error = u64::from(err),
+                        "failed to enable TDX hardware-bound seal keys"
+                    );
+                    false
+                }
+            }
+        } else {
+            false
+        };
+
         let privs = hcl
             .get_privileges_and_features_info()
             .map_err(Error::GetReg)?;
@@ -1769,6 +1834,7 @@ impl<'a> UhProtoPartition<'a> {
             params: UhPartitionNewParams { vtom, ..*params },
             guest_vsm_available,
             create_partition_available: privs.create_partitions(),
+            tdx_hw_seal_keys_enabled,
             #[cfg(guest_arch = "x86_64")]
             cpuid,
         })
@@ -1785,6 +1851,13 @@ impl<'a> UhProtoPartition<'a> {
         self.create_partition_available
     }
 
+    /// Returns whether TDX hardware-bound seal keys were successfully enabled
+    /// for this TD (always `false` for non-TDX isolation). When `true`, the
+    /// `TDG.MR.KEY.GET` TDCALL is available for deriving hardware-bound keys.
+    pub fn tdx_hw_seal_keys_enabled(&self) -> bool {
+        self.tdx_hw_seal_keys_enabled
+    }
+
     /// Returns a new Underhill partition.
     pub async fn build(
         self,
@@ -1795,6 +1868,7 @@ impl<'a> UhProtoPartition<'a> {
             params,
             guest_vsm_available,
             create_partition_available: _,
+            tdx_hw_seal_keys_enabled: _,
             #[cfg(guest_arch = "x86_64")]
             cpuid,
         } = self;

--- a/support/tdx_guest_device/src/lib.rs
+++ b/support/tdx_guest_device/src/lib.rs
@@ -9,7 +9,9 @@
 use std::fs::File;
 use std::os::fd::AsRawFd;
 use thiserror::Error;
+use x86defs::tdx::TDX_DERIVED_KEY_SIZE;
 use x86defs::tdx::TDX_REPORT_DATA_SIZE;
+use x86defs::tdx::TdKeyRequest;
 use x86defs::tdx::TdReport;
 use zerocopy::FromZeros;
 
@@ -23,6 +25,8 @@ pub enum Error {
     OpenDevTdxGuest(#[source] std::io::Error),
     #[error("TDX_CMD_GET_REPORT0 ioctl failed")]
     TdxGetReportIoctl(#[source] nix::Error),
+    #[error("TDX_CMD_KEY_GET ioctl failed with TDCALL error code {1:#x}")]
+    TdxGetDerivedKeyIoctl(#[source] nix::Error, u64),
 }
 
 /// Ioctl struct defined by Linux.
@@ -34,12 +38,31 @@ struct TdxReportReq {
     td_report: TdReport,
 }
 
+/// Ioctl struct defined by Linux for `TDX_CMD_KEY_GET` (`struct tdx_key_get_req`).
+#[repr(C)]
+struct TdxKeyGetReq {
+    /// `TDKEYREQUEST` input passed to the `TDG.MR.KEY.GET` TDCALL.
+    key_request: TdKeyRequest,
+    /// The derived key output.
+    derived_key: [u8; TDX_DERIVED_KEY_SIZE],
+    /// `TDG.MR.KEY.GET` TDCALL return error code.
+    err_code: u64,
+}
+
 nix::ioctl_readwrite!(
     /// `TDX_CMD_GET_REPORT0` ioctl defined by Linux.
     tdx_get_report0,
     TDX_CMD_GET_REPORT0_IOC_TYPE,
     0x1,
     TdxReportReq
+);
+
+nix::ioctl_readwrite!(
+    /// `TDX_CMD_KEY_GET` ioctl defined by Linux.
+    tdx_key_get,
+    TDX_CMD_GET_REPORT0_IOC_TYPE,
+    0x5,
+    TdxKeyGetReq
 );
 
 /// Abstraction of the /dev/tdx_guest device.
@@ -73,5 +96,30 @@ impl TdxGuestDevice {
         }
 
         Ok(tdx_report_request.td_report)
+    }
+
+    /// Invoke the `TDX_CMD_KEY_GET` ioctl via the device to derive a persistent
+    /// key bound to the TD's measurements and policy using the `TDG.MR.KEY.GET`
+    /// TDCALL.
+    pub fn get_derived_key(
+        &self,
+        key_request: &TdKeyRequest,
+    ) -> Result<[u8; TDX_DERIVED_KEY_SIZE], Error> {
+        let mut tdx_key_get_request = TdxKeyGetReq {
+            key_request: *key_request,
+            derived_key: [0u8; TDX_DERIVED_KEY_SIZE],
+            err_code: 0,
+        };
+
+        // SAFETY: Make TDX_CMD_KEY_GET ioctl call to the device with correct types.
+        // The ioctl is encoded as read-write (`_IOWR`): the kernel reads the
+        // `TDKEYREQUEST` input and writes the derived key and error code back
+        // through the same structure.
+        unsafe {
+            tdx_key_get(self.file.as_raw_fd(), &mut tdx_key_get_request)
+                .map_err(|e| Error::TdxGetDerivedKeyIoctl(e, tdx_key_get_request.err_code))?;
+        }
+
+        Ok(tdx_key_get_request.derived_key)
     }
 }

--- a/vm/devices/get/test_igvm_agent_rpc_server/src/rpc/igvm_agent.rs
+++ b/vm/devices/get/test_igvm_agent_rpc_server/src/rpc/igvm_agent.rs
@@ -169,11 +169,27 @@ fn resolve_test_config(vm_name: &str) -> Option<IgvmAgentTestSetting> {
             IgvmAttestTestConfig::KeyReleaseFailureSkipHwUnsealing,
         ),
         (
+            "ubuntu_2504_server_x64_tdx_skip_hw_unseal",
+            IgvmAttestTestConfig::KeyReleaseFailureSkipHwUnsealing,
+        ),
+        (
+            "windows_datacenter_core_2025_x64_prepped_tdx_skip_hw_unseal",
+            IgvmAttestTestConfig::KeyReleaseFailureSkipHwUnsealing,
+        ),
+        (
             "ubuntu_2504_server_x64_snp_use_hw_unseal",
             IgvmAttestTestConfig::KeyReleaseFailure,
         ),
         (
             "windows_datacenter_core_2025_x64_prepped_snp_use_hw_unseal",
+            IgvmAttestTestConfig::KeyReleaseFailure,
+        ),
+        (
+            "ubuntu_2504_server_x64_tdx_use_hw_unseal",
+            IgvmAttestTestConfig::KeyReleaseFailure,
+        ),
+        (
+            "windows_datacenter_core_2025_x64_prepped_tdx_use_hw_unseal",
             IgvmAttestTestConfig::KeyReleaseFailure,
         ),
         (
@@ -206,6 +222,14 @@ fn resolve_test_config(vm_name: &str) -> Option<IgvmAgentTestSetting> {
         ),
         (
             "windows_datacenter_core_2025_x64_prepped_snp_hw_ak_stable",
+            IgvmAttestTestConfig::StateRefresh,
+        ),
+        (
+            "ubuntu_2504_server_x64_tdx_hw_ak_stable",
+            IgvmAttestTestConfig::StateRefresh,
+        ),
+        (
+            "windows_datacenter_core_2025_x64_prepped_tdx_hw_ak_stable",
             IgvmAttestTestConfig::StateRefresh,
         ),
     ];

--- a/vm/x86/tdcall/src/lib.rs
+++ b/vm/x86/tdcall/src/lib.rs
@@ -799,6 +799,71 @@ pub fn tdcall_vp_rd(
     }
 }
 
+/// Issue a TDG.VM.WR call to write a TD-scope metadata field (e.g. `TD_CTLS`).
+///
+/// `field_code` is the field code to use for the call.
+///
+/// `value` is the value to set, with `mask` being the mask controlling which
+/// bits will be set from `value`, as specified by the TDX API.
+///
+/// Returns the old value of the field.
+pub fn tdcall_vm_wr(
+    call: &mut impl Tdcall,
+    field_code: TdxExtendedFieldCode,
+    value: u64,
+    mask: u64,
+) -> Result<u64, TdCallResult> {
+    let input = TdcallInput {
+        leaf: TdCallLeaf::VM_WR,
+        rcx: 0,
+        rdx: field_code.into(),
+        r8: value,
+        r9: mask,
+        r10: 0,
+        r11: 0,
+        r12: 0,
+        r13: 0,
+        r14: 0,
+        r15: 0,
+    };
+
+    let output = call.tdcall(input);
+
+    match output.rax.code() {
+        TdCallResultCode::SUCCESS => Ok(output.r8),
+        _ => Err(output.rax),
+    }
+}
+
+/// Issue a TDG.SYS.RD call to read a global-scope TDX module metadata field
+/// (e.g. `TDX_FEATURES0`).
+///
+/// `field_id` is the metadata field ID to read.
+///
+/// Returns the field value.
+pub fn tdcall_sys_rd(call: &mut impl Tdcall, field_id: u64) -> Result<u64, TdCallResult> {
+    let input = TdcallInput {
+        leaf: TdCallLeaf::SYS_RD,
+        rcx: 0,
+        rdx: field_id,
+        r8: 0,
+        r9: 0,
+        r10: 0,
+        r11: 0,
+        r12: 0,
+        r13: 0,
+        r14: 0,
+        r15: 0,
+    };
+
+    let output = call.tdcall(input);
+
+    match output.rax.code() {
+        TdCallResultCode::SUCCESS => Ok(output.r8),
+        _ => Err(output.rax),
+    }
+}
+
 /// Issue a TDG.VP.INVGLA call.
 pub fn tdcall_vp_invgla(
     call: &mut impl Tdcall,

--- a/vm/x86/x86defs/src/tdx.rs
+++ b/vm/x86/x86defs/src/tdx.rs
@@ -21,6 +21,13 @@ pub const TDX_REPORT_SIZE: usize = 0x400;
 /// Size of `report_data` member in [`ReportMac`].
 pub const TDX_REPORT_DATA_SIZE: usize = 64;
 
+/// Size of the `TDKEYREQUEST` structure ([`TdKeyRequest`]) that is passed as the
+/// input to the `TDG.MR.KEY.GET` TDCALL.
+pub const TDX_TDKEYREQUEST_SIZE: usize = 128;
+
+/// Maximum size of the key derived by the `TDG.MR.KEY.GET` TDCALL (256 bits).
+pub const TDX_DERIVED_KEY_SIZE: usize = 32;
+
 open_enum! {
     /// TDCALL instruction leafs that are passed into the tdcall instruction
     /// in eax.
@@ -36,10 +43,12 @@ open_enum! {
         VM_WR = 8,
         VP_RD = 9,
         VP_WR = 10,
+        SYS_RD = 11,
         MEM_PAGE_ATTR_RD = 23,
         MEM_PAGE_ATTR_WR = 24,
         VP_ENTER = 25,
         VP_INVGLA = 27,
+        MR_KEY_GET = 29,
         MEM_PAGE_RELEASE = 30,
     }
 }
@@ -534,6 +543,64 @@ pub const TDX_FIELD_CODE_L2_CTLS_VM2: TdxExtendedFieldCode =
 pub const TDX_FIELD_CODE_CONFIG_FLAGS: TdxExtendedFieldCode =
     TdxExtendedFieldCode(0x9110000300000016);
 
+/// Field code for the TDCS `TD_CTLS` TD-scope metadata field, accessed via
+/// TDG.VM.RD and TDG.VM.WR.
+pub const TDX_FIELD_CODE_TD_CTLS: TdxExtendedFieldCode = TdxExtendedFieldCode(0x1110000300000017);
+
+/// Metadata field ID for the global-scope `TDX_FEATURES0` field, read by the
+/// guest via the `TDG.SYS.RD` TDCALL.
+pub const TDX_FIELD_ID_TDX_FEATURES0: u64 = 0x0A00000300000008;
+
+/// The global-scope `TDX_FEATURES0` metadata field, enumerating optional TDX
+/// module features. Read by the guest via `TDG.SYS.RD`
+/// ([`TdCallLeaf::SYS_RD`]).
+///
+/// Only the bits relevant to hardware-bound sealing are modeled here; the
+/// remaining bits are documented by the Intel TDX Module ABI specification.
+#[bitfield(u64)]
+#[derive(PartialEq, Eq)]
+pub struct TdxFeatures0 {
+    #[bits(12)]
+    _reserved0: u64,
+    /// `SEALING` (bit 12) - the TDX module supports signed TDs and seal keys
+    /// bound to TD properties, exposing the `TDG.MR.KEY.GET` interface.
+    pub sealing: bool,
+    #[bits(9)]
+    _reserved1: u64,
+    /// `TD_SIGNING_AND_SVN` (bit 22) - prerequisite support that `SEALING`
+    /// depends on.
+    pub td_signing_and_svn: bool,
+    #[bits(27)]
+    _reserved2: u64,
+    /// `SEALKEY_128` (bit 50) - enumerates the seal key size.
+    pub sealkey_128: bool,
+    #[bits(13)]
+    _reserved3: u64,
+}
+
+/// The TDCS `TD_CTLS` TD-scope control field, accessed via TDG.VM.RD and
+/// TDG.VM.WR.
+#[bitfield(u64)]
+#[derive(PartialEq, Eq)]
+pub struct TdCtls {
+    /// `PENDING_VE_DISABLE`
+    pub pending_ve_disable: bool,
+    /// `ENUM_TOPOLOGY`
+    pub enum_topology: bool,
+    /// `VIRT_CPUID2`
+    pub virt_cpuid2: bool,
+    /// `REDUCE_VE`
+    pub reduce_ve: bool,
+    /// `ENABLE_HW_SEAL_KEYS` - opts the TD into hardware-bound seal keys
+    /// returned by `TDG.MR.KEY.GET`, even when
+    /// `CONFIG_FLAGS.SEAL_KEY_SUPPORT` is not set.
+    pub enable_hw_seal_keys: bool,
+    #[bits(58)]
+    _reserved: u64,
+    /// `LOCK` - once set, `TD_CTLS` becomes read-only.
+    pub lock: bool,
+}
+
 /// Extended field code for the Metadata Access Interface TDCalls:
 /// TDG.VP.WR, TDG.VP.RD, TDG.VM.WR, TDG.VM.RD
 #[bitfield(u64)]
@@ -867,3 +934,89 @@ pub struct TdInfoBase {
     /// SHA384 of the `TDINFO_STRUCTs` of bound service TDs if there is any.
     pub servd_hash: [u8; 48],
 }
+
+/// Selects which TD-specific measurement and configuration registers are mixed
+/// into the key derived by the `TDG.MR.KEY.GET` TDCALL. This is the analog of
+/// SNP's [`GuestFieldSelect`](crate::snp::GuestFieldSelect).
+///
+/// See `TDKEYPOLICY`, Table 2-2, "System Architecture Specification: Sealing
+/// Support for Intel TDX", Revision 0.7, September 2025.
+#[bitfield(u64)]
+#[derive(IntoBytes, Immutable, KnownLayout, FromBytes)]
+pub struct TdxKeyPolicy {
+    /// Include `MRTD` (bit 0).
+    pub mr_td: bool,
+    /// Reserved (bit 1).
+    _reserved0: bool,
+    /// Include `MROWNER` (bit 2).
+    pub mr_owner: bool,
+    /// Include `MRCONFIGID` (bit 3).
+    pub mr_config_id: bool,
+    /// Include `MROWNERCONFIG` (bit 4).
+    pub mr_owner_config: bool,
+    /// Reserved (bits 31:5).
+    #[bits(27)]
+    _reserved1: u32,
+    /// `RTMR` selection (bits 47:32). Bits 4:0 select `RTMR n`, bits 7:5 are
+    /// reserved and must be zero.
+    #[bits(16)]
+    pub rtmr: u16,
+    /// Reserved (bits 63:48), must be zero.
+    #[bits(16)]
+    _reserved2: u16,
+}
+
+/// `KEYNAME` value for [`TdKeyRequest::key_name`] that requests a seal key.
+pub const TDX_KEY_NAME_SEAL: u16 = 0;
+
+/// `KEYSIZE` value for [`TdKeyRequest::key_size`] selecting a 128-bit key.
+pub const TDX_KEY_SIZE_128: u8 = 0;
+
+/// `KEYSIZE` value for [`TdKeyRequest::key_size`] selecting a 256-bit key.
+pub const TDX_KEY_SIZE_256: u8 = 1;
+
+/// Request structure (`TDKEYREQUEST`) that is passed as the input to the
+/// `TDG.MR.KEY.GET` TDCALL to derive a persistent key bound to the TD's
+/// measurements and policy.
+///
+/// See `TDKEYREQUEST`, Table 2-1, "System Architecture Specification: Sealing
+/// Support for Intel TDX", Revision 0.7, September 2025.
+#[repr(C)]
+#[derive(Debug, Clone, Copy, IntoBytes, Immutable, KnownLayout, FromBytes)]
+pub struct TdKeyRequest {
+    /// `KEYNAME` - Identifies the key being requested. See
+    /// [`TDX_KEY_NAME_SEAL`].
+    pub key_name: u16,
+    /// `SWKEYNAME` - TD software-assigned key name/identifier.
+    pub sw_key_name: u8,
+    /// `KEYSIZE` - Requested key size. See [`TDX_KEY_SIZE_128`] and
+    /// [`TDX_KEY_SIZE_256`].
+    pub key_size: u8,
+    /// Reserved.
+    pub _reserved0: [u8; 4],
+    /// `KEYPOLICY` - Selects which measurement and configuration registers are
+    /// mixed into the derived key.
+    pub key_policy: TdxKeyPolicy,
+    /// `ATTRIBUTESMASK` - Mask applied to `TDCS.ATTRIBUTES` before mixing into
+    /// the key.
+    pub attributes_mask: u64,
+    /// `XFAMMASK` - Mask applied to `TDCS.XFAM` before mixing into the key.
+    pub xfam_mask: u64,
+    /// `CPUSVN`
+    pub cpu_svn: [u8; 16],
+    /// `TEE_TCB_SVN`
+    pub tee_tcb_svn: [u8; 16],
+    /// `ISVSVN`
+    pub isv_svn: u16,
+    /// `MRCONFIGSVN`
+    pub mr_config_svn: u16,
+    /// `MROWNERCONFIGSVN`
+    pub mr_owner_config_svn: u16,
+    /// `SALT` - Caller-supplied salt mixed into the derived key, allowing the
+    /// same TD to derive multiple distinct keys.
+    pub salt: [u8; 32],
+    /// Reserved.
+    pub _reserved1: [u8; 26],
+}
+
+static_assertions::const_assert_eq!(TDX_TDKEYREQUEST_SIZE, size_of::<TdKeyRequest>());

--- a/vmm_tests/vmm_tests/tests/tests/multiarch/tpm.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch/tpm.rs
@@ -983,7 +983,9 @@ async fn ak_pub_refresh<T, S, U: PetriVmmBackend>(
 /// test function (`skip_hw_unseal`), they all map to
 /// `KeyReleaseFailureSkipHwUnsealing`.
 #[cfg(windows)]
-#[vmm_test_with(unstable(reason = "SNP hardware-unseal key-release test is unreliable in CI; awaiting a fix"), configs(
+#[vmm_test_with(unstable(reason = "hardware-unseal key-release test is unreliable in CI; awaiting a fix"), configs(
+    hyperv_openhcl_uefi_x64[tdx](vhd(ubuntu_2504_server_x64))[TEST_IGVM_AGENT_RPC_SERVER_WINDOWS_X64],
+    hyperv_openhcl_uefi_x64[tdx](vhd(windows_datacenter_core_2025_x64_prepped))[TEST_IGVM_AGENT_RPC_SERVER_WINDOWS_X64],
     hyperv_openhcl_uefi_x64[snp](vhd(ubuntu_2504_server_x64))[TEST_IGVM_AGENT_RPC_SERVER_WINDOWS_X64],
     hyperv_openhcl_uefi_x64[snp](vhd(windows_datacenter_core_2025_x64_prepped))[TEST_IGVM_AGENT_RPC_SERVER_WINDOWS_X64],
 ))]
@@ -1067,6 +1069,8 @@ async fn skip_hw_unseal<T, U: PetriVmmBackend>(
 /// `KeyReleaseFailure`.
 #[cfg(windows)]
 #[vmm_test_with(unstable(reason = "SNP hardware-unseal key-release test is unreliable in CI; awaiting a fix"), configs(
+    hyperv_openhcl_uefi_x64[tdx](vhd(ubuntu_2504_server_x64))[TPM_GUEST_TESTS_LINUX_X64, TEST_IGVM_AGENT_RPC_SERVER_WINDOWS_X64],
+    hyperv_openhcl_uefi_x64[tdx](vhd(windows_datacenter_core_2025_x64_prepped))[TPM_GUEST_TESTS_WINDOWS_X64, TEST_IGVM_AGENT_RPC_SERVER_WINDOWS_X64],
     hyperv_openhcl_uefi_x64[snp](vhd(ubuntu_2504_server_x64))[TPM_GUEST_TESTS_LINUX_X64, TEST_IGVM_AGENT_RPC_SERVER_WINDOWS_X64],
     hyperv_openhcl_uefi_x64[snp](vhd(windows_datacenter_core_2025_x64_prepped))[TPM_GUEST_TESTS_WINDOWS_X64, TEST_IGVM_AGENT_RPC_SERVER_WINDOWS_X64],
 ))]
@@ -1200,6 +1204,8 @@ const TEST_NV_DATA_HEX: &str = "0xdeadbeefcafebabe0102030405060708090a0b0c0d0e0f
 /// Second boot: read the same NV index and verify data persisted.
 #[cfg(windows)]
 #[vmm_test(
+    hyperv_openhcl_uefi_x64[tdx](vhd(ubuntu_2504_server_x64))[TPM_GUEST_TESTS_LINUX_X64, TEST_IGVM_AGENT_RPC_SERVER_WINDOWS_X64],
+    hyperv_openhcl_uefi_x64[tdx](vhd(windows_datacenter_core_2025_x64_prepped))[TPM_GUEST_TESTS_WINDOWS_X64, TEST_IGVM_AGENT_RPC_SERVER_WINDOWS_X64],
     hyperv_openhcl_uefi_x64[snp](vhd(ubuntu_2504_server_x64))[TPM_GUEST_TESTS_LINUX_X64, TEST_IGVM_AGENT_RPC_SERVER_WINDOWS_X64],
     hyperv_openhcl_uefi_x64[snp](vhd(windows_datacenter_core_2025_x64_prepped))[TPM_GUEST_TESTS_WINDOWS_X64, TEST_IGVM_AGENT_RPC_SERVER_WINDOWS_X64],
 )]
@@ -1285,6 +1291,11 @@ async fn hw_seal_hash<T, S, U: PetriVmmBackend>(
 ///
 /// Same as `hw_seal_hash` but uses `HardwareSealedSecretsSignerPolicy`
 /// instead.
+///
+/// SNP-only: TDX has no signer/identity key-policy register to bind a
+/// measurement-independent key to, so OpenHCL refuses signer-based hardware
+/// sealing on TDX (see `TdxCall::get_derived_key`). Do not add TDX configs
+/// here.
 #[cfg(windows)]
 #[vmm_test(
     hyperv_openhcl_uefi_x64[snp](vhd(ubuntu_2504_server_x64))[TPM_GUEST_TESTS_LINUX_X64, TEST_IGVM_AGENT_RPC_SERVER_WINDOWS_X64],
@@ -1386,6 +1397,8 @@ async fn hw_seal_signer<T, S, U: PetriVmmBackend>(
 /// stateless + hardware sealing CVM keeps it stable.
 #[cfg(windows)]
 #[vmm_test(
+    hyperv_openhcl_uefi_x64[tdx](vhd(ubuntu_2504_server_x64))[TPM_GUEST_TESTS_LINUX_X64, TEST_IGVM_AGENT_RPC_SERVER_WINDOWS_X64],
+    hyperv_openhcl_uefi_x64[tdx](vhd(windows_datacenter_core_2025_x64_prepped))[TPM_GUEST_TESTS_WINDOWS_X64, TEST_IGVM_AGENT_RPC_SERVER_WINDOWS_X64],
     hyperv_openhcl_uefi_x64[snp](vhd(ubuntu_2504_server_x64))[TPM_GUEST_TESTS_LINUX_X64, TEST_IGVM_AGENT_RPC_SERVER_WINDOWS_X64],
     hyperv_openhcl_uefi_x64[snp](vhd(windows_datacenter_core_2025_x64_prepped))[TPM_GUEST_TESTS_WINDOWS_X64, TEST_IGVM_AGENT_RPC_SERVER_WINDOWS_X64],
 )]


### PR DESCRIPTION
Add support for deriving a hardware-bound sealing key on Intel TDX,
mirroring the existing SNP get_derived_key path so that OpenHCL can seal
the VMGS DEK to a hardware-derived key on TDX.
    
- x86defs: add TDX TDKEYREQUEST layout, key policy/feature bitfields, and
      the TDG.MR.KEY.GET / TDG.SYS.RD leaf and field-code definitions.
- tdx_guest_device: add get_derived_key wrapping the TDX_CMD_KEY_GET
      ioctl (_IOWR('T', 5)) to invoke TDG.MR.KEY.GET.
- tdcall: add tdcall_vm_wr / tdcall_sys_rd (TD_CTLS / TDX_FEATURES0)
      helpers.
- hcl: add tdx_enable_hw_seal_keys (sets TD_CTLS.ENABLE_HW_SEAL_KEYS via a
      masked VM.WR with read-back verify) and tdx_read_features0.
- virt_mshv_vtl: read TDX_FEATURES0 and enable hardware seal keys during
      UhProtoPartition::new, recording whether enablement succeeded.
- tee_call: implement TeeCallGetDerivedKey for TdxCall, building a
      TDKEYREQUEST bound to MRTD with the recorded TEE_TCB_SVN and CPU_SVN for
      anti-rollback. SVN material is carried in a TEE-tagged KeyDerivationSvn
      enum (Snp { tcb_version } / Tdx { tee_tcb_svn, cpu_svn }) rather than a
      lossy u64, so both TDX report SVNs are bound verbatim. TDX hardware-bound
      seal keys are opt-in at runtime, so TdxCall carries an hw_seal_keys_enabled
      flag (threaded from UhProtoPartition) and supports_get_derived_key is gated
      on it, unlike SNP where key derivation is always available. The TPM AK-cert
      path constructs TdxCall::new(false) since it only issues
      get_attestation_report. Signer (measurement-independent) sealing is
      rejected on TDX, which has no identity key-policy register to bind to when
      MRTD is cleared.
- openhcl_attestation_protocol: add a unified, TEE-tagged HW_KEY_PROTECTOR
      v3 format (HardwareKeyProtectorV3) that records the raw report SVNs so the
      derived key can bind every SVN the TEE mixes in. v3 is now the current
      version for all newly-created protectors (SNP and TDX); v2 is retained
      read-only for legacy SNP protectors and is migrated to v3 on the next
      reseal.
- underhill_attestation: read either the legacy (v1/v2) or v3 protector via
      the HwKeyProtector enum, always seal as v3, reject signer-based sealing on
      TDX at the high level (defense in depth with the tee_call guard), and add
      INFO logging around hardware key sealing.
