### PR TITLE
smmu: forward host SMMU faults to the guest via the iommufd vEVENTQ

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7793,6 +7793,7 @@ dependencies = [
  "pci_core",
  "thiserror 2.0.16",
  "tracelimit",
+ "tracing",
  "vmcore",
  "zerocopy",
 ]
@@ -9334,6 +9335,7 @@ dependencies = [
  "vfio_sys",
  "vm_resource",
  "vmcore",
+ "zerocopy",
 ]
 
 [[package]]
@@ -9359,6 +9361,7 @@ dependencies = [
  "tracelimit",
  "tracing",
  "vfio-bindings",
+ "zerocopy",
 ]
 
 [[package]]

--- a/Guide/src/reference/emulated/iommu/smmuv3.md
+++ b/Guide/src/reference/emulated/iommu/smmuv3.md
@@ -143,7 +143,14 @@ have observed. With a fixed `oas=N`, a value larger than the host's is rejected.
 
 ### Fault reporting
 
-Faults raised by a stream that the physical SMMU is actively translating
-originate in hardware, not in the emulator, so they must be relayed from the
-host to the guest's event queue. That relay is not yet implemented, so
-faults from accelerated streams are currently not visible to the guest.
+Faults raised by a stream the physical SMMU is actively translating originate
+in hardware, not in the emulator, so the VMM never sees the transaction that
+caused them. The host reports them on a virtual event queue attached to the
+vIOMMU; the VMM drains that queue and writes each record into the guest's
+event queue unchanged, since the host has already expressed the StreamID in
+the guest's namespace.
+
+If the host virtual event queue itself overflows, the VMM logs the loss and
+continues forwarding the records that remain available. It cannot represent
+that loss as a guest event queue overflow, because `EVENTQ_PROD.OVFLG`
+specifically means the guest's event queue was full.

--- a/vm/devices/iommu/smmu/Cargo.toml
+++ b/vm/devices/iommu/smmu/Cargo.toml
@@ -7,8 +7,6 @@ edition.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-anyhow.workspace = true
-bitfield-struct.workspace = true
 chipset_device.workspace = true
 guestmem.workspace = true
 iommu_common.workspace = true
@@ -16,11 +14,15 @@ inspect.workspace = true
 mesh.workspace = true
 open_enum.workspace = true
 pal_event.workspace = true
-parking_lot.workspace = true
 pci_core.workspace = true
-thiserror.workspace = true
 tracelimit.workspace = true
 vmcore.workspace = true
+
+anyhow.workspace = true
+bitfield-struct.workspace = true
+parking_lot.workspace = true
+thiserror.workspace = true
+tracing.workspace = true
 zerocopy.workspace = true
 
 [dev-dependencies]

--- a/vm/devices/iommu/smmu/src/emulator.rs
+++ b/vm/devices/iommu/smmu/src/emulator.rs
@@ -559,8 +559,8 @@ impl SmmuDevice {
     /// Handles page 1 register reads (offset >= 0x10000).
     fn read_page1_reg32(&self, offset: u32) -> u32 {
         match offset {
-            registers::EVENTQ_PROD_PAGE1 => self.shared_state.evtq_prod(),
-            registers::EVENTQ_CONS_PAGE1 => self.shared_state.evtq_cons(),
+            registers::EVENTQ_PROD_PAGE1 => self.shared_state.evtq_prod().into(),
+            registers::EVENTQ_CONS_PAGE1 => self.shared_state.evtq_cons().into(),
             registers::CMDQ_IRQ_CFG1_PAGE1 => self.cmdq_msi.data,
             registers::CMDQ_IRQ_CFG2_PAGE1 => self.cmdq_msi.attr,
             _ => {
@@ -585,8 +585,11 @@ impl SmmuDevice {
     fn write_page1_reg32(&mut self, offset: u32, value: u32) {
         match offset {
             registers::EVENTQ_PROD_PAGE1 => {
-                // EVTQ_PROD on page 1 is writable by the SMMU only (for
-                // writing events). Guest writes are ignored.
+                // §6.3.130: software may initialize PROD only while EVENTQEN
+                // and its immediate acknowledgment are clear.
+                if !self.cr0.eventqen() {
+                    self.shared_state.set_evtq_prod(value);
+                }
             }
             registers::EVENTQ_CONS_PAGE1 => {
                 self.shared_state.set_evtq_cons(value);
@@ -1383,6 +1386,8 @@ mod tests {
     use super::*;
     use crate::spec::events::EvtEntry;
     use crate::spec::registers::*;
+    use zerocopy::FromBytes;
+    use zerocopy::IntoBytes;
 
     const TEST_MMIO_BASE: u64 = 0x0900_0000;
 
@@ -1636,14 +1641,24 @@ mod tests {
     #[test]
     fn test_page1_register_access() {
         let mut dev = make_test_device();
+        let evtq_base = QueueBase::new().with_log2size(3);
+        write64(&mut dev, EVENTQ_BASE, evtq_base.into());
 
-        // EVTQ_CONS on page 1 is guest-writable.
-        write32_page1(&mut dev, EVENTQ_CONS_PAGE1, 42);
-        assert_eq!(read32_page1(&mut dev, EVENTQ_CONS_PAGE1), 42);
+        // §6.3.130: software initializes PROD while EVENTQEN and its ACK are
+        // both clear, including the overflow state.
+        let initialized_prod = (1 << 31) | 3;
+        write32_page1(&mut dev, EVENTQ_PROD_PAGE1, initialized_prod);
+        assert_eq!(read32_page1(&mut dev, EVENTQ_PROD_PAGE1), initialized_prod);
 
-        // EVTQ_PROD on page 1 is SMMU-writable only (guest writes ignored).
-        write32_page1(&mut dev, EVENTQ_PROD_PAGE1, 99);
-        assert_eq!(read32_page1(&mut dev, EVENTQ_PROD_PAGE1), 0);
+        // CONS is always writable, but bits above the configured wrap bit have
+        // no effect and read back as zero in this implementation.
+        write32_page1(&mut dev, EVENTQ_CONS_PAGE1, (1 << 19) | 3);
+        assert_eq!(read32_page1(&mut dev, EVENTQ_CONS_PAGE1), 3);
+
+        // Once EVENTQEN is acknowledged, PROD is read-only to software.
+        write32(&mut dev, CR0, Cr0::new().with_eventqen(true).into());
+        write32_page1(&mut dev, EVENTQ_PROD_PAGE1, 4);
+        assert_eq!(read32_page1(&mut dev, EVENTQ_PROD_PAGE1), initialized_prod);
     }
 
     #[test]
@@ -3532,8 +3547,72 @@ mod tests {
         let event = EvtEntry::translation_fault(99, 0xDEAD, false);
         dev.shared_state().write_event(event);
 
-        // PROD should NOT advance (event dropped).
+        // PROD's write index should NOT advance (event dropped); the discard
+        // also raises OVFLG in bit 31, covered by `test_evtq_overflow_*`.
+        const WR_MASK: u32 = (1 << 20) - 1;
+        assert_eq!(
+            read32_page1(&mut dev, EVENTQ_PROD_PAGE1) & WR_MASK,
+            max_entries
+        );
+    }
+
+    /// §7.4: discarding a record because the Event queue is full enters the
+    /// overflow condition, which is `EVENTQ_PROD.OVFLG != EVENTQ_CONS.OVACKFLG`
+    /// — not a Global Error.
+    #[test]
+    fn test_evtq_overflow_toggles_ovflg() {
+        const OVFLG: u32 = 1 << 31;
+        let mut dev = make_evtq_test_device();
+
+        let max_entries = 1u32 << TEST_EVTQ_LOG2SIZE;
+        for i in 0..max_entries {
+            dev.shared_state()
+                .write_event(EvtEntry::translation_fault(i, 0, false));
+        }
+        // A merely full queue has discarded nothing, so no overflow yet.
         assert_eq!(read32_page1(&mut dev, EVENTQ_PROD_PAGE1), max_entries);
+
+        dev.shared_state()
+            .write_event(EvtEntry::translation_fault(99, 0, false));
+        assert_eq!(
+            read32_page1(&mut dev, EVENTQ_PROD_PAGE1),
+            max_entries | OVFLG
+        );
+        // An Event queue access abort is a distinct condition (§7.2.2).
+        assert!(!Gerror::from(read32(&mut dev, GERROR)).eventq_abt_err());
+
+        // A second overflow cannot be indicated before the first is acked.
+        dev.shared_state()
+            .write_event(EvtEntry::translation_fault(100, 0, false));
+        assert_eq!(
+            read32_page1(&mut dev, EVENTQ_PROD_PAGE1),
+            max_entries | OVFLG
+        );
+
+        // Acknowledge by matching OVACKFLG (still leaving the queue full), and
+        // the next discard toggles the flag back.
+        write32_page1(&mut dev, EVENTQ_CONS_PAGE1, OVFLG);
+        dev.shared_state()
+            .write_event(EvtEntry::translation_fault(101, 0, false));
+        assert_eq!(read32_page1(&mut dev, EVENTQ_PROD_PAGE1), max_entries);
+    }
+
+    /// A fault the physical SMMU reported for an accelerated stream is written
+    /// to the guest's Event queue verbatim.
+    #[test]
+    fn test_record_accel_event() {
+        let mut dev = make_evtq_test_device();
+
+        let source = EvtEntry::translation_fault(0x1234, 0xDEAD_0000, true);
+        let record = <[u64; 4]>::read_from_bytes(source.as_bytes()).unwrap();
+        dev.shared_state().record_accel_event(record);
+
+        assert_eq!(read32_page1(&mut dev, EVENTQ_PROD_PAGE1), 1);
+        let written: EvtEntry = dev
+            .guest_memory
+            .read_plain(TEST_EVTQ_GPA)
+            .expect("read event");
+        assert_eq!(written.as_bytes(), source.as_bytes());
     }
 
     #[test]

--- a/vm/devices/iommu/smmu/src/shared.rs
+++ b/vm/devices/iommu/smmu/src/shared.rs
@@ -37,6 +37,7 @@ use std::sync::Weak;
 use vmcore::irqfd::IrqFd;
 use vmcore::irqfd::IrqFdRoute;
 use vmcore::line_interrupt::LineInterrupt;
+use zerocopy::FromBytes;
 use zerocopy::IntoBytes;
 
 /// The context a host-assignment backend needs to wire a VFIO device into
@@ -399,10 +400,12 @@ struct QueueErrorState {
     evtq_enabled: bool,
     /// Whether the EVTQ interrupt is enabled (IRQ_CTRL.EVENTQ_IRQEN).
     evtq_irqen: bool,
-    /// Producer index (advanced by the SMMU when writing events).
-    evtq_prod: u32,
-    /// Consumer index (advanced by the guest via MMIO).
-    evtq_cons: u32,
+    /// SMMU_EVENTQ_PROD: write index, advanced by the SMMU as it writes
+    /// events, plus the overflow flag.
+    evtq_prod: registers::EventqProd,
+    /// SMMU_EVENTQ_CONS: read index, advanced by the guest via MMIO, plus the
+    /// overflow acknowledge flag.
+    evtq_cons: registers::EventqCons,
 
     // -- Global error registers (toggle protocol) --
     /// GERROR register — individual error bits toggled by the SMMU.
@@ -424,6 +427,17 @@ pub(crate) struct SavedQueueState {
     pub evtq_cons: u32,
     pub gerror: u32,
     pub gerrorn: u32,
+}
+
+fn evtq_index_mask(log2size: u8) -> u32 {
+    (1 << (log2size + 1)) - 1
+}
+
+/// Whether the Event queue is empty, i.e. the effective producer and consumer
+/// indices agree. The overflow handshake in bit 31 is independent of emptiness.
+fn evtq_indices_equal(qs: &QueueErrorState) -> bool {
+    let mask = evtq_index_mask(qs.evtq_log2size);
+    qs.evtq_prod.wr() & mask == qs.evtq_cons.rd() & mask
 }
 
 impl SmmuSharedState {
@@ -461,8 +475,8 @@ impl SmmuSharedState {
                 evtq_log2size: 0,
                 evtq_enabled: false,
                 evtq_irqen: false,
-                evtq_prod: 0,
-                evtq_cons: 0,
+                evtq_prod: registers::EventqProd::new(),
+                evtq_cons: registers::EventqCons::new(),
                 gerror: registers::Gerror::new(),
                 gerrorn: registers::Gerror::new(),
                 gerror_irqen: false,
@@ -672,6 +686,11 @@ impl SmmuSharedState {
         let mut qs = self.queue_state.lock();
         qs.evtq_base_addr = base_addr;
         qs.evtq_log2size = log2size;
+        let mask = evtq_index_mask(log2size);
+        let prod = qs.evtq_prod.wr() & mask;
+        let cons = qs.evtq_cons.rd() & mask;
+        qs.evtq_prod.set_wr(prod);
+        qs.evtq_cons.set_rd(cons);
     }
 
     /// Updates the event queue enabled state (called on CR0 writes).
@@ -722,12 +741,24 @@ impl SmmuSharedState {
         self.update_gerror_irq(&qs);
     }
 
-    /// Signals an EVTQ overflow by making GERROR.EVTQ_ABT_ERR active.
+    /// Enters the Event queue overflow condition (§7.4), recording that one or
+    /// more event records were discarded.
     ///
-    /// Per spec, sets the bit to the inverse of GERRORN.EVTQ_ABT_ERR.
-    /// If the error is already active this is a no-op (the bit value
-    /// doesn't change). Called from `write_event` under the same lock.
+    /// The condition is present while `EVENTQ_PROD.OVFLG != EVENTQ_CONS`.`OVACKFLG`,
+    /// and the SMMU only toggles OVFLG when the two agree — a second overflow
+    /// cannot be indicated before software acknowledges the first.
     fn signal_evtq_overflow(&self, qs: &mut QueueErrorState) {
+        if qs.evtq_prod.ovflg() == qs.evtq_cons.ovackflg() {
+            qs.evtq_prod.set_ovflg(!qs.evtq_prod.ovflg());
+        }
+    }
+
+    /// Activates GERROR.EVENTQ_ABT_ERR after an external abort accessing the
+    /// Event queue (§7.2.2).
+    ///
+    /// Per the toggle protocol the bit is set to the inverse of GERRORN's, so
+    /// this is a no-op while the error is already unacknowledged.
+    fn signal_evtq_abt_err(&self, qs: &mut QueueErrorState) {
         let new_val = !qs.gerrorn.eventq_abt_err();
         qs.gerror.set_eventq_abt_err(new_val);
         self.update_gerror_irq(qs);
@@ -751,9 +782,12 @@ impl SmmuSharedState {
     /// Deasserts the EVTQ wired interrupt if the queue is now empty.
     pub(crate) fn set_evtq_cons(&self, cons: u32) {
         let mut qs = self.queue_state.lock();
-        qs.evtq_cons = cons;
+        let cons = registers::EventqCons::from(cons);
+        qs.evtq_cons = registers::EventqCons::new()
+            .with_rd(cons.rd() & evtq_index_mask(qs.evtq_log2size))
+            .with_ovackflg(cons.ovackflg());
         // Deassert EVTQ IRQ when the guest has drained all events.
-        if qs.evtq_irqen && qs.evtq_prod == qs.evtq_cons {
+        if qs.evtq_irqen && evtq_indices_equal(&qs) {
             if let Some(irq) = &self.evtq_irq {
                 irq.set_level(false);
             }
@@ -762,14 +796,24 @@ impl SmmuSharedState {
 
     /// Returns the current event queue producer index (for guest reads
     /// of EVENTQ_PROD on page 1).
-    pub(crate) fn evtq_prod(&self) -> u32 {
+    pub(crate) fn evtq_prod(&self) -> registers::EventqProd {
         self.queue_state.lock().evtq_prod
     }
 
     /// Returns the current event queue consumer index (for guest reads
     /// of EVENTQ_CONS on page 1).
-    pub(crate) fn evtq_cons(&self) -> u32 {
+    pub(crate) fn evtq_cons(&self) -> registers::EventqCons {
         self.queue_state.lock().evtq_cons
+    }
+
+    /// Initializes the Event queue producer register while the queue is
+    /// disabled, as required before enabling or reinitializing it.
+    pub(crate) fn set_evtq_prod(&self, prod: u32) {
+        let mut qs = self.queue_state.lock();
+        let prod = registers::EventqProd::from(prod);
+        qs.evtq_prod = registers::EventqProd::new()
+            .with_wr(prod.wr() & evtq_index_mask(qs.evtq_log2size))
+            .with_ovflg(prod.ovflg());
     }
 
     /// Resets event queue and GERROR state (called on device reset).
@@ -779,8 +823,8 @@ impl SmmuSharedState {
         qs.evtq_log2size = 0;
         qs.evtq_enabled = false;
         qs.evtq_irqen = false;
-        qs.evtq_prod = 0;
-        qs.evtq_cons = 0;
+        qs.evtq_prod = registers::EventqProd::new();
+        qs.evtq_cons = registers::EventqCons::new();
         qs.gerror = registers::Gerror::new();
         qs.gerrorn = registers::Gerror::new();
         qs.gerror_irqen = false;
@@ -807,8 +851,8 @@ impl SmmuSharedState {
             gerror_irqen: _,
         } = *qs;
         SavedQueueState {
-            evtq_prod,
-            evtq_cons,
+            evtq_prod: evtq_prod.into(),
+            evtq_cons: evtq_cons.into(),
             gerror: gerror.into(),
             gerrorn: gerrorn.into(),
         }
@@ -827,15 +871,15 @@ impl SmmuSharedState {
             gerrorn,
         } = state;
         let mut qs = self.queue_state.lock();
-        qs.evtq_prod = evtq_prod;
-        qs.evtq_cons = evtq_cons;
+        qs.evtq_prod = registers::EventqProd::from(evtq_prod);
+        qs.evtq_cons = registers::EventqCons::from(evtq_cons);
         qs.gerror = registers::Gerror::from(gerror);
         qs.gerrorn = registers::Gerror::from(gerrorn);
         self.update_gerror_irq(&qs);
         // Sync EVTQ wired interrupt line to match restored queue state.
         if qs.evtq_irqen {
             if let Some(irq) = &self.evtq_irq {
-                irq.set_level(qs.evtq_prod != qs.evtq_cons);
+                irq.set_level(!evtq_indices_equal(&qs));
             }
         }
     }
@@ -1185,26 +1229,35 @@ impl SmmuSharedState {
 
     /// Write an event record directly to the guest's event queue.
     ///
-    /// Called from per-device DMA fault paths and from the emulator's
-    /// command processing. If the queue is full, drops the event and
-    /// logs a warning. If an event is successfully written, pulses
-    /// the EVTQ wired SPI interrupt (if enabled).
+    /// Called from per-device DMA fault paths, from the emulator's command
+    /// processing, and from the host fault forwarding path
+    /// ([`record_accel_event`](Self::record_accel_event)).
+    ///
+    /// Per §7.2.1 the queue is writable only when it is enabled, not full, and
+    /// free of an unacknowledged access-abort condition; an event that cannot
+    /// be written is discarded. Discarding because the queue is *full*
+    /// additionally enters the overflow condition (§7.4) — the other two cases
+    /// do not.
     pub(crate) fn write_event(&self, event: EvtEntry) {
         let mut qs = self.queue_state.lock();
         if !qs.evtq_enabled {
             return;
         }
+        if qs.gerror.eventq_abt_err() != qs.gerrorn.eventq_abt_err() {
+            tracelimit::warn_ratelimited!(
+                "smmu: EVTQ access abort unacknowledged, discarding event"
+            );
+            return;
+        }
 
         let max_entries = 1u32 << qs.evtq_log2size;
         let index_mask = (max_entries << 1) - 1;
-        let prod = qs.evtq_prod & index_mask;
-        let cons = qs.evtq_cons & index_mask;
+        let prod = qs.evtq_prod.wr() & index_mask;
+        let cons = qs.evtq_cons.rd() & index_mask;
 
         // Check if the queue is full. Full when the index bits match but
         // the wrap bit differs: (prod ^ cons) == max_entries.
         if (prod ^ cons) == max_entries {
-            // Signal EVTQ overflow via GERROR.EVTQ_ABT_ERR — updates
-            // the GERROR register and interrupt line under the same lock.
             self.signal_evtq_overflow(&mut qs);
             tracelimit::warn_ratelimited!("smmu: EVTQ full, dropping event");
             return;
@@ -1220,11 +1273,15 @@ impl SmmuSharedState {
                 entry_addr,
                 "smmu: failed to write EVTQ entry to guest memory"
             );
+            // A failed queue write is an external abort on the Event queue
+            // (§7.2.2). The abort is synchronous here, so PROD is not advanced
+            // and every entry below it remains valid.
+            self.signal_evtq_abt_err(&mut qs);
             return;
         }
 
-        // Advance EVTQ_PROD.
-        qs.evtq_prod = (prod + 1) & index_mask;
+        // Advance EVTQ_PROD, leaving the overflow flag untouched.
+        qs.evtq_prod.set_wr((prod + 1) & index_mask);
 
         // Assert EVTQ wired interrupt — held high while queue is non-empty.
         // Deasserted when the guest drains events via CONS writes.
@@ -1233,6 +1290,25 @@ impl SmmuSharedState {
                 irq.set_level(true);
             }
         }
+    }
+
+    /// Records an event the physical SMMU reported for an accelerated stream.
+    ///
+    /// `record` is a raw SMMUv3 event record (§7.3): four little-endian
+    /// quadwords whose StreamID is already expressed in this SMMU's stream
+    /// namespace. Accelerated streams translate in hardware, so their faults
+    /// are detected by the physical SMMU rather than by this emulator, and this
+    /// is the only path by which they reach the guest.
+    pub fn record_accel_event(&self, record: [u64; 4]) {
+        let event = EvtEntry::read_from_bytes(record.as_bytes())
+            .expect("an SMMUv3 event record is exactly one EvtEntry");
+        tracing::debug!(
+            event_id = event.header.event_id().0,
+            sid = event.sid,
+            input_addr = event.input_addr,
+            "smmu: host SMMU event for an accelerated stream"
+        );
+        self.write_event(event);
     }
 
     /// Creates a translator for PCI devices behind this SMMU.
@@ -1785,7 +1861,7 @@ mod tests {
 
     /// Count events in the EVTQ by reading EVTQ_PROD from shared state.
     fn evtq_event_count(state: &SmmuSharedState) -> u32 {
-        state.evtq_prod()
+        state.evtq_prod().into()
     }
 
     // =========================================================================

--- a/vm/devices/iommu/smmu/src/shared.rs
+++ b/vm/devices/iommu/smmu/src/shared.rs
@@ -1859,9 +1859,12 @@ mod tests {
         state
     }
 
-    /// Count events in the EVTQ by reading EVTQ_PROD from shared state.
+    /// Count events currently queued in the EVTQ as the distance between the
+    /// producer and consumer indices. Masking to the index-with-wrap range
+    /// keeps the OVFLG handshake bit and producer wrap out of the count.
     fn evtq_event_count(state: &SmmuSharedState) -> u32 {
-        state.evtq_prod().into()
+        let index_mask = evtq_index_mask(EVTQ_LOG2SIZE);
+        state.evtq_prod().wr().wrapping_sub(state.evtq_cons().rd()) & index_mask
     }
 
     // =========================================================================

--- a/vm/devices/iommu/smmu/src/spec/registers.rs
+++ b/vm/devices/iommu/smmu/src/spec/registers.rs
@@ -497,6 +497,34 @@ impl QueueBase {
     }
 }
 
+/// SMMU_EVENTQ_PROD: Event queue producer index (§6.3.130).
+#[bitfield(u32)]
+#[derive(PartialEq, Eq, Inspect)]
+pub struct EventqProd {
+    /// Write index with wrap bit (bits `[19:0]`).
+    #[bits(20)]
+    pub wr: u32,
+    #[bits(11)]
+    _reserved: u32,
+    /// Event queue overflowed flag. An overflow condition is present while
+    /// this differs from `EventqCons.ovackflg` (§7.4).
+    pub ovflg: bool,
+}
+
+/// SMMU_EVENTQ_CONS: Event queue consumer index (§6.3.131).
+#[bitfield(u32)]
+#[derive(PartialEq, Eq, Inspect)]
+pub struct EventqCons {
+    /// Read index with wrap bit (bits `[19:0]`).
+    #[bits(20)]
+    pub rd: u32,
+    #[bits(11)]
+    _reserved: u32,
+    /// Overflow acknowledge flag, written by software to match
+    /// `EventqProd.ovflg` once it is safe to report another overflow.
+    pub ovackflg: bool,
+}
+
 /// SMMU_CMDQ_CONS: Command queue consumer index.
 ///
 /// Has an error field in the upper bits that indicates the reason for a

--- a/vm/devices/pci/vfio_assigned_device/Cargo.toml
+++ b/vm/devices/pci/vfio_assigned_device/Cargo.toml
@@ -28,6 +28,7 @@ anyhow.workspace = true
 async-trait.workspace = true
 tracelimit.workspace = true
 tracing.workspace = true
+zerocopy.workspace = true
 
 [target.'cfg(target_os = "linux")'.dev-dependencies]
 test_with_tracing.workspace = true

--- a/vm/devices/pci/vfio_assigned_device/src/iommufd_nesting.rs
+++ b/vm/devices/pci/vfio_assigned_device/src/iommufd_nesting.rs
@@ -44,10 +44,26 @@
 //!   ones, which is why the SMMU never has to be told a StreamID changed.
 
 use anyhow::Context as _;
+use pal_async::driver::PollImpl;
+use pal_async::driver::SpawnDriver;
+use pal_async::fd::PollFdReady;
+use pal_async::interest::InterestSlot;
+use pal_async::interest::PollEvents;
+use pal_async::task::Spawn;
+use pal_async::task::Task;
 use parking_lot::Mutex;
+use std::fs::File;
+use std::io;
+use std::io::Read as _;
+use std::os::fd::AsRawFd as _;
 use std::sync::Arc;
+use std::sync::Weak;
+use std::task::Poll;
+use vfio_sys::iommufd::IommuVeventArmSmmuv3;
 use vfio_sys::iommufd::IommufdCtx;
+use vfio_sys::iommufd::IommufdVeventHeader;
 use vfio_sys::iommufd::ViommuAlloc;
+use zerocopy::FromBytes;
 
 /// Query the physical SMMUv3's capabilities for a device bound to iommufd.
 ///
@@ -182,6 +198,28 @@ impl Drop for NestingParent {
     }
 }
 
+/// The host vIOMMU standing for one emulated SMMU.
+///
+/// Refcounted separately from [`SmmuAccelState`] so the vEVENTQ poll task can
+/// hold it: the queue is a kernel object nested under the vIOMMU and keeps a
+/// reference on it, so the vIOMMU cannot be destroyed until the task has closed
+/// the queue fd and destroyed the queue.
+struct Viommu {
+    ctx: Arc<IommufdCtx>,
+    /// Keeps the nesting parent alive for at least as long as this vIOMMU.
+    _parent: Arc<NestingParent>,
+    id: u32,
+}
+
+impl Drop for Viommu {
+    fn drop(&mut self) {
+        self.ctx.destroy(self.id).unwrap_or_else(|e| {
+            panic!("smmu accel: failed to destroy vIOMMU {:#x}: {e:#}", self.id)
+        });
+        tracing::info!(viommu_id = self.id, "destroyed vIOMMU");
+    }
+}
+
 /// Per-SMMU iommufd objects for HW-accelerated nested translation.
 ///
 /// Created lazily on first VFIO device attachment for an accel-capable SMMU.
@@ -196,10 +234,8 @@ impl Drop for NestingParent {
 pub struct SmmuAccelState {
     /// The iommufd context (shared with IoasManager).
     ctx: Arc<IommufdCtx>,
-    /// Keeps the nesting parent alive for at least as long as this vIOMMU.
-    _parent: Arc<NestingParent>,
-    /// Virtual IOMMU ID (one per emulated SMMU instance).
-    viommu_id: u32,
+    /// The host vIOMMU every object below is allocated under.
+    viommu: Arc<Viommu>,
     /// Shared, persistent nested HWPT with an abort STE (`Config=0b000`).
     /// Devices in ABORT attach here (rather than detaching), staying vIOMMU
     /// members. One per vIOMMU.
@@ -208,6 +244,10 @@ pub struct SmmuAccelState {
     /// bypass over the S2 parent). Devices in BYPASS attach here for identity
     /// GPA→HPA. One per vIOMMU.
     bypass_hwpt_id: u32,
+    /// Forwards host SMMU faults for this vIOMMU's streams into the guest's
+    /// Event queue. Dropping the handle cancels the task, which then tears the
+    /// queue down in order and releases its own vIOMMU reference.
+    _veventq: Task<()>,
 }
 
 impl SmmuAccelState {
@@ -221,6 +261,8 @@ impl SmmuAccelState {
         dev_id: u32,
         parent: Arc<NestingParent>,
         viommu_id: u32,
+        vsmmu: &Arc<smmu::SmmuSharedState>,
+        driver: &dyn SpawnDriver,
     ) -> anyhow::Result<Self> {
         let viommu = PendingIommufdObject::new(&ctx, viommu_id, "vIOMMU");
 
@@ -267,16 +309,21 @@ impl SmmuAccelState {
             "created SMMU accel state (vIOMMU)"
         );
 
-        let viommu_id = viommu.into_id();
+        let viommu = Arc::new(Viommu {
+            ctx: ctx.clone(),
+            _parent: parent,
+            id: viommu.into_id(),
+        });
+        let veventq = spawn_veventq(&ctx, &viommu, vsmmu, driver)?;
         let abort_hwpt_id = abort_hwpt.into_id();
         let bypass_hwpt_id = bypass_hwpt.into_id();
 
         Ok(Self {
             ctx,
-            _parent: parent,
-            viommu_id,
+            viommu,
             abort_hwpt_id,
             bypass_hwpt_id,
+            _veventq: veventq,
         })
     }
 }
@@ -289,7 +336,7 @@ impl SmmuAccelState {
     pub fn alloc_vdevice(&self, dev_id: u32, vsid: u32) -> anyhow::Result<VDevice> {
         let id = self
             .ctx
-            .vdevice_alloc(self.viommu_id, dev_id, vsid.into())
+            .vdevice_alloc(self.viommu.id, dev_id, vsid.into())
             .with_context(|| {
                 format!("failed to allocate vDevice for dev_id={dev_id}, vsid={vsid:#x}")
             })?;
@@ -330,18 +377,224 @@ impl Drop for SmmuAccelState {
     fn drop(&mut self) {
         // Runs once the cache entry and every stream backend behind this vSMMU
         // are gone, so each backend has already destroyed its own nested HWPT
-        // and vDevice. Children before the vIOMMU they nest under.
+        // and vDevice. These are the last children of the vIOMMU this state
+        // owns directly; the vIOMMU itself outlives them, and outlives the
+        // vEVENTQ task too, until the last `Arc<Viommu>` goes.
         for (id, kind) in [
             (self.bypass_hwpt_id, "bypass HWPT"),
             (self.abort_hwpt_id, "abort HWPT"),
-            (self.viommu_id, "vIOMMU"),
         ] {
             self.ctx
                 .destroy(id)
                 .unwrap_or_else(|e| panic!("smmu accel: failed to destroy {kind} {id:#x}: {e:#}"));
         }
-        tracing::debug!(viommu_id = self.viommu_id, "destroyed SMMU accel state");
+        tracing::debug!(viommu_id = self.viommu.id, "destroyed SMMU accel state");
     }
+}
+
+/// Host-side buffering for physical SMMU events awaiting forwarding.
+///
+/// This absorbs event bursts and userspace scheduling latency independently
+/// of the guest's Event queue, which also receives emulated SMMU events.
+const HOST_VEVENTQ_DEPTH: u32 = 256;
+
+/// vEVENT sequence numbers are monotonic over `[0, i32::MAX]`, wrapping to 0.
+const VEVENT_SEQUENCE_MODULUS: u32 = i32::MAX as u32 + 1;
+
+/// A header plus one ARM SMMUv3 record. The kernel only ever writes whole
+/// records, so a read buffer sized in multiples of this is never truncated.
+const VEVENT_RECORD_LEN: usize =
+    size_of::<IommufdVeventHeader>() + size_of::<IommuVeventArmSmmuv3>();
+
+/// How many records to drain per read.
+const VEVENT_BATCH_LEN: usize = VEVENT_RECORD_LEN * 16;
+
+/// An iommufd object destroyed when this handle drops.
+struct OwnedIommufdObject {
+    ctx: Arc<IommufdCtx>,
+    id: u32,
+    kind: &'static str,
+}
+
+impl Drop for OwnedIommufdObject {
+    fn drop(&mut self) {
+        self.ctx.destroy(self.id).unwrap_or_else(|e| {
+            panic!(
+                "smmu accel: failed to destroy {} {:#x}: {e:#}",
+                self.kind, self.id
+            )
+        });
+    }
+}
+
+/// One vIOMMU's virtual event queue: the host's channel for SMMU faults taken
+/// by streams that translate in hardware, and so are invisible to the emulator.
+///
+/// Field order is load-bearing, because teardown has to run inwards: the
+/// readiness registration (which unregisters the fd, and so must precede the
+/// close), then the fd (which holds a kernel reference on the queue), then the
+/// queue object, and only then this reference to the vIOMMU it nests under.
+struct VEventQ {
+    fd_ready: PollImpl<dyn PollFdReady>,
+    file: File,
+    _object: OwnedIommufdObject,
+    _viommu: Arc<Viommu>,
+}
+
+impl VEventQ {
+    /// Waits for and reads the next batch of whole event records.
+    async fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        std::future::poll_fn(|cx| {
+            loop {
+                // Clear readiness *before* reading, so an event arriving after
+                // the read leaves the fd marked ready rather than having its
+                // wakeup clobbered by a later clear.
+                self.fd_ready.clear_fd_ready(InterestSlot::Read);
+                match (&self.file).read(buf) {
+                    // An empty queue reads as zero bytes rather than failing
+                    // with `EAGAIN`; the fd never reaches end of file.
+                    Ok(0) => {}
+                    Err(err) if err.kind() == io::ErrorKind::Interrupted => {}
+                    r => return Poll::Ready(r),
+                }
+                std::task::ready!(self.fd_ready.poll_fd_ready(
+                    cx,
+                    InterestSlot::Read,
+                    PollEvents::IN
+                ));
+            }
+        })
+        .await
+    }
+}
+
+/// Allocates this vIOMMU's virtual event queue and spawns the task forwarding
+/// its records into the guest's Event queue.
+fn spawn_veventq(
+    ctx: &Arc<IommufdCtx>,
+    viommu: &Arc<Viommu>,
+    vsmmu: &Arc<smmu::SmmuSharedState>,
+    driver: &dyn SpawnDriver,
+) -> anyhow::Result<Task<()>> {
+    let (queue_id, file) = ctx
+        .veventq_alloc(
+            viommu.id,
+            vfio_sys::iommufd::IOMMU_VEVENTQ_TYPE_ARM_SMMUV3,
+            HOST_VEVENTQ_DEPTH,
+        )
+        .context("failed to allocate vEVENTQ for accel SMMU")?;
+    let pending = PendingIommufdObject::new(ctx, queue_id, "vEVENTQ");
+    let fd_ready = match driver.new_dyn_fd_ready(file.as_raw_fd()) {
+        Ok(fd_ready) => fd_ready,
+        Err(err) => {
+            // Close the fd before `pending` destroys the queue: the fd holds a
+            // kernel reference that would make the destroy fail.
+            drop(file);
+            return Err(err).context("failed to register the vEVENTQ fd for polling");
+        }
+    };
+    let queue = VEventQ {
+        fd_ready,
+        file,
+        _object: OwnedIommufdObject {
+            ctx: ctx.clone(),
+            id: pending.into_id(),
+            kind: "vEVENTQ",
+        },
+        _viommu: viommu.clone(),
+    };
+    tracing::info!(viommu_id = viommu.id, queue_id, "allocated vEVENTQ");
+    Ok(Spawn::spawn(
+        &driver,
+        "smmu-veventq",
+        forward_veventq(queue, Arc::downgrade(vsmmu)),
+    ))
+}
+
+/// Forwards host SMMU events for this vIOMMU's streams into the guest's Event
+/// queue until the emulated SMMU goes away or the task is cancelled.
+async fn forward_veventq(mut queue: VEventQ, vsmmu: Weak<smmu::SmmuSharedState>) {
+    let mut buf = [0; VEVENT_BATCH_LEN];
+    let mut last_sequence = None;
+    loop {
+        let len = match queue.read(&mut buf).await {
+            Ok(len) => len,
+            Err(err) => {
+                tracing::error!(
+                    error = &err as &dyn std::error::Error,
+                    "smmu accel: vEVENTQ read failed; host events can no longer reach the guest"
+                );
+                return;
+            }
+        };
+        let Some(vsmmu) = vsmmu.upgrade() else {
+            return;
+        };
+        let mut stream = &buf[..len];
+        while let Some(event) = next_vevent(&mut stream, &mut last_sequence) {
+            if event.lost > 0 {
+                tracelimit::warn_ratelimited!(
+                    lost = event.lost,
+                    "smmu accel: host vEVENTQ events lost"
+                );
+            }
+            if let Some(record) = event.record {
+                vsmmu.record_accel_event(record);
+            }
+        }
+    }
+}
+
+/// One entry decoded from the vEVENTQ stream.
+struct VEvent {
+    /// How many records the host discarded immediately before this one.
+    lost: u32,
+    /// The event record, absent when the header only reports loss.
+    record: Option<[u64; 4]>,
+}
+
+/// Pops the next entry off the vEVENTQ stream, returning `None` once it is
+/// exhausted or found to be truncated.
+///
+/// The stream is a packed run of headers, each followed by an ARM SMMUv3 record
+/// unless it carries `LOST_EVENTS`. Every reported event consumes a sequence
+/// number, including ones the host had no room to queue, so a gap between
+/// adjacent headers counts exactly the records lost in between.
+fn next_vevent(stream: &mut &[u8], last_sequence: &mut Option<u32>) -> Option<VEvent> {
+    if stream.is_empty() {
+        return None;
+    }
+    let (header, rest) = IommufdVeventHeader::read_from_prefix(stream)
+        .inspect_err(|_| {
+            tracelimit::warn_ratelimited!(len = stream.len(), "smmu accel: truncated vEVENT header")
+        })
+        .ok()?;
+    *stream = rest;
+
+    let gap = last_sequence.map_or(0, |last| {
+        (header.sequence.wrapping_sub(last) % VEVENT_SEQUENCE_MODULUS).saturating_sub(1)
+    });
+    *last_sequence = Some(header.sequence);
+
+    // A `LOST_EVENTS` header stands in for a record the host could not queue,
+    // and carries no data of its own.
+    if header.flags & vfio_sys::iommufd::IOMMU_VEVENTQ_FLAG_LOST_EVENTS != 0 {
+        return Some(VEvent {
+            lost: gap + 1,
+            record: None,
+        });
+    }
+
+    let (event, rest) = IommuVeventArmSmmuv3::read_from_prefix(stream)
+        .inspect_err(|_| {
+            tracelimit::warn_ratelimited!(len = stream.len(), "smmu accel: truncated vEVENT record")
+        })
+        .ok()?;
+    *stream = rest;
+    Some(VEvent {
+        lost: gap,
+        record: Some(event.evt),
+    })
 }
 
 /// Per-device iommufd stream backend for HW-accelerated nested S1.
@@ -521,7 +774,7 @@ impl IommufdStreamBackend {
                 .hwpt_alloc(
                     0, // flags: not a nest parent
                     self.dev_id,
-                    self.accel.viommu_id, // parent is the vIOMMU
+                    self.accel.viommu.id, // parent is the vIOMMU
                     vfio_sys::iommufd::IOMMU_HWPT_DATA_ARM_SMMUV3,
                     Some(&ste_data),
                 )
@@ -571,7 +824,7 @@ impl smmu::Invalidate for SmmuAccelState {
         // kernel's ARM SMMUv3 invalidate command expects, so the emulator's
         // batch buffer is forwarded directly with no copy.
         match self.ctx.hwpt_invalidate(
-            self.viommu_id,
+            self.viommu.id,
             vfio_sys::iommufd::IOMMU_VIOMMU_INVALIDATE_DATA_ARM_SMMUV3,
             entries,
         ) {
@@ -718,5 +971,109 @@ impl AccelStream {
     /// clears the captured BDF.
     pub fn unbind(&mut self) {
         self.bound = None;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use test_with_tracing::test;
+    use zerocopy::IntoBytes;
+
+    fn push_header(stream: &mut Vec<u8>, flags: u32, sequence: u32) {
+        stream.extend_from_slice(IommufdVeventHeader { flags, sequence }.as_bytes());
+    }
+
+    fn push_record(stream: &mut Vec<u8>, flags: u32, sequence: u32, evt: [u64; 4]) {
+        push_header(stream, flags, sequence);
+        stream.extend_from_slice(IommuVeventArmSmmuv3 { evt }.as_bytes());
+    }
+
+    fn drain(stream: &[u8], last_sequence: &mut Option<u32>) -> Vec<(u32, Option<[u64; 4]>)> {
+        let mut stream = stream;
+        let mut out = Vec::new();
+        while let Some(event) = next_vevent(&mut stream, last_sequence) {
+            out.push((event.lost, event.record));
+        }
+        out
+    }
+
+    #[test]
+    fn vevent_stream_yields_each_record() {
+        let mut stream = Vec::new();
+        push_record(&mut stream, 0, 0, [1, 2, 3, 4]);
+        push_record(&mut stream, 0, 1, [5, 6, 7, 8]);
+
+        assert_eq!(
+            drain(&stream, &mut None),
+            [(0, Some([1, 2, 3, 4])), (0, Some([5, 6, 7, 8]))]
+        );
+    }
+
+    #[test]
+    fn vevent_sequence_gap_counts_lost_records() {
+        let mut stream = Vec::new();
+        push_record(&mut stream, 0, 3, [0; 4]);
+        // Sequences 4 and 5 never arrive, so two records were lost.
+        push_record(&mut stream, 0, 6, [9; 4]);
+
+        assert_eq!(
+            drain(&stream, &mut None),
+            [(0, Some([0; 4])), (2, Some([9; 4]))]
+        );
+    }
+
+    #[test]
+    fn vevent_sequence_wraps_at_i32_max() {
+        let mut stream = Vec::new();
+        push_record(&mut stream, 0, i32::MAX as u32, [0; 4]);
+        push_record(&mut stream, 0, 0, [1; 4]);
+        push_record(&mut stream, 0, 3, [2; 4]);
+
+        assert_eq!(
+            drain(&stream, &mut None),
+            [(0, Some([0; 4])), (0, Some([1; 4])), (2, Some([2; 4]))]
+        );
+    }
+
+    /// A trailing `LOST_EVENTS` header stands in for a record the host could
+    /// not queue, and carries no data.
+    #[test]
+    fn vevent_lost_events_header_reports_loss_without_a_record() {
+        let mut stream = Vec::new();
+        push_record(&mut stream, 0, 0, [7; 4]);
+        push_header(
+            &mut stream,
+            vfio_sys::iommufd::IOMMU_VEVENTQ_FLAG_LOST_EVENTS,
+            2,
+        );
+
+        // Sequence 1 was lost as well as the record this header stands for.
+        assert_eq!(drain(&stream, &mut None), [(0, Some([7; 4])), (2, None)]);
+    }
+
+    /// A read that ends mid-record must not be misparsed; the kernel only
+    /// writes whole records, so this can only mean a malformed stream.
+    #[test]
+    fn vevent_truncated_record_stops_the_stream() {
+        let mut stream = Vec::new();
+        push_record(&mut stream, 0, 0, [7; 4]);
+        push_header(&mut stream, 0, 1);
+
+        assert_eq!(drain(&stream, &mut None), [(0, Some([7; 4]))]);
+    }
+
+    /// Loss accounting continues across reads.
+    #[test]
+    fn vevent_sequence_carries_across_reads() {
+        let mut last_sequence = None;
+
+        let mut first = Vec::new();
+        push_record(&mut first, 0, 10, [0; 4]);
+        assert_eq!(drain(&first, &mut last_sequence), [(0, Some([0; 4]))]);
+
+        let mut second = Vec::new();
+        push_record(&mut second, 0, 13, [1; 4]);
+        assert_eq!(drain(&second, &mut last_sequence), [(2, Some([1; 4]))]);
     }
 }

--- a/vm/devices/pci/vfio_assigned_device/src/iommufd_nesting.rs
+++ b/vm/devices/pci/vfio_assigned_device/src/iommufd_nesting.rs
@@ -264,7 +264,15 @@ impl SmmuAccelState {
         vsmmu: &Arc<smmu::SmmuSharedState>,
         driver: &dyn SpawnDriver,
     ) -> anyhow::Result<Self> {
-        let viommu = PendingIommufdObject::new(&ctx, viommu_id, "vIOMMU");
+        let s2_parent_hwpt_id = parent.hwpt_id;
+        // Take ownership of the vIOMMU before allocating anything under it, so
+        // that the locals below are declared parent-first and therefore drop
+        // children-first on every error path.
+        let viommu = Arc::new(Viommu {
+            ctx: ctx.clone(),
+            _parent: parent,
+            id: viommu_id,
+        });
 
         // Pre-allocate the persistent abort and bypass nested HWPTs under this
         // vIOMMU (matching QEMU). Every device is always attached to a nested
@@ -277,7 +285,7 @@ impl SmmuAccelState {
             ctx.hwpt_alloc(
                 0,
                 dev_id,
-                viommu.id(),
+                viommu.id,
                 vfio_sys::iommufd::IOMMU_HWPT_DATA_ARM_SMMUV3,
                 Some(&vfio_sys::iommufd::IommuHwptArmSmmuv3 {
                     ste: ABORT_STE_DWORDS,
@@ -291,7 +299,7 @@ impl SmmuAccelState {
             ctx.hwpt_alloc(
                 0,
                 dev_id,
-                viommu.id(),
+                viommu.id,
                 vfio_sys::iommufd::IOMMU_HWPT_DATA_ARM_SMMUV3,
                 Some(&vfio_sys::iommufd::IommuHwptArmSmmuv3 {
                     ste: BYPASS_STE_DWORDS,
@@ -302,18 +310,13 @@ impl SmmuAccelState {
         );
 
         tracing::debug!(
-            viommu_id = viommu.id(),
-            s2_parent_hwpt_id = parent.hwpt_id,
+            viommu_id = viommu.id,
+            s2_parent_hwpt_id,
             abort_hwpt_id = abort_hwpt.id(),
             bypass_hwpt_id = bypass_hwpt.id(),
             "created SMMU accel state (vIOMMU)"
         );
 
-        let viommu = Arc::new(Viommu {
-            ctx: ctx.clone(),
-            _parent: parent,
-            id: viommu.into_id(),
-        });
         let veventq = spawn_veventq(&ctx, &viommu, vsmmu, driver)?;
         let abort_hwpt_id = abort_hwpt.into_id();
         let bypass_hwpt_id = bypass_hwpt.into_id();

--- a/vm/devices/pci/vfio_assigned_device/src/manager.rs
+++ b/vm/devices/pci/vfio_assigned_device/src/manager.rs
@@ -711,6 +711,9 @@ struct IoasManager {
     /// Next accelerated-state ID (unique within this manager).
     #[inspect(skip)]
     next_accel_state_id: u64,
+    /// Spawns and polls the per-vIOMMU vEVENTQ tasks.
+    #[inspect(skip)]
+    driver: Arc<dyn pal_async::driver::SpawnDriver>,
     #[inspect(skip)]
     recv: mesh::Receiver<IoasManagerRpc>,
 }
@@ -757,6 +760,7 @@ impl IoasManager {
         iommu_id: String,
         iommufd: File,
         dma_mapper_client: &DmaMapperClient,
+        driver: Arc<dyn pal_async::driver::SpawnDriver>,
         recv: mesh::Receiver<IoasManagerRpc>,
     ) -> anyhow::Result<Self> {
         let ctx = Arc::new(vfio_sys::iommufd::IommufdCtx::from_file(iommufd));
@@ -790,6 +794,7 @@ impl IoasManager {
             devices: Vec::new(),
             next_device_id: 0,
             next_accel_state_id: 0,
+            driver,
             recv,
         })
     }
@@ -863,6 +868,8 @@ impl IoasManager {
                             devid,
                             parent.clone(),
                             viommu_id,
+                            &vsmmu,
+                            self.driver.as_ref(),
                         )
                         .context("failed to create SMMU accel state")?,
                     );
@@ -1075,8 +1082,9 @@ pub(crate) struct VfioCdevManager {
     vsmmu_associations: VsmmuAssociations,
     /// DMA mapper client, cloned for each new per-iommu manager.
     dma_mapper_client: DmaMapperClient,
-    /// Spawner for per-iommu manager tasks.
-    spawner: Arc<dyn pal_async::task::Spawn>,
+    /// Spawner for per-iommu manager tasks, and driver for the vEVENTQ fds
+    /// they poll.
+    spawner: Arc<dyn pal_async::driver::SpawnDriver>,
     /// Per-iommu manager tasks (kept alive).
     tasks: Vec<pal_async::task::Task<()>>,
     recv: mesh::Receiver<VfioCdevManagerRpc>,
@@ -1157,7 +1165,7 @@ impl VfioCdevManagerClient {
 impl VfioCdevManager {
     /// Create a new cdev dispatcher.
     pub fn new(
-        spawner: Arc<dyn pal_async::task::Spawn>,
+        spawner: Arc<dyn pal_async::driver::SpawnDriver>,
         dma_mapper_client: DmaMapperClient,
     ) -> Self {
         Self {
@@ -1244,6 +1252,7 @@ impl VfioCdevManager {
                     iommu_id.clone(),
                     iommufd,
                     &self.dma_mapper_client,
+                    self.spawner.clone(),
                     ioas_recv,
                 )
                 .await

--- a/vm/devices/pci/vfio_assigned_device/src/resolver.rs
+++ b/vm/devices/pci/vfio_assigned_device/src/resolver.rs
@@ -128,11 +128,11 @@ pub struct VfioCdevDeviceResolver {
 impl VfioCdevDeviceResolver {
     /// Create a new cdev resolver, spawning the cdev dispatcher task.
     pub fn new(
-        spawner: impl pal_async::task::Spawn + 'static,
+        spawner: impl pal_async::driver::SpawnDriver,
         dma_mapper_client: DmaMapperClient,
     ) -> Self {
         // Arc the spawner so the dispatcher can spawn per-iommu manager tasks.
-        let spawner: Arc<dyn pal_async::task::Spawn> = Arc::new(spawner);
+        let spawner: Arc<dyn pal_async::driver::SpawnDriver> = Arc::new(spawner);
         let mut manager = crate::manager::VfioCdevManager::new(spawner.clone(), dma_mapper_client);
         let client = manager.client();
         let task = spawner.spawn("vfio-cdev-dispatch", manager.run());

--- a/vm/devices/user_driver/vfio_sys/Cargo.toml
+++ b/vm/devices/user_driver/vfio_sys/Cargo.toml
@@ -19,6 +19,7 @@ thiserror.workspace = true
 tracelimit.workspace = true
 tracing.workspace = true
 vfio-bindings.workspace = true
+zerocopy.workspace = true
 
 [lints]
 workspace = true

--- a/vm/devices/user_driver/vfio_sys/src/iommufd.rs
+++ b/vm/devices/user_driver/vfio_sys/src/iommufd.rs
@@ -17,6 +17,10 @@
 use anyhow::Context as _;
 use std::fs;
 use std::os::unix::prelude::*;
+use zerocopy::FromBytes;
+use zerocopy::Immutable;
+use zerocopy::IntoBytes;
+use zerocopy::KnownLayout;
 
 /// iommufd ioctl type character (';' = 0x3B).
 const IOMMUFD_TYPE: u8 = b';';
@@ -322,6 +326,10 @@ struct IommuVdeviceAlloc {
 /// vEVENTQ type: ARM SMMUv3.
 pub const IOMMU_VEVENTQ_TYPE_ARM_SMMUV3: u32 = 1;
 
+/// `IommufdVeventHeader::flags`: the queue lost one or more events before this
+/// one. No event data follows a header carrying this flag.
+pub const IOMMU_VEVENTQ_FLAG_LOST_EVENTS: u32 = 1 << 0;
+
 #[repr(C)]
 struct IommuVeventqAlloc {
     size: u32,
@@ -335,7 +343,11 @@ struct IommuVeventqAlloc {
 }
 
 /// Header for each event in a vEVENTQ fd read.
+///
+/// `sequence` is monotonic over `[0, i32::MAX]`, wrapping back to 0. A gap of
+/// more than 1 between adjacent headers means the intervening events were lost.
 #[repr(C)]
+#[derive(Copy, Clone, FromBytes, Immutable, IntoBytes, KnownLayout)]
 pub struct IommufdVeventHeader {
     pub flags: u32,
     pub sequence: u32,
@@ -343,8 +355,12 @@ pub struct IommufdVeventHeader {
 
 /// ARM SMMUv3 virtual event record (256-bit, little-endian).
 ///
-/// Follows an `IommufdVeventHeader` in the vEVENTQ fd read stream.
+/// Follows an `IommufdVeventHeader` in the vEVENTQ fd read stream. The four
+/// quadwords are a verbatim SMMUv3 Event queue record, except that the kernel
+/// has rewritten the StreamID field to the virtual StreamID the vDevice was
+/// allocated with.
 #[repr(C)]
+#[derive(Copy, Clone, FromBytes, Immutable, IntoBytes, KnownLayout)]
 pub struct IommuVeventArmSmmuv3 {
     pub evt: [u64; 4],
 }

--- a/vmm_tests/vmm_tests/tests/tests/aarch64_exclusive.rs
+++ b/vmm_tests/vmm_tests/tests/tests/aarch64_exclusive.rs
@@ -651,3 +651,196 @@ async fn assigned_device_peer_to_peer_dma_aarch64_tcg(
     vm.wait_for_clean_teardown().await?;
     Ok(())
 }
+
+/// Verify that a fault taken by the *physical* SMMU on an accelerated stream is
+/// forwarded to the guest's Event queue.
+///
+/// An accelerated stream translates in hardware, so the VMM is not in its DMA
+/// data path and cannot observe — let alone synthesize — its faults. They are
+/// reported by the physical SMMU and reach the VMM only through the iommufd
+/// vEVENTQ, which is the path under test.
+///
+/// `edu` is a deterministic fault generator here: it has no in-tree Linux
+/// driver, so with `iommu.passthrough=0` its IOMMU group gets a translating
+/// default domain that nothing ever populates, and any DMA it initiates hits an
+/// unmapped IOVA. The guest programs the DMA itself with `devmem`, so the fault
+/// is produced on demand rather than raced for.
+///
+/// The `_aarch64_tcg` name suffix opts this test into the TCG incubator pass.
+#[vmm_test_with(openvmm, requires(edu_initiator), configs(linux_direct_aarch64))]
+async fn assigned_device_smmu_accel_fault_aarch64_tcg(
+    config: PetriVmBuilder<OpenVmmPetriBackend>,
+    _: (),
+    driver: DefaultDriver,
+) -> anyhow::Result<()> {
+    let edu_bdf = incubator_vfio_bdf("edu-initiator")?;
+
+    tracing::info!(%edu_bdf, "assigning the edu fault generator behind an accelerated SMMU");
+
+    let edu_cdev = open_vfio_cdev(&edu_bdf)?;
+    let iommufd = std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open("/dev/iommu")
+        .context("failed to open /dev/iommu")?;
+
+    let (vm, agent) = config
+        .with_no_vmbus()
+        .with_memory(petri::MemoryConfig {
+            startup_bytes: 1024 * 1024 * 1024,
+            ..Default::default()
+        })
+        .modify_backend(move |b| {
+            b.with_pcie_root_topology(1, 1, 3)
+                .with_smmu_accel(&["s0rc0"])
+                .with_custom_config(move |c| {
+                    c.hypervisor.with_hv = false;
+                    if let openvmm_defs::config::LoadMode::Linux { cmdline, .. } = &mut c.load_mode
+                    {
+                        cmdline.push_str(" iommu.passthrough=0");
+                    }
+                    for rc in &mut c.pcie_root_complexes {
+                        if rc.name == "s0rc0" {
+                            for port in &mut rc.ports {
+                                port.acs_capabilities_supported = Some(0x5D);
+                            }
+                        }
+                    }
+                    c.pcie_devices.push(openvmm_defs::config::PcieDeviceConfig {
+                        port_name: "s0rc0rp1".into(),
+                        resource: vfio_assigned_device_resources::VfioCdevDeviceHandle {
+                            pci_id: edu_bdf,
+                            cdev: edu_cdev,
+                            iommufd,
+                            iommu_id: "iommu0".into(),
+                            bar_addresses: [BarAddressConfig::GuestAssigned; 6],
+                        }
+                        .into_resource(),
+                    });
+                })
+        })
+        .run()
+        .await?;
+
+    let sh = agent.unix_shell();
+
+    // Find edu inside the guest by its PCI ID, since its guest BDF is assigned
+    // by the guest's own enumeration rather than inherited from the host.
+    const EDU_VENDOR_DEVICE: &str = "0x11e8";
+    let mut guest_bdf = None;
+    for entry in cmd!(sh, "ls /sys/bus/pci/devices")
+        .read()
+        .await?
+        .split_whitespace()
+    {
+        let device = sh
+            .read_file(format!("/sys/bus/pci/devices/{entry}/device"))
+            .await?;
+        if device.trim() == EDU_VENDOR_DEVICE {
+            guest_bdf = Some(entry.to_string());
+            break;
+        }
+    }
+    let guest_bdf = guest_bdf.context("the assigned edu device did not enumerate in the guest")?;
+
+    // The SMMU's StreamID for a device on segment 0 is its RID, so the fault
+    // the guest logs must name exactly this value.
+    let (bus, dev, func) = {
+        let (_segment, rest) = guest_bdf
+            .split_once(':')
+            .context("unexpected guest BDF format")?;
+        let (bus, rest) = rest
+            .split_once(':')
+            .context("unexpected guest BDF format")?;
+        let (dev, func) = rest
+            .split_once('.')
+            .context("unexpected guest BDF format")?;
+        (
+            u32::from_str_radix(bus, 16)?,
+            u32::from_str_radix(dev, 16)?,
+            u32::from_str_radix(func, 16)?,
+        )
+    };
+    let expected_sid = (bus << 8) | (dev << 3) | func;
+    tracing::info!(guest_bdf, expected_sid, "located the assigned edu device");
+
+    // Nothing binds edu, so its default domain stays empty and any IOVA it
+    // touches faults. Confirm the domain is translating rather than identity —
+    // an identity domain would make the DMA below succeed silently.
+    let group_type = sh
+        .read_file(format!("/sys/bus/pci/devices/{guest_bdf}/iommu_group/type"))
+        .await?;
+    anyhow::ensure!(
+        matches!(group_type.trim(), "DMA" | "DMA-FQ"),
+        "expected edu in a translating SMMU domain, got {:?}",
+        group_type.trim()
+    );
+
+    // Enable memory-space decode and bus mastering so edu decodes its BARs and
+    // can initiate DMA. 0x0006 = MEM (bit 1) | BUSMASTER (bit 2) at COMMAND.
+    let cfg = format!("/sys/bus/pci/devices/{guest_bdf}/config");
+    cmd!(sh, "dd of={cfg} bs=1 seek=4 count=2 conv=notrunc")
+        .stdin([0x06u8, 0x00u8])
+        .ignore_stdout()
+        .run()
+        .await
+        .context("failed to enable MEM|BUSMASTER on the assigned edu device")?;
+
+    let resource = sh
+        .read_file(format!("/sys/bus/pci/devices/{guest_bdf}/resource"))
+        .await?;
+    let bar0 = resource
+        .lines()
+        .next()
+        .and_then(|l| l.split_whitespace().next())
+        .context("edu BAR0 missing from its sysfs resource list")?;
+    let bar0 = u64::from_str_radix(bar0.trim().trim_start_matches("0x"), 16)
+        .context("failed to parse the edu BAR0 base")?;
+
+    let devmem_write = async |addr: u64, val: u64| -> anyhow::Result<()> {
+        let addr = format!("{addr:#x}");
+        let val = format!("{val:#x}");
+        cmd!(sh, "devmem {addr} 64 {val}").run().await
+    };
+
+    // edu BAR0 register map: 0x80 DMA source, 0x88 destination, 0x90 byte
+    // count, 0x98 command (bit 0 RUN, bit 1 direction, 1 = edu buffer -> bus).
+    // edu's internal buffer is addressed at 0x40000; the destination is an
+    // arbitrary bus address that the empty default domain cannot translate.
+    const EDU_BUF: u64 = 0x40000;
+    const UNMAPPED_IOVA: u64 = 0x1_0000_0000;
+    devmem_write(bar0 + 0x80, EDU_BUF).await?;
+    devmem_write(bar0 + 0x88, UNMAPPED_IOVA).await?;
+    devmem_write(bar0 + 0x90, 4).await?;
+    devmem_write(bar0 + 0x98, 3).await?; // RUN | TO_PCI
+
+    // edu runs the transfer on a ~100ms timer, and the fault then crosses the
+    // physical SMMU, the host kernel, the vEVENTQ and the guest's Event queue
+    // interrupt before it is logged.
+    let expected = format!("sid: {expected_sid:#x}");
+    let mut timer = PolledTimer::new(&driver);
+    let mut dmesg = String::new();
+    for _ in 0..30 {
+        dmesg = cmd!(sh, "dmesg").read().await?;
+        if dmesg
+            .lines()
+            .any(|l| l.contains("arm-smmu-v3") && l.contains(&expected))
+        {
+            tracing::info!("guest logged the forwarded SMMU fault");
+            agent.power_off().await?;
+            vm.wait_for_clean_teardown().await?;
+            return Ok(());
+        }
+        timer.sleep(Duration::from_millis(200)).await;
+    }
+
+    let smmu_lines: Vec<&str> = dmesg
+        .lines()
+        .filter(|l| l.contains("arm-smmu-v3"))
+        .collect();
+    anyhow::bail!(
+        "the guest never logged an SMMU event naming {expected:?}; the physical SMMU's \
+         fault did not reach the guest Event queue. SMMU lines:\n{}",
+        smmu_lines.join("\n")
+    )
+}


### PR DESCRIPTION
A stream that translates in hardware takes its faults in the physical SMMU, which the VMM is not in the data path of, so the emulator can neither observe those faults nor synthesize them from the guest's configuration. Until now they were simply lost: an accelerated device could fault forever and the guest would never hear about it.

Allocate one vEVENTQ per vIOMMU alongside the abort and bypass page tables, and drain it from a task that writes each record into the guest's Event queue. The kernel has already rewritten the StreamID into the guest's namespace and the record is otherwise a verbatim SMMUv3 event, so injection is a reinterpretation rather than a translation. Queue depth comes from the largest Event queue the guest can configure on this SMMU, since buffering more than that would only defer a loss the guest takes anyway.

Teardown is the interesting part. The queue fd holds a kernel reference on the queue object and the queue holds one on the vIOMMU, so they have to be released inwards, but the poll task lives on an executor while the objects are released from a synchronous Drop. Rather than block, the vIOMMU moves behind its own Arc: the task's future owns the fd, the queue handle and a strong vIOMMU reference in that field order, so cancelling the task tears everything down in the required order and the last reference out destroys the vIOMMU. The queue fd also reads as zero bytes when empty instead of failing with EAGAIN, so the read helper clears cached readiness before each read rather than treating a short read as end of file.

Reporting lost records exposed a pre-existing bug. The emulator was signalling GERROR.EVENTQ_ABT_ERR when it discarded an event from a full queue, but per IHI 0070H.a §7.4 an Event queue overflow is EVENTQ_PROD.OVFLG differing from EVENTQ_CONS.OVACKFLG, toggled only once software has acknowledged the previous one; §7.2.2 reserves EVENTQ_ABT_ERR for an external abort accessing the queue. Linux detects overflow through the former and acknowledges it through the latter half of that handshake, so the old signal was invisible to the guest. Model the producer and consumer registers with their spec types, toggle OVFLG on a discard, raise EVENTQ_ABT_ERR only when the queue write itself fails, and honor the rule that the queue is unwritable while an abort is unacknowledged. Records the host dropped are then reported the same way as ones the emulator dropped, which is what the guest would have observed either way.

Covered by a new incubator test that puts QEMU's edu device behind an accelerated SMMU with iommu.passthrough=0 — it has no in-tree driver, so its default domain is translating and empty — and has the guest program a DMA to an unmapped IOVA. The guest's arm-smmu-v3 driver logs a translation fault naming the expected StreamID.