### PR TITLE
openhcl: make hibernate Token::CURRENT arch-specific

### DIFF
--- a/openhcl/underhill_core/src/hibernate.rs
+++ b/openhcl/underhill_core/src/hibernate.rs
@@ -204,6 +204,9 @@ mod tests {
     #[test]
     fn constants_encode_as_expected() {
         assert_eq!(u64::from(Token::NotHibernated), 0);
+        #[cfg(guest_arch = "aarch64")]
+        assert_eq!(u64::from(Token::CURRENT), 0x0108);
+        #[cfg(guest_arch = "x86_64")]
         assert_eq!(u64::from(Token::CURRENT), 0x0107);
         assert_eq!(u64::from(Token::UNKNOWN), 0x0100);
     }

--- a/openhcl/underhill_core/src/hibernate.rs
+++ b/openhcl/underhill_core/src/hibernate.rs
@@ -29,11 +29,16 @@ pub enum Token {
 
 impl Token {
     /// Written when the current firmware hibernates; bump per release.
-    // TODO: The 1.8 branch will start with the 1.7-era uefi firmware (in
+    #[cfg(guest_arch = "aarch64")]
+    pub const CURRENT: Self = Self::Hibernated { major: 1, minor: 8 };
+    /// Written when the current firmware hibernates; bump per release.
+    // TODO: On x86_64 the 1.8 branch starts with the 1.7-era uefi firmware (in
     // internal builds) to maintain hibernation compat. This will be changed
     // later in servicing.
+    #[cfg(guest_arch = "x86_64")]
     pub const CURRENT: Self = Self::Hibernated { major: 1, minor: 7 };
-    /// Written when the firmware version is unknown (e.g. after servicing).
+    /// Written when the firmware version is unknown, e.g. after servicing from
+    /// a previous build that didn't write the token.
     pub const UNKNOWN: Self = Self::Hibernated { major: 1, minor: 0 };
 }
 


### PR DESCRIPTION
## Make hibernate `Token::CURRENT` architecture-specific

### Summary

The OpenHCL hibernate token (`vmgs::FileId::HIBERNATION_TOKEN`) records the firmware version under which the guest hibernated, so resume can detect a firmware-version mismatch. Previously `Token::CURRENT` was a single value (`1.7`) shared by all guest architectures. This change makes it depend on `guest_arch`:

- **aarch64**: `1.8`
- **x86_64**: `1.7`

On x86_64 the 1.8 branch continues to ship the 1.7-era UEFI firmware (in internal builds) to preserve hibernation compatibility, so its token stays at `1.7`; aarch64 advances to `1.8`.

### Changes

- `openhcl/underhill_core/src/hibernate.rs`:
  - Split `Token::CURRENT` into `cfg(guest_arch = "aarch64")` (`1.8`) and `cfg(guest_arch = "x86_64")` (`1.7`) variants.
  - Moved the TODO explaining the x64 1.7-era-firmware compat carve-out next to the x86_64 variant.
  - Clarified the `Token::UNKNOWN` doc comment: written after servicing from a previous build that didn't write the token.

No functional behavior change beyond the per-architecture token value; encoding/round-trip logic is unchanged.