### PR TITLE
vmm_tests: Fix temp dir handling in init_vmm_tests_env

### DIFF
--- a/flowey/flowey_lib_hvlite/Cargo.toml
+++ b/flowey/flowey_lib_hvlite/Cargo.toml
@@ -22,11 +22,9 @@ paste.workspace = true
 serde = { workspace = true, features = ["std"] }
 serde_json = { workspace = true, features = ["std"] }
 target-lexicon = { workspace = true, features = ["serde_support"] }
+tempfile.workspace = true
 toml_edit.workspace = true
 which.workspace = true
-
-[dev-dependencies]
-tempfile.workspace = true
 
 [target.'cfg(windows)'.dependencies]
 crossterm = { workspace = true, features = ["windows"] }

--- a/flowey/flowey_lib_hvlite/src/init_vmm_tests_env.rs
+++ b/flowey/flowey_lib_hvlite/src/init_vmm_tests_env.rs
@@ -185,7 +185,7 @@ impl SimpleFlowNode for Node {
                 let test_content_dir = rt.read(test_content_dir);
 
                 let test_log_dir = test_content_dir.join("test_results");
-                let temp_dir = test_content_dir.join("temp");
+                let temp_dir = tempfile::tempdir_in(&test_content_dir)?;
 
                 let mut env = BTreeMap::new();
 
@@ -218,7 +218,7 @@ impl SimpleFlowNode for Node {
                 // Eagerly convert all known paths.
                 let converted_content_dir = wsl_convert_path(&test_content_dir)?;
                 let converted_log_dir = wsl_convert_path(&test_log_dir)?;
-                let converted_temp_dir = wsl_convert_path(&temp_dir)?;
+                let converted_temp_dir = wsl_convert_path(temp_dir.path())?;
                 let converted_disk_image_dir = disk_image_dir
                     .as_ref()
                     .map(|p| wsl_convert_path(p))
@@ -276,10 +276,6 @@ impl SimpleFlowNode for Node {
                     make_portable_path(converted_log_dir)?,
                 );
 
-                if temp_dir.exists() {
-                    fs_err::remove_dir_all(&temp_dir)?;
-                };
-                fs_err::create_dir(&temp_dir)?;
                 let portable_temp_dir = make_portable_path(converted_temp_dir)?;
                 if matches!(rt.platform().kind(), FlowPlatformKind::Windows) || windows_via_wsl2 {
                     env.insert("TEMP".into(), portable_temp_dir.clone());


### PR DESCRIPTION
PR #4246 changed how temp dirs are handled during vmm test environment setup. Since that PR landed we've seen a few hits of: 

Error: failed to remove directory `E:\actions-runner\_work\_temp\test\temp`:
The process cannot access the file because it is being used by another process. (os error 32)

Try to fix this by using tempfile to create new, unique temp directories instead, that will clean up after themselves automatically.