### PR TITLE
hyperv_dump: Give tests more time for disk IO

### DIFF
--- a/vmm_core/hyperv_dump/tests/cross_validate.rs
+++ b/vmm_core/hyperv_dump/tests/cross_validate.rs
@@ -309,7 +309,8 @@ fn dll_validates_large_memory() {
     );
     let blob = builder.finish();
 
-    let buf = Cursor::new(Vec::new());
+    let mut tmp = tempfile::Builder::new().suffix(".vmrs").tempfile().unwrap();
+    let buf = std::io::BufWriter::new(tmp.as_file_mut());
     let mut vmrs = VmrsWriter::new(buf).unwrap();
 
     // 500 MiB of memory at GPA 0 — 500 × 1 MiB blocks.
@@ -330,17 +331,18 @@ fn dll_validates_large_memory() {
     }
 
     let mut mem = StampReader;
-    let vmrs_data = vmrs.finish(&blob, &mut mem).unwrap().into_inner();
+    vmrs.finish(&blob, &mut mem).unwrap().into_inner().unwrap();
+    let vmrs_len = tmp.as_file().metadata().unwrap().len();
     eprintln!(
         "Built large VMRS: {} bytes ({} MiB, {} blocks)",
-        vmrs_data.len(),
-        vmrs_data.len() / 1_048_576,
+        vmrs_len,
+        vmrs_len / MIB,
         BLOCK_COUNT
     );
 
     // Verify round-trip through our reader: spot-check a few blocks.
     {
-        let mut reader = hvs_file::reader::HvsFileReader::open(Cursor::new(&vmrs_data)).unwrap();
+        let mut reader = hvs_file::reader::HvsFileReader::open(tmp.reopen().unwrap()).unwrap();
         for i in [0u64, 1, 249, 250, 499] {
             let data = reader
                 .read_array(&format!("/savedstate/RamBlock{i}"))
@@ -352,9 +354,6 @@ fn dll_validates_large_memory() {
     }
 
     // Verify the DLL can load the file.
-    let mut tmp = tempfile::Builder::new().suffix(".vmrs").tempfile().unwrap();
-    std::io::Write::write_all(&mut tmp, &vmrs_data).unwrap();
-
     let vmrs_path = tmp.path();
     let wide_path: Vec<u16> = vmrs_path
         .to_str()


### PR DESCRIPTION
https://github.com/microsoft/openvmm/actions/runs/31836071808/job/94882549054 had a failure of some tests in hyperv_dump. Copilot attributes these test failures to the impact of writing a 500mb file all at once in the final step while the machine is already under IO pressure. Attempt to mitigate this by using a file from the very beginning, rather than an in-memory buffer, allowing the VmrsWriter the ability to stretch out the different writes over the test runtime, and potentially leave unwritten areas alone rather than having to write out a bunch of zeros.