### PR TITLE
flowey: Don't require target packs for fake csprojs

### DIFF
--- a/flowey/flowey_lib_common/src/nuget_install_package.rs
+++ b/flowey/flowey_lib_common/src/nuget_install_package.rs
@@ -133,6 +133,13 @@ impl Node {
                     // transitive dependencies — this is intentional, as these
                     // packages are standalone native binaries / firmware blobs
                     // that do not have NuGet transitive dependencies.
+                    //
+                    // The project is never compiled, so all implicit framework
+                    // references / targeting + runtime pack downloads are
+                    // disabled. Without this, an SDK newer than the
+                    // `TargetFramework` below would try to restore the matching
+                    // targeting packs (e.g. `Microsoft.NETCore.App.Ref`) from
+                    // the configured feeds, which typically don't mirror them.
                     let csproj_content = {
                         let items: String = packages
                             .keys()
@@ -148,6 +155,10 @@ impl Node {
 r#"<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
+    <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
+    <EnableTargetingPackDownload>false</EnableTargetingPackDownload>
+    <EnableRuntimePackDownload>false</EnableRuntimePackDownload>
+    <EnableAppHostPackDownload>false</EnableAppHostPackDownload>
   </PropertyGroup>
   <ItemGroup>
 {items}


### PR DESCRIPTION
Flowey generates a fake .csproj file to facilitate the downloading and installing of nuget packages. If the version of .net specified in this fake file is older than the locally installed SDK the SDK has to download the 'targeting packs' for this older version in order to compile the csproj. These targeting packs are typically not mirrored in our internal feeds, but also we're never going to actually compile this fake csproj. So just disable this automatic behavior.