### PR TITLE
flowey: drop the dangling --output from the rustup-init download

### DIFF
--- a/.github/workflows/openvmm-ci.yaml
+++ b/.github/workflows/openvmm-ci.yaml
@@ -42,7 +42,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64
         ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
@@ -50,7 +50,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64
         ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
@@ -202,7 +202,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64
         ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
@@ -210,7 +210,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64
         ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
@@ -377,7 +377,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64
         ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
@@ -385,7 +385,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64
         ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
@@ -650,7 +650,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64
         ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
@@ -658,7 +658,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64
         ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
@@ -1034,7 +1034,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64
         ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
@@ -1042,7 +1042,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64
         ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
@@ -1394,7 +1394,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64
         ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
@@ -1402,7 +1402,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64
         ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
@@ -1690,7 +1690,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64
         ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
@@ -1698,7 +1698,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64
         ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
@@ -2076,7 +2076,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64
         ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
@@ -2084,7 +2084,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64
         ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
@@ -2474,7 +2474,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64
         ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
@@ -2482,7 +2482,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64
         ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
@@ -2770,7 +2770,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64
         ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
@@ -2778,7 +2778,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64
         ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
@@ -3132,7 +3132,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64
         ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
@@ -3140,7 +3140,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64
         ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
@@ -3818,7 +3818,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64
         ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
@@ -3826,7 +3826,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64
         ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
@@ -5425,7 +5425,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64
         ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
@@ -5433,7 +5433,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64
         ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
@@ -5745,7 +5745,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64
         ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
@@ -5753,7 +5753,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64
         ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
@@ -6324,7 +6324,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64
         ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
@@ -6332,7 +6332,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64
         ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
@@ -6441,7 +6441,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64
         ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
@@ -6449,7 +6449,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64
         ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
@@ -6567,7 +6567,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64
         ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
@@ -6575,7 +6575,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64
         ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
@@ -7115,7 +7115,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64
         ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
@@ -7123,7 +7123,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64
         ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
@@ -7334,7 +7334,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64
         ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
@@ -7342,7 +7342,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64
         ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
@@ -7656,7 +7656,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64
         ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
@@ -7664,7 +7664,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64
         ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
@@ -7879,7 +7879,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64
         ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
@@ -7887,7 +7887,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64
         ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
@@ -8209,7 +8209,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64
         ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
@@ -8217,7 +8217,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64
         ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
@@ -8642,7 +8642,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64
         ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
@@ -8650,7 +8650,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64
         ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'

--- a/.github/workflows/openvmm-docs-ci.yaml
+++ b/.github/workflows/openvmm-docs-ci.yaml
@@ -36,7 +36,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64
         ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
@@ -44,7 +44,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64
         ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
@@ -198,7 +198,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64
         ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
@@ -206,7 +206,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64
         ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
@@ -361,7 +361,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64
         ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
@@ -369,7 +369,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64
         ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'

--- a/.github/workflows/openvmm-docs-pr.yaml
+++ b/.github/workflows/openvmm-docs-pr.yaml
@@ -44,7 +44,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64
         ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
@@ -52,7 +52,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64
         ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
@@ -206,7 +206,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64
         ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
@@ -214,7 +214,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64
         ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
@@ -369,7 +369,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64
         ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
@@ -377,7 +377,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64
         ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'

--- a/.github/workflows/openvmm-pr-release.yaml
+++ b/.github/workflows/openvmm-pr-release.yaml
@@ -50,7 +50,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64
         ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
@@ -58,7 +58,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64
         ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
@@ -264,7 +264,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64
         ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
@@ -272,7 +272,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64
         ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
@@ -1273,7 +1273,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64
         ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
@@ -1281,7 +1281,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64
         ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
@@ -2239,7 +2239,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64
         ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
@@ -2247,7 +2247,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64
         ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
@@ -2537,7 +2537,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64
         ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
@@ -2545,7 +2545,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64
         ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
@@ -2901,7 +2901,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64
         ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
@@ -2909,7 +2909,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64
         ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
@@ -3590,7 +3590,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64
         ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
@@ -3598,7 +3598,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64
         ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
@@ -5202,7 +5202,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64
         ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
@@ -5210,7 +5210,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64
         ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
@@ -5523,7 +5523,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64
         ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
@@ -5531,7 +5531,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64
         ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
@@ -6623,7 +6623,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64
         ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
@@ -6631,7 +6631,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64
         ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
@@ -6844,7 +6844,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64
         ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
@@ -6852,7 +6852,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64
         ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
@@ -7168,7 +7168,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64
         ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
@@ -7176,7 +7176,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64
         ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
@@ -7393,7 +7393,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64
         ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
@@ -7401,7 +7401,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64
         ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'

--- a/.github/workflows/openvmm-pr.yaml
+++ b/.github/workflows/openvmm-pr.yaml
@@ -49,7 +49,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64
         ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
@@ -57,7 +57,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64
         ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
@@ -263,7 +263,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64
         ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
@@ -271,7 +271,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64
         ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
@@ -1686,7 +1686,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64
         ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
@@ -1694,7 +1694,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64
         ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
@@ -2652,7 +2652,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64
         ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
@@ -2660,7 +2660,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64
         ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
@@ -2950,7 +2950,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64
         ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
@@ -2958,7 +2958,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64
         ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
@@ -3314,7 +3314,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64
         ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
@@ -3322,7 +3322,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64
         ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
@@ -3502,7 +3502,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64
         ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
@@ -3510,7 +3510,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64
         ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
@@ -5615,7 +5615,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64
         ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
@@ -5623,7 +5623,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64
         ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
@@ -5936,7 +5936,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64
         ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
@@ -5944,7 +5944,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64
         ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
@@ -7104,7 +7104,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64
         ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
@@ -7112,7 +7112,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64
         ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
@@ -7325,7 +7325,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64
         ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
@@ -7333,7 +7333,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64
         ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
@@ -7649,7 +7649,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64
         ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
@@ -7657,7 +7657,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64
         ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'
@@ -7874,7 +7874,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64
         ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
@@ -7882,7 +7882,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64
         ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'

--- a/.github/workflows/openvmm-source-release.yaml
+++ b/.github/workflows/openvmm-source-release.yaml
@@ -32,7 +32,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64
         ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'X64'
@@ -40,7 +40,7 @@ jobs:
       shell: bash
     - run: |
         set -x
-        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+        curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64
         ./rustup-init.exe -y --default-toolchain=1.95.0
         echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
       if: runner.os == 'Windows' && runner.arch == 'ARM64'

--- a/ci-flowey/openvmm-pr.yaml
+++ b/ci-flowey/openvmm-pr.yaml
@@ -44,7 +44,7 @@ jobs:
     displayName: rustup (Linux)
   - bash: |
       set -x
-      curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+      curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64
       ./rustup-init.exe -y --default-toolchain=1.95.0
       echo '##vso[task.prependpath]$(USERPROFILE)\\.cargo\\bin'
     condition: eq(variables['Agent.OS'], 'Windows_NT')
@@ -962,7 +962,7 @@ jobs:
     displayName: rustup (Linux)
   - bash: |
       set -x
-      curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+      curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64
       ./rustup-init.exe -y --default-toolchain=1.95.0
       echo '##vso[task.prependpath]$(USERPROFILE)\\.cargo\\bin'
     condition: eq(variables['Agent.OS'], 'Windows_NT')
@@ -2710,7 +2710,7 @@ jobs:
     displayName: rustup (Linux)
   - bash: |
       set -x
-      curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+      curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64
       ./rustup-init.exe -y --default-toolchain=1.95.0
       echo '##vso[task.prependpath]$(USERPROFILE)\\.cargo\\bin'
     condition: eq(variables['Agent.OS'], 'Windows_NT')
@@ -3009,7 +3009,7 @@ jobs:
     displayName: rustup (Linux)
   - bash: |
       set -x
-      curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+      curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64
       ./rustup-init.exe -y --default-toolchain=1.95.0
       echo '##vso[task.prependpath]$(USERPROFILE)\\.cargo\\bin'
     condition: eq(variables['Agent.OS'], 'Windows_NT')
@@ -3217,7 +3217,7 @@ jobs:
     displayName: rustup (Linux)
   - bash: |
       set -x
-      curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+      curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64
       ./rustup-init.exe -y --default-toolchain=1.95.0
       echo '##vso[task.prependpath]$(USERPROFILE)\\.cargo\\bin'
     condition: eq(variables['Agent.OS'], 'Windows_NT')
@@ -3511,7 +3511,7 @@ jobs:
     displayName: rustup (Linux)
   - bash: |
       set -x
-      curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+      curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64
       ./rustup-init.exe -y --default-toolchain=1.95.0
       echo '##vso[task.prependpath]$(USERPROFILE)\\.cargo\\bin'
     condition: eq(variables['Agent.OS'], 'Windows_NT')
@@ -4274,7 +4274,7 @@ jobs:
     displayName: rustup (Linux)
   - bash: |
       set -x
-      curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+      curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64
       ./rustup-init.exe -y --default-toolchain=1.95.0
       echo '##vso[task.prependpath]$(USERPROFILE)\\.cargo\\bin'
     condition: eq(variables['Agent.OS'], 'Windows_NT')
@@ -5644,7 +5644,7 @@ jobs:
     displayName: rustup (Linux)
   - bash: |
       set -x
-      curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+      curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64
       ./rustup-init.exe -y --default-toolchain=1.95.0
       echo '##vso[task.prependpath]$(USERPROFILE)\\.cargo\\bin'
     condition: eq(variables['Agent.OS'], 'Windows_NT')

--- a/flowey/flowey_hvlite/src/pipelines_shared/ado_flowey_bootstrap_template.yml
+++ b/flowey/flowey_hvlite/src/pipelines_shared/ado_flowey_bootstrap_template.yml
@@ -28,7 +28,7 @@
 # but that currently needs to be preinstalled on the actions runner.
 - bash: |
     set -x
-    curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+    curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64
     ./rustup-init.exe -y --default-toolchain={{RUSTUP_TOOLCHAIN}}
     echo '##vso[task.prependpath]$(USERPROFILE)\\.cargo\\bin'
   condition: eq(variables['Agent.OS'], 'Windows_NT')

--- a/flowey/flowey_hvlite/src/pipelines_shared/gh_flowey_bootstrap_template.yml
+++ b/flowey/flowey_hvlite/src/pipelines_shared/gh_flowey_bootstrap_template.yml
@@ -30,7 +30,7 @@
 # but that currently needs to be preinstalled on the actions runner.
 - run: |
     set -x
-    curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64 --output rustup-init
+    curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/x86_64
     ./rustup-init.exe -y --default-toolchain={{RUSTUP_TOOLCHAIN}}
     echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
   if: runner.os == 'Windows' && runner.arch == 'X64'
@@ -39,7 +39,7 @@
 
 - run: |
     set -x
-    curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64 --output rustup-init
+    curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/aarch64
     ./rustup-init.exe -y --default-toolchain={{RUSTUP_TOOLCHAIN}}
     echo "$USERPROFILE\\.cargo\\bin" >> $GITHUB_PATH
   if: runner.os == 'Windows' && runner.arch == 'ARM64'

--- a/flowey/flowey_lib_common/src/install_rust.rs
+++ b/flowey/flowey_lib_common/src/install_rust.rs
@@ -298,7 +298,7 @@ impl FlowNodeWithConfig for Node {
 
                                     flowey::shell_cmd!(
                                         rt,
-                                        "curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/{arch} --output rustup-init"
+                                        "curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/{arch}"
                                     ).run()?;
                                     flowey::shell_cmd!(
                                         rt,


### PR DESCRIPTION
The Windows `rustup-init` download is written as:

```
curl --fail -sSfLo rustup-init.exe https://win.rustup.rs/{arch} --output rustup-init
```

curl pairs each `-o`/`--output` with the URL in the *same position*, so the first one binds to the only URL and the trailing `--output` is silently discarded. Verified on curl 8.21 (Windows):

| command | result |
| --- | --- |
| `-o a.txt <url> --output b.txt` | writes **a.txt**, exit 0 |
| `--output b.txt -o a.txt <url>` | writes **b.txt** |
| `-o a.txt -o b.txt <url> <url>` | writes **both** |

So the file already lands at `rustup-init.exe`, which is what the next line invokes — the flag is dead. But it reads as though the download is named `rustup-init`, directly contradicting the `./rustup-init.exe` on the following line, and it only survives because curl tolerates an `-o` with no URL to bind to.

The same line appears in the GitHub and ADO flowey bootstrap templates, so the generated pipeline YAML changes too. Every one of the 240 changed YAML lines is this same curl line — no other churn.

No behavior change.