### PR TITLE
DNM: nix: point OpenHCL kernel at 6.18.37.3.memregressionfix

### DIFF
--- a/flowey/flowey_lib_hvlite/src/_jobs/cfg_versions.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/cfg_versions.rs
@@ -29,7 +29,7 @@ pub const NEXTEST: &str = "0.9.133";
 pub const NODEJS: &str = "24.x";
 // None disables hcl-dev builds and tests; Some(version) enables them.
 pub const OPENHCL_KERNEL_DEV_VERSION: Option<&str> = None;
-pub const OPENHCL_KERNEL_STABLE_VERSION: &str = "6.18.37.3";
+pub const OPENHCL_KERNEL_STABLE_VERSION: &str = "6.18.37.3.memregressionfix";
 pub const OPENVMM_DEPS: &str = "0.3.0-116";
 pub const PROTOC: &str = "27.1";
 

--- a/nix/openhcl_kernel.nix
+++ b/nix/openhcl_kernel.nix
@@ -1,7 +1,7 @@
 { system, stdenv, fetchzip, targetArch ? null, is_dev ? false, is_cvm ? false }:
 
 let
-  version = if is_dev then "deprecated" else "6.18.37.3";
+  version = if is_dev then "deprecated" else "6.18.37.3.memregressionfix";
   # Allow explicit override of architecture, otherwise derive from host system
   # Note: targetArch uses "x86_64"/"aarch64", but URLs use "x64"/"arm64"
   arch = if targetArch == "x86_64" then "x64"
@@ -18,11 +18,11 @@ let
   hashes = {
     hcl-main = {
       std = {
-        x64 = "sha256-4SwccsD57lf0GmDp0sVNDegG3g/FCqW+pjnjOPNClwo=";
-        arm64 = "sha256-j5cKHKsTH3tD6X+uvl42gr7jJ+q1sYTWQFGiA8CjbNE=";
+        x64 = "sha256-NOg7Lo6vJ6ngXbTIuqq3ZHW5QSlAw6CHGEXyaMd1v0I=";
+        arm64 = "sha256-lfoqoiDjdeOVx3jgEgZqdARx/wE3B6C9YgiJxnFrXJk=";
       };
       cvm = {
-        x64 = "sha256-4GbgaaOvVdL/sEo2cTMFgzQ1P8MRHCeb4ZidHfs4rfU=";
+        x64 = "sha256-bfKPV+yKEDyyQe5D1CeufEZnwDtfzOdmQ0XD2Qbo0/4=";
         arm64 = throw "openhcl-kernel: cvm arm64 variant not available";
       };
     };


### PR DESCRIPTION
Pin the non-dev (hcl-main) OpenHCL kernel to the
6.18.37.3.memregressionfix release, which carries the VTL0 low-mapping PageTables regression fix, and refresh the hcl-main std/cvm hashes.