### PR TITLE
Revert "Zero pad trailing data when importing file regions (#4197)"

### DIFF
--- a/vm/loader/src/common.rs
+++ b/vm/loader/src/common.rs
@@ -354,19 +354,18 @@ impl ChunkBuf {
                 0
             };
             let data_len = file_remaining.min((chunk_bytes - data_start) as u64) as usize;
-            let data_end = data_start + data_len;
 
-            // Zero the leading padding on the first chunk, and the trailing
-            // bytes of this chunk.
+            // Zero leading padding on the first chunk.
             chunk_buf[..data_start].fill(0);
-            file.read_exact(&mut chunk_buf[data_start..data_end])
+
+            // Read file data.
+            file.read_exact(&mut chunk_buf[data_start..data_start + data_len])
                 .map_err(ImportFileRegionError::Read)?;
-            chunk_buf[data_end..].fill(0);
 
             file_remaining -= data_len as u64;
 
             // On the last chunk with file data, extend page_count to cover all
-            // remaining pages.
+            // remaining pages. import_pages will zero beyond the data.
             let import_page_count = if file_remaining == 0 {
                 total_page_count - pages_done
             } else {
@@ -379,7 +378,7 @@ impl ChunkBuf {
                     import_page_count,
                     tag,
                     acceptance,
-                    chunk_buf,
+                    &chunk_buf[..data_start + data_len],
                 )
                 .map_err(ImportFileRegionError::ImportPages)?;
 


### PR DESCRIPTION
Change isn't needed 