### PR TITLE
virtio: notify when a packed completion passes the armed position

### DIFF
--- a/vm/devices/virtio/virtio/src/queue/packed.rs
+++ b/vm/devices/virtio/virtio/src/queue/packed.rs
@@ -245,13 +245,17 @@ impl PackedQueueCompleteWork {
         // notification, so advance first and keep the start.
         let start = self.next_index;
         let start_wrap = self.wrapped_bit;
-        // Wraps at most once (see `advance`); compare-and-subtract avoids a modulo.
-        let raw = start + context.descriptor_count;
-        self.next_index = if raw >= self.queue_size {
+        // The un-wrapped end of the range, computed in u32 because the u16 sum has no
+        // headroom: `start + descriptor_count` reaches `2 * queue_size - 1`, which is
+        // exactly `u16::MAX` at the largest ring the spec allows.
+        let end = u32::from(start) + u32::from(context.descriptor_count);
+        // Wraps at most once (see `advance`); compare-and-subtract avoids a modulo. Both
+        // arms are reduced into the ring, so they fit u16.
+        self.next_index = if end >= u32::from(self.queue_size) {
             self.wrapped_bit = !self.wrapped_bit;
-            raw - self.queue_size
+            (end - u32::from(self.queue_size)) as u16
         } else {
-            raw
+            end as u16
         };
         let send_signal = match driver_event.flags() {
             EventSuppressionFlags::Disabled => false,
@@ -261,7 +265,7 @@ impl PackedQueueCompleteWork {
                     driver_event.wrap(),
                     start,
                     start_wrap,
-                    raw,
+                    end,
                     self.queue_size,
                 )
             }
@@ -297,20 +301,20 @@ fn armed_position_passed(
     event_wrap: bool,
     start: u16,
     start_wrap: bool,
-    end: u16,
+    end: u32,
     queue_size: u16,
 ) -> bool {
     // `end` is deliberately NOT reduced modulo the ring: it is the un-wrapped end of the range,
     // so a completion that crosses the lap boundary stays comparable with a lifted armed
-    // position. Widen to u32 first - `event_offset + queue_size` overflows u16 near the top of
-    // a large ring.
+    // position. That is why it is a u32, along with the armed position below, which is lifted
+    // by a ring and would overflow u16 near the top of a large one.
     let armed = u32::from(event_offset)
         + if event_wrap == start_wrap {
             0
         } else {
             u32::from(queue_size)
         };
-    (u32::from(start)..u32::from(end)).contains(&armed)
+    (u32::from(start)..end).contains(&armed)
 }
 
 #[cfg(test)]

--- a/vm/devices/virtio/virtio/src/queue/packed.rs
+++ b/vm/devices/virtio/virtio/src/queue/packed.rs
@@ -241,21 +241,126 @@ impl PackedQueueCompleteWork {
             .driver_event
             .read_plain(0)
             .map_err(QueueError::Memory)?;
-        let send_signal = match driver_event.flags() {
-            EventSuppressionFlags::Disabled => false,
-            EventSuppressionFlags::DescriptorIndex if self.use_event_index => {
-                driver_event.offset() == self.next_index && driver_event.wrap() == self.wrapped_bit
-            }
-            _ => true,
-        };
+        // Both ends of the range this completion covers are needed to decide the
+        // notification, so advance first and keep the start.
+        let start = self.next_index;
+        let start_wrap = self.wrapped_bit;
         // Wraps at most once (see `advance`); compare-and-subtract avoids a modulo.
-        let raw = self.next_index + context.descriptor_count;
+        let raw = start + context.descriptor_count;
         self.next_index = if raw >= self.queue_size {
             self.wrapped_bit = !self.wrapped_bit;
             raw - self.queue_size
         } else {
             raw
         };
+        let send_signal = match driver_event.flags() {
+            EventSuppressionFlags::Disabled => false,
+            EventSuppressionFlags::DescriptorIndex if self.use_event_index => {
+                armed_position_passed(
+                    driver_event.offset(),
+                    driver_event.wrap(),
+                    start,
+                    start_wrap,
+                    raw,
+                    self.queue_size,
+                )
+            }
+            _ => true,
+        };
         Ok(send_signal)
+    }
+}
+
+/// Whether a completion covering the descriptors `[start, end)` reaches or passes the ring
+/// position the driver armed at.
+///
+/// The driver publishes the position it wants to be woken AT OR PAST (VIRTIO 1.3 section
+/// 2.8.10, "Event Suppression Structure Format"), so this is CONTAINMENT of that position in
+/// the completed range, never equality with either endpoint. Equality is right only while every
+/// completion advances by exactly one descriptor - which is why it survived so long: at
+/// `descriptor_count == 1` the two agree on every input. A chained completion (virtio-net
+/// receive, a virtio-blk header/data/status chain) steps OVER the armed position without
+/// landing on it, and the driver is then never woken for a request the device has already
+/// finished. It waits forever while the device reports itself idle.
+///
+/// Linux makes that the common case rather than a corner: `virtqueue_enable_cb_delayed_packed`
+/// arms at `last_used + 3/4 of the in-flight count`, deliberately far ahead of the next
+/// descriptor.
+///
+/// Positions are compared in a lap-extended space anchored at `start`: `end` is
+/// `start + descriptor_count` and may run past `queue_size` when the completion wraps, and an
+/// armed position whose wrap counter belongs to the next lap is lifted by one ring. The
+/// equivalent modular arithmetic over `u16` is harder to read at the wrap boundary, which is
+/// where this is easiest to get wrong.
+fn armed_position_passed(
+    event_offset: u16,
+    event_wrap: bool,
+    start: u16,
+    start_wrap: bool,
+    end: u16,
+    queue_size: u16,
+) -> bool {
+    // `end` is deliberately NOT reduced modulo the ring: it is the un-wrapped end of the range,
+    // so a completion that crosses the lap boundary stays comparable with a lifted armed
+    // position. Widen to u32 first - `event_offset + queue_size` overflows u16 near the top of
+    // a large ring.
+    let armed = u32::from(event_offset)
+        + if event_wrap == start_wrap {
+            0
+        } else {
+            u32::from(queue_size)
+        };
+    (u32::from(start)..u32::from(end)).contains(&armed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::armed_position_passed;
+
+    /// A small ring, so a completion can be placed right at the lap boundary.
+    const RING: u16 = 8;
+
+    /// The case the integration test drives end to end, pinned here at the boundary itself:
+    /// a chain completes 5 and 6 in one step, and a driver armed at 6 must be woken even
+    /// though the used position never equals 6 - it goes from 5 straight to 7.
+    #[test]
+    fn a_chain_that_steps_over_the_armed_position_notifies() {
+        assert!(armed_position_passed(6, true, 5, true, 7, RING));
+        // The landing case still holds: armed exactly where the completion starts.
+        assert!(armed_position_passed(5, true, 5, true, 6, RING));
+    }
+
+    /// A completion that crosses the ring boundary must still wake a driver armed just past
+    /// it, which is only possible if the armed position is lifted by one ring: the driver
+    /// publishes it with the NEXT lap's wrap counter, so raw offset 0 sits AHEAD of start 7,
+    /// not six descriptors behind it. Getting this wrong is invisible until a queue happens
+    /// to wrap mid-chain, and then it hangs the same way.
+    #[test]
+    fn a_completion_crossing_the_ring_boundary_notifies_for_the_next_lap() {
+        // start 7 (wrap true), a 2-descriptor chain -> un-wrapped end 9, covering 7 and 8(=0').
+        assert!(armed_position_passed(0, false, 7, true, 9, RING));
+        // With the armed position one short of being covered, there is nothing to announce
+        // yet - the boundary has to hold from both sides.
+        assert!(!armed_position_passed(1, false, 7, true, 9, RING));
+    }
+
+    /// An armed position the device has ALREADY passed in this lap earns no notification:
+    /// it was announced when it was covered, and re-announcing it would be a spurious
+    /// interrupt on every later completion. This is the branch a naive "armed <= end" test
+    /// would get wrong, and no chained test would catch it.
+    #[test]
+    fn an_armed_position_already_behind_the_device_does_not_notify() {
+        assert!(!armed_position_passed(2, true, 5, true, 6, RING));
+        // Nor when the completion is a long chain that ends well past it.
+        assert!(!armed_position_passed(0, true, 4, true, 8, RING));
+    }
+
+    /// The boundary is half-open at BOTH ends, which is what keeps a wake from firing one
+    /// completion early: the range covers the descriptors completed, not the position the
+    /// device will write next.
+    #[test]
+    fn the_position_the_device_will_write_next_is_not_yet_covered() {
+        assert!(!armed_position_passed(6, true, 5, true, 6, RING));
+        assert!(!armed_position_passed(0, false, 7, true, 8, RING));
     }
 }

--- a/vm/devices/virtio/virtio/src/queue/packed.rs
+++ b/vm/devices/virtio/virtio/src/queue/packed.rs
@@ -241,134 +241,82 @@ impl PackedQueueCompleteWork {
             .driver_event
             .read_plain(0)
             .map_err(QueueError::Memory)?;
-        // Both ends of the range this completion covers are needed to decide the
-        // notification, so advance first and keep the start.
         let start = self.next_index;
-        let start_wrap = self.wrapped_bit;
-        // The un-wrapped end of the range, computed in u32 because the u16 sum has no
-        // headroom: `start + descriptor_count` reaches `2 * queue_size - 1`, which is
-        // exactly `u16::MAX` at the largest ring the spec allows.
-        let end = u32::from(start) + u32::from(context.descriptor_count);
-        // Wraps at most once (see `advance`); compare-and-subtract avoids a modulo. Both
-        // arms are reduced into the ring, so they fit u16.
-        self.next_index = if end >= u32::from(self.queue_size) {
-            self.wrapped_bit = !self.wrapped_bit;
-            (end - u32::from(self.queue_size)) as u16
-        } else {
-            end as u16
-        };
+        // Keep the endpoint unwrapped so a completion can cross the ring boundary.
+        let end = start + context.descriptor_count;
         let send_signal = match driver_event.flags() {
             EventSuppressionFlags::Disabled => false,
             EventSuppressionFlags::DescriptorIndex if self.use_event_index => {
-                armed_position_passed(
-                    driver_event.offset(),
-                    driver_event.wrap(),
+                event_in_completed_range(
+                    driver_event,
                     start,
-                    start_wrap,
+                    self.wrapped_bit,
                     end,
                     self.queue_size,
                 )
             }
             _ => true,
         };
+        // Wraps at most once (see `advance`); compare-and-subtract avoids a modulo.
+        self.next_index = if end >= self.queue_size {
+            self.wrapped_bit = !self.wrapped_bit;
+            end - self.queue_size
+        } else {
+            end
+        };
         Ok(send_signal)
     }
 }
 
-/// Whether a completion covering the descriptors `[start, end)` reaches or passes the ring
-/// position the driver armed at.
+/// Returns whether the driver event lies in the completed range `[start, end)`.
 ///
-/// The driver publishes that position in the Driver Event Suppression structure (VIRTIO 1.3
-/// section 2.8.14, "Event Suppression Structure Format"). The spec's literal rule for it is a
-/// position match: "Event will only trigger when this descriptor is made available/used
-/// respectively" (section 2.8.10, "Driver and Device Event Suppression"). This test is a
-/// deliberate superset of that wording, CONTAINMENT of the armed position in the completed
-/// range, never equality with either endpoint. Equality is right only while every completion
-/// advances by exactly one descriptor - which is why it survived so long: at
-/// `descriptor_count == 1` the two agree on every input. A chained completion (virtio-net
-/// receive, a virtio-blk header/data/status chain) steps OVER the armed position without
-/// landing on it, and the driver is then never woken for a request the device has already
-/// finished. It waits forever while the device reports itself idle.
-///
-/// The superset is grounded in the driver this device serves, not in spec prose. Linux makes the
-/// gap the common case rather than a corner: `virtqueue_enable_cb_delayed_packed` arms at
-/// `last_used + 3/4 of the in-flight count`, a position no single completion is obliged to land
-/// on.
-///
-/// Positions are compared in a lap-extended space anchored at `start`: `end` is
-/// `start + descriptor_count` and may run past `queue_size` when the completion wraps, and an
-/// armed position whose wrap counter belongs to the next lap is lifted by one ring. The
-/// equivalent modular arithmetic over `u16` is harder to read at the wrap boundary, which is
-/// where this is easiest to get wrong.
-fn armed_position_passed(
-    event_offset: u16,
-    event_wrap: bool,
+/// Although the specification describes descriptor-specific events in terms of
+/// a descriptor being used, Linux can arm delayed notifications inside a
+/// descriptor chain. Treat the event as a used-cursor threshold so that
+/// advancing over it does not lose an interrupt.
+fn event_in_completed_range(
+    event: PackedEventSuppression,
     start: u16,
     start_wrap: bool,
-    end: u32,
+    end: u16,
     queue_size: u16,
 ) -> bool {
-    // `end` is deliberately NOT reduced modulo the ring: it is the un-wrapped end of the range,
-    // so a completion that crosses the lap boundary stays comparable with a lifted armed
-    // position. That is why it is a u32, along with the armed position below, which is lifted
-    // by a ring and would overflow u16 near the top of a large one.
-    let armed = u32::from(event_offset)
-        + if event_wrap == start_wrap {
+    // Lift an event on the next lap into the same linear range as `end`.
+    let event = event.offset()
+        + if event.wrap() == start_wrap {
             0
         } else {
-            u32::from(queue_size)
+            queue_size
         };
-    (u32::from(start)..end).contains(&armed)
+    (start..end).contains(&event)
 }
 
 #[cfg(test)]
 mod tests {
-    use super::armed_position_passed;
+    use super::PackedEventSuppression;
+    use super::event_in_completed_range;
 
-    /// A small ring, so a completion can be placed right at the lap boundary.
     const RING: u16 = 8;
 
-    /// The case the integration test drives end to end, pinned here at the boundary itself:
-    /// a chain completes 5 and 6 in one step, and a driver armed at 6 must be woken even
-    /// though the used position never equals 6 - it goes from 5 straight to 7.
-    #[test]
-    fn a_chain_that_steps_over_the_armed_position_notifies() {
-        assert!(armed_position_passed(6, true, 5, true, 7, RING));
-        // The landing case still holds: armed exactly where the completion starts.
-        assert!(armed_position_passed(5, true, 5, true, 6, RING));
+    fn event(offset: u16, wrap: bool) -> PackedEventSuppression {
+        PackedEventSuppression::new()
+            .with_offset(offset)
+            .with_wrap(wrap)
     }
 
-    /// A completion that crosses the ring boundary must still wake a driver armed just past
-    /// it, which is only possible if the armed position is lifted by one ring: the driver
-    /// publishes it with the NEXT lap's wrap counter, so raw offset 0 sits AHEAD of start 7,
-    /// not six descriptors behind it. Getting this wrong is invisible until a queue happens
-    /// to wrap mid-chain, and then it hangs the same way.
     #[test]
-    fn a_completion_crossing_the_ring_boundary_notifies_for_the_next_lap() {
-        // start 7 (wrap true), a 2-descriptor chain -> un-wrapped end 9, covering 7 and 8(=0').
-        assert!(armed_position_passed(0, false, 7, true, 9, RING));
-        // With the armed position one short of being covered, there is nothing to announce
-        // yet - the boundary has to hold from both sides.
-        assert!(!armed_position_passed(1, false, 7, true, 9, RING));
+    fn event_in_completed_range_without_wrap() {
+        assert!(event_in_completed_range(event(5, true), 5, true, 7, RING));
+        assert!(event_in_completed_range(event(6, true), 5, true, 7, RING));
+        assert!(!event_in_completed_range(event(2, true), 5, true, 7, RING));
+        assert!(!event_in_completed_range(event(7, true), 5, true, 7, RING));
     }
 
-    /// An armed position the device has ALREADY passed in this lap earns no notification:
-    /// it was announced when it was covered, and re-announcing it would be a spurious
-    /// interrupt on every later completion. This is the branch a naive "armed <= end" test
-    /// would get wrong, and no chained test would catch it.
     #[test]
-    fn an_armed_position_already_behind_the_device_does_not_notify() {
-        assert!(!armed_position_passed(2, true, 5, true, 6, RING));
-        // Nor when the completion is a long chain that ends well past it.
-        assert!(!armed_position_passed(0, true, 4, true, 8, RING));
-    }
-
-    /// The boundary is half-open at BOTH ends, which is what keeps a wake from firing one
-    /// completion early: the range covers the descriptors completed, not the position the
-    /// device will write next.
-    #[test]
-    fn the_position_the_device_will_write_next_is_not_yet_covered() {
-        assert!(!armed_position_passed(6, true, 5, true, 6, RING));
-        assert!(!armed_position_passed(0, false, 7, true, 8, RING));
+    fn event_in_completed_range_with_wrap() {
+        assert!(event_in_completed_range(event(7, true), 7, true, 9, RING));
+        assert!(event_in_completed_range(event(0, false), 7, true, 9, RING));
+        assert!(!event_in_completed_range(event(6, true), 7, true, 9, RING));
+        assert!(!event_in_completed_range(event(1, false), 7, true, 9, RING));
     }
 }

--- a/vm/devices/virtio/virtio/src/queue/packed.rs
+++ b/vm/devices/virtio/virtio/src/queue/packed.rs
@@ -278,18 +278,22 @@ impl PackedQueueCompleteWork {
 /// Whether a completion covering the descriptors `[start, end)` reaches or passes the ring
 /// position the driver armed at.
 ///
-/// The driver publishes the position it wants to be woken AT OR PAST (VIRTIO 1.3 section
-/// 2.8.10, "Event Suppression Structure Format"), so this is CONTAINMENT of that position in
-/// the completed range, never equality with either endpoint. Equality is right only while every
-/// completion advances by exactly one descriptor - which is why it survived so long: at
+/// The driver publishes that position in the Driver Event Suppression structure (VIRTIO 1.3
+/// section 2.8.14, "Event Suppression Structure Format"). The spec's literal rule for it is a
+/// position match: "Event will only trigger when this descriptor is made available/used
+/// respectively" (section 2.8.10, "Driver and Device Event Suppression"). This test is a
+/// deliberate superset of that wording, CONTAINMENT of the armed position in the completed
+/// range, never equality with either endpoint. Equality is right only while every completion
+/// advances by exactly one descriptor - which is why it survived so long: at
 /// `descriptor_count == 1` the two agree on every input. A chained completion (virtio-net
 /// receive, a virtio-blk header/data/status chain) steps OVER the armed position without
 /// landing on it, and the driver is then never woken for a request the device has already
 /// finished. It waits forever while the device reports itself idle.
 ///
-/// Linux makes that the common case rather than a corner: `virtqueue_enable_cb_delayed_packed`
-/// arms at `last_used + 3/4 of the in-flight count`, deliberately far ahead of the next
-/// descriptor.
+/// The superset is grounded in the driver this device serves, not in spec prose. Linux makes the
+/// gap the common case rather than a corner: `virtqueue_enable_cb_delayed_packed` arms at
+/// `last_used + 3/4 of the in-flight count`, a position no single completion is obliged to land
+/// on.
 ///
 /// Positions are compared in a lap-extended space anchored at `start`: `end` is
 /// `start + descriptor_count` and may run past `queue_size` when the completion wraps, and an

--- a/vm/devices/virtio/virtio/src/tests.rs
+++ b/vm/devices/virtio/virtio/src/tests.rs
@@ -2693,6 +2693,65 @@ async fn verify_split_queue_indirect(driver: DefaultDriver) {
     let test_mem = VirtioTestMemoryAccess::new();
     verify_queue_indirect_inner(VirtioTestGuest::new_split(&driver, &test_mem, 1, 2, true)).await;
 }
+/// A CHAINED completion must wake a driver armed INSIDE the chain, not only one armed at the
+/// exact descriptor the completion starts on.
+///
+/// The regression this pins: the packed ring decided the notification with
+/// `driver_event.offset() == self.next_index`, an equality against the START of the completed
+/// range. Every existing test completed one descriptor at a time, where the range is a single
+/// position and equality and containment agree on every input - so nothing here could fail
+/// while the device silently dropped the wakeup for every multi-descriptor completion, which is
+/// the production shape for virtio-net receive and for a virtio-blk header/data/status chain.
+///
+/// The guest arms at descriptor 1 and the device completes a 2-descriptor chain covering 0 and
+/// 1 in one step, moving the used position from 0 straight to 2. The armed position is passed
+/// but never landed on, so the pre-fix code sends nothing and the driver waits forever on a
+/// request the device has already finished.
+async fn verify_queue_chained_completion_wakes_a_driver_armed_inside_the_chain(
+    mut guest: VirtioTestGuest,
+) {
+    const CHAIN_LEN: u16 = 2;
+
+    let (tx, mut rx) = mesh::mpsc_channel();
+    let event = Event::new();
+    let mut queues = guest.create_direct_queues(|i| {
+        let tx = tx.clone();
+        CreateDirectQueueParams {
+            process_work: Box::new(
+                move |queue: &mut VirtioQueue, work: VirtioQueueCallbackWork| {
+                    assert_eq!(work.payload.len(), CHAIN_LEN as usize);
+                    queue.complete(work, 123);
+                },
+            ),
+            notify: Interrupt::from_fn(move || {
+                tx.send(i as usize);
+            }),
+            event: event.clone(),
+        }
+    });
+
+    // Arm INSIDE the chain the device is about to complete: position 1 of the 0..2 range.
+    guest.enable_interrupt(0, Some(1));
+    guest.add_linked_to_avail_queue(0, CHAIN_LEN);
+    event.signal();
+    must_recv_in_timeout(&mut rx, Duration::from_millis(500)).await;
+
+    let (_, len) = guest.get_next_completed(0).unwrap();
+    assert_eq!(len, 123);
+    queues[0].stop().await;
+}
+
+#[async_test]
+async fn verify_packed_queue_chained_completion_wakes_a_driver_armed_inside_the_chain(
+    driver: DefaultDriver,
+) {
+    let test_mem = VirtioTestMemoryAccess::new();
+    verify_queue_chained_completion_wakes_a_driver_armed_inside_the_chain(
+        VirtioTestGuest::new_packed(&driver, &test_mem, 1, 8, true),
+    )
+    .await;
+}
+
 #[async_test]
 async fn verify_packed_queue_indirect(driver: DefaultDriver) {
     let test_mem = VirtioTestMemoryAccess::new();

--- a/vm/devices/virtio/virtio/src/tests.rs
+++ b/vm/devices/virtio/virtio/src/tests.rs
@@ -2693,25 +2693,14 @@ async fn verify_split_queue_indirect(driver: DefaultDriver) {
     let test_mem = VirtioTestMemoryAccess::new();
     verify_queue_indirect_inner(VirtioTestGuest::new_split(&driver, &test_mem, 1, 2, true)).await;
 }
-/// A CHAINED completion must wake a driver armed INSIDE the chain, not only one armed at the
-/// exact descriptor the completion starts on.
-///
-/// The regression this pins: the packed ring decided the notification with
-/// `driver_event.offset() == self.next_index`, an equality against the START of the completed
-/// range. Every existing test completed one descriptor at a time, where the range is a single
-/// position and equality and containment agree on every input - so nothing here could fail
-/// while the device silently dropped the wakeup for every multi-descriptor completion, which is
-/// the production shape for virtio-net receive and for a virtio-blk header/data/status chain.
-///
-/// The guest arms at descriptor 1 and the device completes a 2-descriptor chain covering 0 and
-/// 1 in one step, moving the used position from 0 straight to 2. The armed position is passed
-/// but never landed on, so the pre-fix code sends nothing and the driver waits forever on a
-/// request the device has already finished.
-async fn verify_queue_chained_completion_wakes_a_driver_armed_inside_the_chain(
-    mut guest: VirtioTestGuest,
-) {
+
+/// A packed chain must notify when the driver event lies inside the chain.
+#[async_test]
+async fn verify_packed_queue_chained_completion_wakes_for_interior_event(driver: DefaultDriver) {
     const CHAIN_LEN: u16 = 2;
 
+    let test_mem = VirtioTestMemoryAccess::new();
+    let mut guest = VirtioTestGuest::new_packed(&driver, &test_mem, 1, 8, true);
     let (tx, mut rx) = mesh::mpsc_channel();
     let event = Event::new();
     let mut queues = guest.create_direct_queues(|i| {
@@ -2730,7 +2719,7 @@ async fn verify_queue_chained_completion_wakes_a_driver_armed_inside_the_chain(
         }
     });
 
-    // Arm INSIDE the chain the device is about to complete: position 1 of the 0..2 range.
+    // Arm at position 1 of the chain covering positions 0 and 1.
     guest.enable_interrupt(0, Some(1));
     guest.add_linked_to_avail_queue(0, CHAIN_LEN);
     event.signal();
@@ -2739,17 +2728,6 @@ async fn verify_queue_chained_completion_wakes_a_driver_armed_inside_the_chain(
     let (_, len) = guest.get_next_completed(0).unwrap();
     assert_eq!(len, 123);
     queues[0].stop().await;
-}
-
-#[async_test]
-async fn verify_packed_queue_chained_completion_wakes_a_driver_armed_inside_the_chain(
-    driver: DefaultDriver,
-) {
-    let test_mem = VirtioTestMemoryAccess::new();
-    verify_queue_chained_completion_wakes_a_driver_armed_inside_the_chain(
-        VirtioTestGuest::new_packed(&driver, &test_mem, 1, 8, true),
-    )
-    .await;
 }
 
 #[async_test]


### PR DESCRIPTION
The packed ring decided the completion interrupt by comparing the driver's armed position for equality with the start of the completed range:

```rust
driver_event.offset() == self.next_index && driver_event.wrap() == self.wrapped_bit
```

The driver publishes the position it wants to be woken at or past (VIRTIO 1.3, 2.8.10), so the device owes a notification whenever the used position reaches or passes it. Equality matches that only while a completion advances by exactly one descriptor, where the range is a single position.

For a chained completion the used position steps from the start of the chain to past its end, over any position armed inside it, and no interrupt is sent. The driver then waits on a request the device has already finished. Neither side logs anything, and the device's own state reads as idle.

Chains are not a corner case. A receive chain without mergeable buffers is MAX_SKB_FRAGS + 2 buffers, a block request is header, data and status, and `virtqueue_enable_cb_delayed_packed` arms at `last_used` plus three quarters of the in-flight count, well ahead of the next descriptor.

The fix advances the index first, then asks whether the armed position lies in the range the completion covered. The comparison happens in a lap-extended space so a chain that crosses the ring boundary stays comparable with an armed position carrying the next lap's wrap counter.

The existing queue tests all complete one descriptor at a time, where the old and new decisions agree on every input, so none of them could catch this. This adds a chained completion whose driver is armed inside the chain, which fails against the previous code, plus boundary cases for the wrap crossing, for an armed position already behind the device, and for the half-open upper end. Each was checked to fail against a targeted mutation of the new logic.
