### PR TITLE
vmm_tests: Mark the uefi_force_dma_bounce test as unstable

### DIFF
--- a/vmm_tests/vmm_tests/tests/tests/multiarch.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch.rs
@@ -713,6 +713,7 @@ async fn efi_diagnostics_info_level<T: PetriVmmBackend>(
 /// whether IoMmuDxe will force bounce buffering on all DMA operations.
 #[vmm_test_with(
     requires(vpci),
+    unstable(reason = "Test is flaky on CI, known WHP bug suspected"),
     configs(openvmm_openhcl_uefi_x64(vhd(windows_datacenter_core_2022_x64)))
 )]
 async fn uefi_force_dma_bounce<T: PetriVmmBackend>(


### PR DESCRIPTION
This test times out quite often. I suspect it's just more likely to be hitting the known lost interrupt bug on WHP than other tests, but I haven't had the time to dig in further yet. For now, mark it unstable.