### PR TITLE
[release/1.8.2607] cvm: improve boot times by parallelize applying vtl protections and z…

### DIFF
--- a/openhcl/underhill_mem/src/init.rs
+++ b/openhcl/underhill_mem/src/init.rs
@@ -9,6 +9,7 @@ use crate::mapping::GuestMemoryMapping;
 use crate::mapping::GuestMemoryView;
 use crate::mapping::GuestMemoryViewReadType;
 use crate::mapping::GuestPartitionMemoryView;
+use crate::parallelize_mem_op;
 use anyhow::Context;
 use cvm_tracing::CVM_ALLOWED;
 use futures::future::try_join_all;
@@ -112,6 +113,8 @@ pub async fn init(params: &Init<'_>) -> anyhow::Result<MemoryMappings> {
         None
     };
 
+    let vp_count = params.processor_topology.vp_count();
+
     let hardware_isolated = params.isolation.is_hardware_isolated();
 
     if let Some(boot_init) = &params.boot_init {
@@ -135,16 +138,17 @@ pub async fn init(params: &Init<'_>) -> anyhow::Result<MemoryMappings> {
             // VTL2 only permissions. Provide VTL0 access here.
             tracing::debug!("Applying VTL0 protections");
             if hardware_isolated {
-                for range in memory_range::overlapping_ranges(ram.clone(), accepted_ranges.clone())
-                {
-                    acceptor.apply_initial_lower_vtl_protections(range)?;
-                }
+                let accepted_ram: Vec<_> =
+                    memory_range::overlapping_ranges(ram.clone(), accepted_ranges.clone())
+                        .collect();
+                parallelize_mem_op(&accepted_ram, vp_count, |range| {
+                    acceptor.apply_initial_lower_vtl_protections(range)
+                })?;
             }
 
             // Accept the memory that was not accepted by the boot loader.
             // FUTURE: do this lazily.
-            let vp_count = std::cmp::max(1, params.processor_topology.vp_count() - 1);
-            let accept_subrange = move |subrange| {
+            let accept_subrange = move |subrange| -> Result<(), std::convert::Infallible> {
                 acceptor.accept_lower_vtl_pages(subrange).unwrap();
                 if hardware_isolated {
                     // For VBS-isolated VMs, the VTL protections are set as
@@ -153,42 +157,16 @@ pub async fn init(params: &Init<'_>) -> anyhow::Result<MemoryMappings> {
                         .apply_initial_lower_vtl_protections(subrange)
                         .unwrap();
                 }
+                Ok(())
             };
             tracing::debug!("Accepting VTL0 memory");
-            std::thread::scope(|scope| {
-                for source_range in memory_range::subtract_ranges(ram, accepted_ranges) {
-                    validated_ranges.push(source_range);
 
-                    // Chunks must be 2mb aligned
-                    let two_mb = 2 * 1024 * 1024;
-                    let mut range = source_range.aligned_subrange(two_mb);
-                    if !range.is_empty() {
-                        let chunk_size = (range.page_count_2m().div_ceil(vp_count as u64)) * two_mb;
-                        let chunk_count = range.len().div_ceil(chunk_size);
+            let source_ranges =
+                memory_range::subtract_ranges(ram, accepted_ranges).collect::<Vec<_>>();
+            validated_ranges.extend_from_slice(&source_ranges);
 
-                        for _ in 0..chunk_count {
-                            let subrange;
-                            (subrange, range) = if range.len() >= chunk_size {
-                                range.split_at_offset(chunk_size)
-                            } else {
-                                (range, MemoryRange::EMPTY)
-                            };
-                            scope.spawn(move || accept_subrange(subrange));
-                        }
-                        assert!(range.is_empty());
-                    }
-
-                    // Now accept whatever wasn't aligned on the edges
-                    scope.spawn(move || {
-                        for unaligned_subrange in memory_range::subtract_ranges(
-                            [source_range],
-                            [source_range.aligned_subrange(two_mb)],
-                        ) {
-                            accept_subrange(unaligned_subrange);
-                        }
-                    });
-                }
-            });
+            parallelize_mem_op(&source_ranges, vp_count, accept_subrange)
+                .expect("accepting VTL0 memory should not fail");
         }
     }
 
@@ -226,9 +204,9 @@ pub async fn init(params: &Init<'_>) -> anyhow::Result<MemoryMappings> {
 
         // Create the encrypted mapping with just the lower VTL memory.
         //
-        // Do not register this mapping with the kernel. It will not be safe for
-        // use with syscalls that expect virtual addresses to be in
-        // kernel-registered RAM.
+        // Do not register this mapping object with the kernel. SNP registration
+        // is associated with the separate VTL0 mapping below after every lower
+        // VTL mapping has been established.
 
         tracing::debug!("Building valid encrypted memory view");
         let encrypted_memory_view = {
@@ -255,14 +233,17 @@ pub async fn init(params: &Init<'_>) -> anyhow::Result<MemoryMappings> {
         // TODO GUEST VSM: with lazy acceptance, it should instead be initialized to no
         // access.
         tracing::debug!("Building VTL0 memory map");
-        let vtl0_mapping = Arc::new({
+        let vtl0_mapping = {
             let _span = tracing::info_span!("map_vtl0_memory", CVM_ALLOWED).entered();
             GuestMemoryMapping::builder(0)
                 .dma_base_address(None)
+                // Configure the registrar now, but do not register until all
+                // aliases have been mapped.
+                .for_kernel_access(params.isolation == IsolationType::Snp)
                 .use_permissions_bitmaps(if use_vtl1 { Some(true) } else { None })
                 .build_with_bitmap(&gpa_fd, &encrypted_memory_view)
                 .context("failed to map vtl0 memory")?
-        });
+        };
 
         // Create the shared mapping with the complete memory map, to include
         // the shared pool. This memory is not private to VTL2 and is expected
@@ -358,6 +339,16 @@ pub async fn init(params: &Init<'_>) -> anyhow::Result<MemoryMappings> {
                 .context("failed to map shared memory")?
         });
 
+        if params.isolation == IsolationType::Snp {
+            // The kernel can now create PUD-sized backing for aligned 1-GB
+            // ranges before the zeroing pass faults in the private mapping.
+            let _span = tracing::info_span!("register_vtl0_memory", CVM_ALLOWED).entered();
+            vtl0_mapping
+                .register_all_memory()
+                .context("failed to eagerly register SNP VTL0 memory")?;
+        }
+        let vtl0_mapping = Arc::new(vtl0_mapping);
+
         let protector = Arc::new(HardwareIsolatedMemoryProtector::new(
             encrypted_memory_view.partition_valid_memory().clone(),
             valid_shared_memory.clone(),
@@ -365,6 +356,7 @@ pub async fn init(params: &Init<'_>) -> anyhow::Result<MemoryMappings> {
             vtl0_mapping.clone(),
             params.mem_layout.clone(),
             acceptor.as_ref().unwrap().clone(),
+            params.processor_topology.vp_count(),
         )) as Arc<dyn ProtectIsolatedMemory>;
 
         tracing::debug!("Creating VTL0 guest memory");
@@ -432,11 +424,10 @@ pub async fn init(params: &Init<'_>) -> anyhow::Result<MemoryMappings> {
                 tracing::info_span!("zeroing lower vtl memory for SNP", CVM_ALLOWED).entered();
 
             tracing::debug!("zeroing lower vtl memory for SNP");
-            for range in validated_ranges {
-                vtl0_gm
-                    .fill_at(range.start(), 0, range.len() as usize)
-                    .expect("private memory should be valid at this stage");
-            }
+            parallelize_mem_op(&validated_ranges, vp_count, |range| {
+                vtl0_gm.fill_at(range.start(), 0, range.len() as usize)
+            })
+            .expect("private memory should be valid at this stage");
         }
 
         // Untrusted devices can only access shared memory, but they can do so

--- a/openhcl/underhill_mem/src/lib.rs
+++ b/openhcl/underhill_mem/src/lib.rs
@@ -39,6 +39,7 @@ use hvdef::hypercall::HostVisibilityType;
 use hvdef::hypercall::HvInputVtl;
 use mapping::GuestMemoryMapping;
 use mapping::GuestValidMemory;
+use memory_range::AlignedSubranges;
 use memory_range::MemoryRange;
 use parking_lot::Mutex;
 use parking_lot::MutexGuard;
@@ -46,6 +47,7 @@ use registrar::RegisterMemory;
 use std::collections::VecDeque;
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering;
 use thiserror::Error;
 use virt::IsolationType;
 use virt_mshv_vtl::GpnSource;
@@ -382,6 +384,8 @@ pub struct HardwareIsolatedMemoryProtector {
     acceptor: Arc<MemoryAcceptor>,
     vtl0: Arc<GuestMemoryMapping>,
     vtl1_protections_enabled: AtomicBool,
+    /// Number of VPs, used to parallelize long-running memory operations.
+    vp_count: u32,
 }
 
 struct HardwareIsolatedMemoryProtectorInner {
@@ -413,6 +417,7 @@ impl HardwareIsolatedMemoryProtector {
         vtl0: Arc<GuestMemoryMapping>,
         layout: MemoryLayout,
         acceptor: Arc<MemoryAcceptor>,
+        vp_count: u32,
     ) -> Self {
         Self {
             inner: Mutex::new(HardwareIsolatedMemoryProtectorInner {
@@ -432,49 +437,13 @@ impl HardwareIsolatedMemoryProtector {
             acceptor,
             vtl0,
             vtl1_protections_enabled: AtomicBool::new(false),
+            vp_count,
         }
     }
 
-    fn apply_protections_with_overlay_handling(
-        &self,
-        range: MemoryRange,
-        target_vtl: GuestVtl,
-        protections: HvMapGpaFlags,
-        inner: &mut MutexGuard<'_, HardwareIsolatedMemoryProtectorInner>,
-    ) -> Result<(), ApplyVtlProtectionsError> {
-        let mut range_queue = VecDeque::new();
-        range_queue.push_back(range);
-
-        'outer: while let Some(range) = range_queue.pop_front() {
-            for overlay_page in inner.overlay_pages[target_vtl].iter_mut() {
-                let overlay_addr = overlay_page.gpn * HV_PAGE_SIZE;
-                if range.contains_addr(overlay_addr) {
-                    // If the overlay page is within the range, update the
-                    // permissions that will be restored when it is unlocked.
-                    overlay_page.previous_permissions = protections;
-                    // And split the range around it.
-                    let (left, right_with_overlay) =
-                        range.split_at_offset(range.offset_of(overlay_addr).unwrap());
-                    let (overlay, right) = right_with_overlay.split_at_offset(HV_PAGE_SIZE);
-                    debug_assert_eq!(overlay.start_4k_gpn(), overlay_page.gpn);
-                    debug_assert_eq!(overlay.len(), HV_PAGE_SIZE);
-                    if !left.is_empty() {
-                        range_queue.push_back(left);
-                    }
-                    if !right.is_empty() {
-                        range_queue.push_back(right);
-                    }
-                    continue 'outer;
-                }
-            }
-            // We can only reach here if the range does not contain any overlay
-            // pages, so now we can apply the protections to the range.
-            self.apply_protections(range, target_vtl, protections, GpnSource::GuestMemory)?
-        }
-
-        Ok(())
-    }
-
+    /// Apply the given protections to the given range for the given VTL.
+    /// Overlay page permissions are tracked separately; those permissions are
+    /// not updated here.
     fn apply_protections(
         &self,
         range: MemoryRange,
@@ -486,6 +455,7 @@ impl HardwareIsolatedMemoryProtector {
             // Only permissions imposed on VTL 0 guest memory are explicitly tracked
             self.vtl0.update_permission_bitmaps(range, protections);
         }
+
         self.acceptor
             .apply_protections(range, target_vtl, protections)
     }
@@ -862,15 +832,57 @@ impl ProtectIsolatedMemory for HardwareIsolatedMemoryProtector {
             }
         }
 
-        for range in ranges {
-            self.apply_protections_with_overlay_handling(
-                range,
+        tracing::trace!("Applying default vtl protections.");
+
+        let protect_subrange = move |subrange: MemoryRange| {
+            self.apply_protections(
+                subrange,
                 target_vtl,
                 vtl_protections,
-                &mut inner,
+                GpnSource::GuestMemory,
             )
-            .unwrap();
+        };
+
+        // Handle overlay pages first, collecting the ranges that don't contain
+        // any so they can be protected in parallel below.
+        let mut protect_ranges = Vec::new();
+        for source_range in ranges {
+            let mut range_queue = VecDeque::new();
+            range_queue.push_back(source_range);
+
+            'outer: while let Some(range) = range_queue.pop_front() {
+                for overlay_page in inner.overlay_pages[target_vtl].iter_mut() {
+                    let overlay_addr = overlay_page.gpn * HV_PAGE_SIZE;
+                    if range.contains_addr(overlay_addr) {
+                        // If the overlay page is within the range, update the
+                        // permissions that will be restored when it is unlocked.
+                        overlay_page.previous_permissions = vtl_protections;
+                        // And split the range around it.
+                        let (left, right_with_overlay) =
+                            range.split_at_offset(range.offset_of(overlay_addr).unwrap());
+                        let (overlay, right) = right_with_overlay.split_at_offset(HV_PAGE_SIZE);
+                        debug_assert_eq!(overlay.start_4k_gpn(), overlay_page.gpn);
+                        debug_assert_eq!(overlay.len(), HV_PAGE_SIZE);
+                        if !left.is_empty() {
+                            range_queue.push_back(left);
+                        }
+                        if !right.is_empty() {
+                            range_queue.push_back(right);
+                        }
+                        continue 'outer;
+                    }
+                }
+
+                // We can only reach here if the range does not contain any overlay
+                // pages, so it can be protected in parallel.
+                protect_ranges.push(range);
+            }
         }
+
+        parallelize_mem_op(&protect_ranges, self.vp_count, protect_subrange)
+            .expect("applying default VTL protections should not fail");
+
+        tracing::trace!("Finished applying default vtl protections.");
 
         // Flush any threads accessing pages that had their VTL protections
         // changed.
@@ -1118,12 +1130,150 @@ impl ProtectIsolatedMemory for HardwareIsolatedMemoryProtector {
     }
 
     fn set_vtl1_protections_enabled(&self) {
-        self.vtl1_protections_enabled
-            .store(true, std::sync::atomic::Ordering::Relaxed);
+        self.vtl1_protections_enabled.store(true, Ordering::Relaxed);
     }
 
     fn vtl1_protections_enabled(&self) -> bool {
-        self.vtl1_protections_enabled
-            .load(std::sync::atomic::Ordering::Relaxed)
+        self.vtl1_protections_enabled.load(Ordering::Relaxed)
+    }
+}
+
+pub(crate) fn parallelize_mem_op<E>(
+    source_ranges: &[MemoryRange],
+    vp_count: u32,
+    op: impl Fn(MemoryRange) -> Result<(), E> + Send + Sync + Copy,
+) -> Result<(), E>
+where
+    E: Send,
+{
+    const LARGE_PAGE_SIZE: u64 = 2 * 1024 * 1024;
+    // Cap the work unit size so that very large ranges are split across multiple
+    // workers instead of being handled by a single one.
+    const MAX_RANGE_LEN: u64 = 2 * 1024 * 1024 * 1024;
+
+    let worker_count = vp_count.saturating_sub(1).max(1);
+
+    let total_len = source_ranges
+        .iter()
+        .fold(0_u64, |len, range| len.saturating_add(range.len()));
+    let target_range_len = total_len
+        .div_ceil(u64::from(worker_count))
+        .clamp(LARGE_PAGE_SIZE, MAX_RANGE_LEN)
+        .next_multiple_of(LARGE_PAGE_SIZE)
+        .min(MAX_RANGE_LEN);
+
+    // Preserve large-page alignment while creating enough work to keep all
+    // workers busy, with a ceiling to balance very large memory ranges.
+    let ranges: Vec<_> = source_ranges
+        .iter()
+        .flat_map(|range| AlignedSubranges::new(*range).with_max_range_len(target_range_len))
+        .collect();
+    if ranges.is_empty() {
+        return Ok(());
+    }
+
+    std::thread::scope(|scope| {
+        // Divide the work up front so each worker owns a contiguous chunk of
+        // ranges, avoiding shared state between workers.
+        let chunk_len = ranges.len().div_ceil(worker_count as usize);
+        let workers: Vec<_> = ranges
+            .chunks(chunk_len)
+            .map(|chunk| {
+                scope.spawn(move || {
+                    for &range in chunk {
+                        op(range)?;
+                    }
+                    Ok::<(), E>(())
+                })
+            })
+            .collect();
+
+        for worker in workers {
+            worker.join().expect("memory range worker panicked")?;
+        }
+
+        Ok(())
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::convert::Infallible;
+
+    #[test]
+    fn parallelize_mem_op_covers_source_ranges() {
+        const MB: u64 = 1024 * 1024;
+
+        let source_ranges = [
+            MemoryRange::new(0x1000..7 * MB + 0x1000),
+            MemoryRange::new(10 * MB..11 * MB),
+        ];
+        let completed = Mutex::new(Vec::new());
+
+        parallelize_mem_op(&source_ranges, 5, |range| {
+            completed.lock().push(range);
+            Ok::<_, Infallible>(())
+        })
+        .unwrap();
+
+        let mut completed = completed.into_inner();
+        completed.sort_by_key(|range| range.start());
+
+        // The exact subdivision doesn't matter, only that the subranges tile
+        // the source ranges without gaps or overlaps.
+        assert!(
+            memory_range::flatten_ranges(completed).eq(memory_range::flatten_ranges(source_ranges))
+        );
+    }
+
+    #[test]
+    fn parallelize_mem_op_handles_empty_input() {
+        parallelize_mem_op(&[], 0, |_| Ok::<_, Infallible>(())).unwrap();
+    }
+
+    #[test]
+    fn parallelize_mem_op_fewer_workers_than_ranges() {
+        const MB: u64 = 1024 * 1024;
+        const PAGE: u64 = 0x1000;
+
+        // A mix of ranges that exercise the 2MB boundary in different ways:
+        // smaller and larger than 2MB, with aligned and unaligned starts/ends.
+        let source_ranges = [
+            // Sub-2MB, unaligned on both ends.
+            MemoryRange::new(PAGE..3 * PAGE),
+            // Sub-2MB, starts exactly on a 2MB boundary.
+            MemoryRange::new(2 * MB..2 * MB + PAGE),
+            // Sub-2MB, straddles a 2MB boundary.
+            MemoryRange::new(4 * MB - PAGE..4 * MB + PAGE),
+            // Exactly 2MB and fully aligned.
+            MemoryRange::new(6 * MB..8 * MB),
+            // Larger than 2MB, aligned start, unaligned end.
+            MemoryRange::new(10 * MB..12 * MB + PAGE),
+            // Larger than 2MB, unaligned start, aligned end, spanning boundaries.
+            MemoryRange::new(14 * MB + PAGE..18 * MB),
+        ];
+        let completed = Mutex::new(Vec::new());
+
+        // Fewer workers than ranges, so each worker processes multiple ranges.
+        parallelize_mem_op(&source_ranges, 4, |range| {
+            completed.lock().push(range);
+            Ok::<_, Infallible>(())
+        })
+        .unwrap();
+
+        let mut completed = completed.into_inner();
+        completed.sort_by_key(|range| range.start());
+
+        assert!(
+            memory_range::flatten_ranges(completed).eq(memory_range::flatten_ranges(source_ranges))
+        );
+    }
+
+    #[test]
+    fn parallelize_mem_op_propagates_worker_error() {
+        let error = parallelize_mem_op(&[MemoryRange::new(0..0x1000)], 2, |_| Err("failed"));
+
+        assert_eq!(error, Err("failed"));
     }
 }

--- a/openhcl/underhill_mem/src/mapping.rs
+++ b/openhcl/underhill_mem/src/mapping.rs
@@ -388,15 +388,27 @@ pub enum VtlPermissionsError {
     NoPermissionsTracked,
 }
 
+#[derive(Debug, Error)]
+pub(crate) enum RegisterMemoryError {
+    #[error("memory mapping is not configured for kernel registration")]
+    NotConfigured,
+    #[error("failed to register memory starting at {address:#x}")]
+    RegistrationFailed { address: u64 },
+}
+
 #[derive(Debug)]
 struct GuestMemoryBitmap {
     bitmap: SparseMapping,
 }
 
 impl GuestMemoryBitmap {
+    const PAGES_PER_CHUNK: u64 = 8;
+    const BYTES_PER_CHUNK: u64 = PAGE_SIZE as u64 * Self::PAGES_PER_CHUNK;
     fn new(address_space_size: usize) -> Result<Self, MappingError> {
-        let bitmap = SparseMapping::new((address_space_size / PAGE_SIZE).div_ceil(8))
-            .map_err(MappingError::BitmapReserve)?;
+        let bitmap = SparseMapping::new(
+            (address_space_size / PAGE_SIZE).div_ceil(Self::PAGES_PER_CHUNK as usize),
+        )
+        .map_err(MappingError::BitmapReserve)?;
         bitmap
             .map_zero(0, bitmap.len())
             .map_err(MappingError::BitmapMap)?;
@@ -404,14 +416,14 @@ impl GuestMemoryBitmap {
     }
 
     fn init(&mut self, range: MemoryRange, state: bool) -> Result<(), MappingError> {
-        if !range.start().is_multiple_of(PAGE_SIZE as u64 * 8)
-            || !range.end().is_multiple_of(PAGE_SIZE as u64 * 8)
+        if !range.start().is_multiple_of(Self::BYTES_PER_CHUNK)
+            || !range.end().is_multiple_of(Self::BYTES_PER_CHUNK)
         {
             return Err(MappingError::BadAlignment(range));
         }
 
-        let bitmap_start = range.start() as usize / PAGE_SIZE / 8;
-        let bitmap_end = (range.end() - 1) as usize / PAGE_SIZE / 8;
+        let bitmap_start = (range.start() / Self::BYTES_PER_CHUNK) as usize;
+        let bitmap_end = ((range.end() - 1) / Self::BYTES_PER_CHUNK) as usize;
         let bitmap_page_start = bitmap_start / PAGE_SIZE;
         let bitmap_page_end = bitmap_end / PAGE_SIZE;
         let page_count = bitmap_page_end + 1 - bitmap_page_start;
@@ -432,10 +444,14 @@ impl GuestMemoryBitmap {
         if state {
             let start_gpn = range.start() / PAGE_SIZE as u64;
             let gpn_count = range.len() / PAGE_SIZE as u64;
-            assert_eq!(range.start() % 8, 0);
-            assert_eq!(gpn_count % 8, 0);
+            assert_eq!(range.start() % Self::PAGES_PER_CHUNK, 0);
+            assert_eq!(gpn_count % Self::PAGES_PER_CHUNK, 0);
             self.bitmap
-                .fill_at(start_gpn as usize / 8, 0xff, gpn_count as usize / 8)
+                .fill_at(
+                    (start_gpn / Self::PAGES_PER_CHUNK) as usize,
+                    0xff,
+                    (gpn_count / Self::PAGES_PER_CHUNK) as usize,
+                )
                 .unwrap();
         }
 
@@ -444,20 +460,40 @@ impl GuestMemoryBitmap {
 
     /// Panics if the range is outside of guest RAM.
     fn update(&self, range: MemoryRange, state: bool) {
-        for gpn in range.start() / PAGE_SIZE as u64..range.end() / PAGE_SIZE as u64 {
-            // TODO: use `fill_at` for the aligned part of the range.
-            let mut b = 0;
+        let aligned_range = range.aligned_subrange(Self::BYTES_PER_CHUNK);
+        if !aligned_range.is_empty() {
             self.bitmap
-                .read_at(gpn as usize / 8, std::slice::from_mut(&mut b))
+                .fill_at(
+                    (aligned_range.start() / Self::BYTES_PER_CHUNK) as usize,
+                    if state { u8::MAX } else { 0u8 },
+                    (aligned_range.len() / Self::BYTES_PER_CHUNK) as usize,
+                )
                 .unwrap();
-            if state {
-                b |= 1 << (gpn % 8);
-            } else {
-                b &= !(1 << (gpn % 8));
+        }
+
+        for unaligned_range in memory_range::subtract_ranges([range], [aligned_range]) {
+            for gpn in
+                unaligned_range.start() / PAGE_SIZE as u64..unaligned_range.end() / PAGE_SIZE as u64
+            {
+                let mut b = 0;
+                self.bitmap
+                    .read_at(
+                        (gpn / Self::PAGES_PER_CHUNK) as usize,
+                        std::slice::from_mut(&mut b),
+                    )
+                    .unwrap();
+                if state {
+                    b |= 1 << (gpn % Self::PAGES_PER_CHUNK);
+                } else {
+                    b &= !(1 << (gpn % Self::PAGES_PER_CHUNK));
+                }
+                self.bitmap
+                    .write_at(
+                        (gpn / Self::PAGES_PER_CHUNK) as usize,
+                        std::slice::from_ref(&b),
+                    )
+                    .unwrap();
             }
-            self.bitmap
-                .write_at(gpn as usize / 8, std::slice::from_ref(&b))
-                .unwrap();
         }
     }
 
@@ -466,9 +502,12 @@ impl GuestMemoryBitmap {
     fn page_state(&self, gpn: u64) -> bool {
         let mut b = 0;
         self.bitmap
-            .read_at(gpn as usize / 8, std::slice::from_mut(&mut b))
+            .read_at(
+                (gpn / Self::PAGES_PER_CHUNK) as usize,
+                std::slice::from_mut(&mut b),
+            )
             .unwrap();
-        b & (1 << (gpn % 8)) != 0
+        b & (1 << (gpn % Self::PAGES_PER_CHUNK)) != 0
     }
 
     fn as_ptr(&self) -> *mut u8 {
@@ -715,6 +754,15 @@ impl GuestMemoryMapping {
         }
     }
 
+    /// Register all mapped RAM before it is accessed.
+    pub(crate) fn register_all_memory(&self) -> Result<(), RegisterMemoryError> {
+        self.registrar
+            .as_ref()
+            .ok_or(RegisterMemoryError::NotConfigured)?
+            .register_all()
+            .map_err(|address| RegisterMemoryError::RegistrationFailed { address })
+    }
+
     /// Update the permission bitmaps to reflect the given flags.
     /// Panics if the range is outside of guest RAM.
     pub fn update_permission_bitmaps(&self, range: MemoryRange, flags: HvMapGpaFlags) {
@@ -757,8 +805,10 @@ impl GuestMemoryMapping {
 
 #[cfg(test)]
 mod tests {
+    use crate::mapping::GuestMemoryBitmap;
     use crate::mapping::GuestValidMemory;
     use crate::mapping::GuestValidMemoryType;
+    use guestmem::PAGE_SIZE;
     use memory_range::MemoryRange;
     use vm_topology::memory::MemoryLayout;
     use vm_topology::memory::MemoryRangeWithNode;
@@ -777,6 +827,66 @@ mod tests {
             GuestValidMemory::new(&memory_layout, GuestValidMemoryType::Encrypted, true).unwrap();
         for (i, &b) in [true, true, false, true, false].iter().enumerate() {
             assert_eq!(guest_valid_mem.check_valid(i as u64 * 8), b, "{i}");
+        }
+    }
+
+    #[test]
+    fn test_bitmap_update() {
+        const PAGE_COUNT: u64 = 24;
+
+        // Cover fully-aligned, single-edge, both-edge, sub-byte, and
+        // full-coverage ranges.
+        for gpn_range in [8..16, 3..21, 5..6, 8..13, 3..8, 0..24, 7..17] {
+            let mut bitmap = GuestMemoryBitmap::new(PAGE_COUNT as usize * PAGE_SIZE).unwrap();
+            bitmap
+                .init(MemoryRange::from_4k_gpn_range(0..PAGE_COUNT), false)
+                .unwrap();
+
+            let range = MemoryRange::from_4k_gpn_range(gpn_range.clone());
+            bitmap.update(range, true);
+            for gpn in 0..PAGE_COUNT {
+                assert_eq!(bitmap.page_state(gpn), gpn_range.contains(&gpn), "{gpn}");
+            }
+
+            bitmap.update(range, false);
+            for gpn in 0..PAGE_COUNT {
+                assert!(!bitmap.page_state(gpn), "{gpn}");
+            }
+        }
+    }
+
+    // Apply a sequence of overlapping and partially-overlapping updates and
+    // check the running state after each one.
+    #[test]
+    fn test_bitmap_update_overlapping() {
+        const PAGE_COUNT: u64 = 24;
+
+        let mut bitmap = GuestMemoryBitmap::new(PAGE_COUNT as usize * PAGE_SIZE).unwrap();
+        bitmap
+            .init(MemoryRange::from_4k_gpn_range(0..PAGE_COUNT), false)
+            .unwrap();
+
+        let mut expected = [false; PAGE_COUNT as usize];
+        let ops = [
+            (3..21, true),   // unaligned on both edges
+            (0..4, false),   // clears the left chunk, shares an edge
+            (6..10, true),   // partial overlap, re-sets some pages
+            (9..24, true),   // shares the right edge
+            (20..22, false), // clears an interior sub-byte span
+        ];
+
+        for (gpn_range, state) in ops {
+            bitmap.update(MemoryRange::from_4k_gpn_range(gpn_range.clone()), state);
+            for gpn in gpn_range.clone() {
+                expected[gpn as usize] = state;
+            }
+            for gpn in 0..PAGE_COUNT {
+                assert_eq!(
+                    bitmap.page_state(gpn),
+                    expected[gpn as usize],
+                    "gpn {gpn} after updating {gpn_range:?} to {state}"
+                );
+            }
         }
     }
 }

--- a/openhcl/underhill_mem/src/registrar.rs
+++ b/openhcl/underhill_mem/src/registrar.rs
@@ -14,10 +14,10 @@
 //! when a VA might leak out of a `GuestMemory` object and possibly be passed to
 //! a kernel routine.
 //!
-//! This is done by registering memory in 2GB chunks, which is large enough to
-//! get large pages in the kernel, but small enough to keep the overhead of the
-//! initial registration for a chunk small. We track whether a given chunk has
-//! been registered via a small bitmap.
+//! This is done by registering memory in 1-GB chunks. Fully aligned chunks can
+//! use PUD mappings in the kernel, while unaligned RAM edges automatically fall
+//! back to smaller mappings. We track whether a given chunk has been registered
+//! via a small bitmap.
 
 use cvm_tracing::CVM_ALLOWED;
 use inspect::Inspect;
@@ -107,8 +107,8 @@ impl<T: Fn(MemoryRange) -> Result<(), E>, E: 'static + std::error::Error> Regist
     }
 }
 
-/// Register in 2GB chunks.
-const GRANULARITY: u64 = 2 << 30;
+/// Register in 1-GB chunks so aligned RAM can use PUD mappings.
+const GRANULARITY: u64 = 1 << 30;
 
 impl<T: RegisterMemory> MemoryRegistrar<T> {
     pub fn new(layout: &MemoryLayout, registration_offset: u64, register: T) -> Self {
@@ -184,6 +184,12 @@ impl<T: RegisterMemory> MemoryRegistrar<T> {
         }
         Ok(())
     }
+
+    /// Register every RAM range in the address space.
+    pub fn register_all(&self) -> Result<(), u64> {
+        let address_space_size = self.ram.last().unwrap().end();
+        self.register(0, address_space_size)
+    }
 }
 
 #[cfg(test)]
@@ -194,6 +200,7 @@ mod tests {
     use std::cell::RefCell;
     use std::convert::Infallible;
     use vm_topology::memory::MemoryLayout;
+    use vm_topology::memory::MemoryRangeWithNode;
 
     #[test]
     fn test_registrar() {
@@ -253,6 +260,91 @@ mod tests {
                 .map(|r| r.to_string())
                 .collect::<Vec<_>>()
                 .join("\n")
+        );
+    }
+
+    #[test]
+    fn test_register_all_preserves_aligned_interior() {
+        let layout = MemoryLayout::new_from_ranges(
+            &[MemoryRangeWithNode {
+                range: MemoryRange::new(0x10000..2 * GRANULARITY + 0x20000),
+                vnode: 0,
+            }],
+            &[],
+        )
+        .unwrap();
+
+        let ranges = RefCell::new(Vec::new());
+        let registrar = MemoryRegistrar::new(&layout, 0, |range| {
+            ranges.borrow_mut().push(range);
+            Ok::<_, Infallible>(())
+        });
+
+        registrar.register_all().unwrap();
+
+        assert_eq!(
+            ranges.take(),
+            [
+                MemoryRange::new(0x10000..GRANULARITY),
+                MemoryRange::new(GRANULARITY..2 * GRANULARITY),
+                MemoryRange::new(2 * GRANULARITY..2 * GRANULARITY + 0x20000),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_register_all_multiple_ranges_with_gap() {
+        // A mix of RAM ranges with unbacked gaps between them: one spanning a
+        // chunk boundary, one contained in a single chunk, one spanning
+        // several whole chunks, and one crossing a boundary with unaligned ends.
+        let layout = MemoryLayout::new_from_ranges(
+            &[
+                MemoryRangeWithNode {
+                    range: MemoryRange::new(0x10000..GRANULARITY + 0x20000),
+                    vnode: 0,
+                },
+                MemoryRangeWithNode {
+                    range: MemoryRange::new(3 * GRANULARITY + 0x10000..3 * GRANULARITY + 0x30000),
+                    vnode: 0,
+                },
+                MemoryRangeWithNode {
+                    range: MemoryRange::new(4 * GRANULARITY + 0x40000..4 * GRANULARITY + 0x50000),
+                    vnode: 0,
+                },
+                MemoryRangeWithNode {
+                    range: MemoryRange::new(5 * GRANULARITY..8 * GRANULARITY),
+                    vnode: 0,
+                },
+                MemoryRangeWithNode {
+                    range: MemoryRange::new(9 * GRANULARITY + 0x30000..10 * GRANULARITY + 0x10000),
+                    vnode: 0,
+                },
+            ],
+            &[],
+        )
+        .unwrap();
+
+        let ranges = RefCell::new(Vec::new());
+        let registrar = MemoryRegistrar::new(&layout, 0, |range| {
+            ranges.borrow_mut().push(range);
+            Ok::<_, Infallible>(())
+        });
+
+        registrar.register_all().unwrap();
+
+        assert_eq!(
+            ranges.take(),
+            [
+                MemoryRange::new(0x10000..GRANULARITY),
+                MemoryRange::new(GRANULARITY..GRANULARITY + 0x20000),
+                MemoryRange::new(3 * GRANULARITY + 0x10000..3 * GRANULARITY + 0x30000),
+                MemoryRange::new(4 * GRANULARITY + 0x40000..4 * GRANULARITY + 0x50000),
+                MemoryRange::new(5 * GRANULARITY..6 * GRANULARITY),
+                MemoryRange::new(6 * GRANULARITY..7 * GRANULARITY),
+                MemoryRange::new(7 * GRANULARITY..8 * GRANULARITY),
+                MemoryRange::new(9 * GRANULARITY + 0x30000..10 * GRANULARITY),
+                MemoryRange::new(10 * GRANULARITY..10 * GRANULARITY + 0x10000),
+            ]
         );
     }
 }

--- a/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
@@ -2247,19 +2247,20 @@ impl<B: HardwareIsolatedBacking> UhProcessor<'_, B> {
         // than the VTL specified as an argument for hardware CVMs.
         let targeted_vtl = GuestVtl::Vtl0;
 
-        // Don't allow changing existing protections once vtl protection is enabled
-        if protector.vtl1_protections_enabled() {
-            let current_protections = protector.default_vtl0_protections();
-            if protections != current_protections {
+        let current_protections = protector.default_vtl0_protections();
+        if protections != current_protections {
+            if protector.vtl1_protections_enabled() {
+                // Don't allow changing existing protections once vtl protection
+                // is enabled
                 return Err(HvError::InvalidRegisterValue);
+            } else {
+                protector.change_default_vtl_protections(
+                    targeted_vtl,
+                    protections,
+                    &mut self.tlb_flush_lock_access(),
+                )?;
             }
         }
-
-        protector.change_default_vtl_protections(
-            targeted_vtl,
-            protections,
-            &mut self.tlb_flush_lock_access(),
-        )?;
 
         // TODO GUEST VSM: should only be set if enable_vtl_protection is true?
         // We're not to spec but match the HCL, so good enough for now?


### PR DESCRIPTION
…eroing memory (#4250)

Changes to default protections must apply over all lower VTL memory, which can be a long-running operation. Same with granting VTL 0  permissions to pages and zeroing memory after acceptance (for SNP). This change parallelizes these operations, updates the vtl permission bitmap updates to be more performant as well, and uses 1GB pages for zeroing to have a better memory footprint.

Tested:
- Booted SNP Windows with SK and measured performance of applying default VTL protections.
- 128 and 256 GB SNP Windows boots successfully (previously timed out)

---------

Clean cherry-pick.