### PR TITLE
cca-irq: add initial GICv3 delivery for timer, SGI, and SPI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8383,6 +8383,7 @@ dependencies = [
 name = "tmk_vmm"
 version = "0.0.0"
 dependencies = [
+ "aarch64defs",
  "anyhow",
  "build_rs_guest_arch",
  "clap",
@@ -8408,6 +8409,7 @@ dependencies = [
  "virt_kvm",
  "virt_mshv",
  "virt_mshv_vtl",
+ "virt_support_gic",
  "virt_whp",
  "vm_loader",
  "vm_topology",
@@ -9665,6 +9667,7 @@ dependencies = [
  "virt",
  "virt_support_aarch64emu",
  "virt_support_apic",
+ "virt_support_gic",
  "virt_support_x86emu",
  "vm_topology",
  "vmcore",
@@ -9717,6 +9720,7 @@ dependencies = [
  "inspect",
  "memory_range",
  "parking_lot",
+ "thiserror 2.0.16",
  "tracelimit",
  "tracing",
  "vm_topology",

--- a/openhcl/hcl/src/ioctl/cca.rs
+++ b/openhcl/hcl/src/ioctl/cca.rs
@@ -35,6 +35,8 @@ use memory_range::MemoryRange;
 use sidecar_client::SidecarVp;
 use user_driver::memory::MemoryBlock;
 
+const RSI_PLANE_EXIT_INVALID: u64 = u64::MAX;
+
 #[derive(Debug, Error)]
 #[expect(missing_docs)]
 pub enum GetIpaStateError {
@@ -136,6 +138,16 @@ impl Cca {
 }
 
 impl ProcessorRunner<'_, Cca> {
+    /// Runs the CCA plane and returns whether the RMM produced a fresh plane
+    /// exit.
+    pub fn run_cca_plane(&mut self) -> Result<bool, Error> {
+        self.state.plane_run_mut().exit.exit_reason = RSI_PLANE_EXIT_INVALID;
+
+        let intercepted = self.run()?;
+
+        Ok(intercepted && self.state.plane_run_ref().exit.exit_reason != RSI_PLANE_EXIT_INVALID)
+    }
+
     /// Returns a reference to the current VTL's CPU context.
     pub fn cpu_context(&self) -> &u64 {
         // SAFETY: the cpu context will not be concurrently accessed by the

--- a/openhcl/virt_mshv_vtl/Cargo.toml
+++ b/openhcl/virt_mshv_vtl/Cargo.toml
@@ -57,6 +57,7 @@ safe_intrinsics.workspace = true
 aarch64defs.workspace = true
 aarch64emu.workspace = true
 virt_support_aarch64emu.workspace = true
+virt_support_gic.workspace = true
 
 [build-dependencies]
 build_rs_guest_arch.workspace = true

--- a/openhcl/virt_mshv_vtl/src/lib.rs
+++ b/openhcl/virt_mshv_vtl/src/lib.rs
@@ -42,6 +42,8 @@ cfg_if::cfg_if!(
         use crate::processor::mshv::arm64::HypervisorBackedArm64Shared as HypervisorBackedShared;
         use processor::cca::CcaBackedShared;
         use safe_intrinsics::read_cntfrq_el0;
+        use virt_support_gic::GicV3Model;
+        use virt_support_gic::GicV3ModelError;
     }
 );
 
@@ -154,6 +156,9 @@ pub enum Error {
     #[error("failed to create cpuid tables for cvm")]
     #[cfg(guest_arch = "x86_64")]
     CvmCpuid(#[source] cvm_cpuid::CpuidResultsError),
+    #[error("failed to create GICv3 model")]
+    #[cfg(guest_arch = "aarch64")]
+    GicV3Model(#[source] GicV3ModelError),
     #[error("failed to update hypercall msr")]
     UpdateHypercallMsr,
     #[error("failed to update reference tsc msr")]
@@ -292,9 +297,10 @@ impl BackingShared {
                 backing_shared_params,
             )?),
             #[cfg(guest_arch = "aarch64")]
-            IsolationType::Cca => {
-                BackingShared::Cca(Box::new(CcaBackedShared::new(backing_shared_params)?))
-            }
+            IsolationType::Cca => BackingShared::Cca(Box::new(CcaBackedShared::new(
+                backing_shared_params,
+                partition_params.topology.virt_timer_ppi(),
+            )?)),
             _ => unreachable!(),
         })
     }
@@ -494,6 +500,9 @@ struct UhCvmPartitionState {
     #[cfg(guest_arch = "x86_64")]
     /// The emulated local APIC set.
     lapic: VtlArray<LocalApicSet, 2>,
+    #[cfg(guest_arch = "aarch64")]
+    #[inspect(skip)]
+    gic: Arc<GicV3Model>,
     /// The emulated hypervisor state.
     hv: GlobalHv<2>,
     /// Guest VSM state.
@@ -651,6 +660,25 @@ impl GetReferenceTime for TscReferenceTimeSource {
 
 impl virt::irqcon::ControlGic for UhPartitionInner {
     fn set_spi_irq(&self, irq_id: u32, high: bool) {
+        #[cfg(guest_arch = "aarch64")]
+        if self.isolation == IsolationType::Cca {
+            let Some(cvm) = self.backing_shared.cvm_state() else {
+                tracelimit::warn_ratelimited!(
+                    irq = irq_id,
+                    asserted = high,
+                    "failed to request CCA SPI without CVM state"
+                );
+                return;
+            };
+
+            for vp_index in cvm.gic.set_spi_irq(irq_id, high) {
+                if let Some(vp) = self.vp(vp_index) {
+                    vp.wake(GuestVtl::Vtl0, WakeReason::INTCON);
+                }
+            }
+            return;
+        }
+
         if let Err(err) = self.hcl.request_interrupt(
             hvdef::HvInterruptControl::new()
                 .with_arm64_asserted(high)
@@ -703,6 +731,15 @@ impl UhProcessorBox {
         self.partition
             .hcl
             .sidecar_base_cpu(self.vp_info.base.vp_index.index())
+    }
+
+    /// Returns the partition-owned GICv3 model, when this processor belongs to a CCA partition.
+    #[cfg(guest_arch = "aarch64")]
+    pub fn gic_v3_model(&self) -> Option<Arc<GicV3Model>> {
+        match &self.partition.backing_shared {
+            BackingShared::Cca(shared) => Some(Arc::clone(&shared.cvm.gic)),
+            _ => None,
+        }
     }
 
     /// Returns the processor object, bound to this thread.
@@ -836,7 +873,6 @@ impl WakeReason {
     const MESSAGE_QUEUES: Self = Self::new().with_message_queues(true);
     #[cfg(guest_arch = "x86_64")]
     const HV_START_ENABLE_VP_VTL: Self = Self::new().with_hv_start_enable_vtl_vp(true); // StartVp/EnableVpVtl handling
-    #[cfg(guest_arch = "x86_64")]
     const INTCON: Self = Self::new().with_intcon(true);
     #[cfg(guest_arch = "x86_64")]
     const UPDATE_PROXY_IRR_FILTER: Self = Self::new().with_update_proxy_irr_filter(true);
@@ -2355,6 +2391,9 @@ impl UhProtoPartition<'_> {
                 .build()
         });
 
+        #[cfg(guest_arch = "aarch64")]
+        let gic = Arc::new(GicV3Model::new(params.topology).map_err(Error::GicV3Model)?);
+
         let tsc_frequency = get_tsc_frequency(params.isolation)?;
         let ref_time = ReferenceTimeSource::new(TscReferenceTimeSource::new(tsc_frequency));
 
@@ -2381,6 +2420,8 @@ impl UhProtoPartition<'_> {
             isolated_memory_protector: late_params.isolated_memory_protector,
             #[cfg(guest_arch = "x86_64")]
             lapic,
+            #[cfg(guest_arch = "aarch64")]
+            gic,
             hv,
             guest_vsm: RwLock::new(GuestVsmState::from_availability(guest_vsm_available)),
             access_vsm_privilege: guest_vsm_available,

--- a/openhcl/virt_mshv_vtl/src/processor/cca/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/cca/mod.rs
@@ -21,6 +21,7 @@ use aarch64defs::HpfarEl2;
 use aarch64defs::InstructionAbortReason;
 use aarch64defs::IssDataAbort;
 use aarch64defs::IssInstructionAbort;
+use aarch64defs::IssSystem;
 use aarch64defs::SystemReg;
 use aarch64defs::rsi::cca_rsi_plane_exit;
 use hcl::GuestVtl;
@@ -33,12 +34,14 @@ use hv1_structs::VtlArray;
 use hvdef::HvRegisterCrInterceptControl;
 use inspect::Inspect;
 use inspect::InspectMut;
+use std::cmp::min;
 use virt::VpHaltReason;
 use virt::VpIndex;
 use virt::aarch64::vp;
 use virt::aarch64::vp::AccessVpState;
 use virt::io::CpuIo;
 use virt_support_aarch64emu::translate::TranslationRegisters;
+use virt_support_gic::PendingInterrupt;
 use zerocopy::FromZeros;
 
 #[derive(Debug, Error)]
@@ -67,9 +70,32 @@ enum CcaUnsupportedExit {
         reason: InstructionAbortReason,
         far_not_valid: bool,
     },
+    #[allow(dead_code)]
+    #[error("CCA private GIC interrupt ID {0} is outside the SGI/PPI range")]
+    InvalidPrivateGicInterrupt(u32),
+    #[error("unsupported CCA system register trap for {system_reg:?} in ESR_EL2 {esr_el2:#x}")]
+    UnsupportedSystemRegister { system_reg: SystemReg, esr_el2: u64 },
+    #[allow(dead_code)]
+    #[error("CCA {system_reg:?} write in ESR_EL2 {esr_el2:#x} has no accessible source register")]
+    MissingSystemRegisterValue { system_reg: SystemReg, esr_el2: u64 },
 }
 
 const AARCH64_ZERO_REGISTER_INDEX: u8 = 31;
+const CNTV_CTL_ENABLE: u64 = 1 << 0;
+const CNTV_CTL_IMASK: u64 = 1 << 1;
+const CNTV_CTL_ISTATUS: u64 = 1 << 2;
+
+const ICH_HCR_TC: u64 = 1 << 10;
+
+const ICH_LR_VINTID_MASK: u64 = u32::MAX as u64;
+const ICH_LR_PRIORITY_SHIFT: u32 = 48;
+const ICH_LR_GROUP1: u64 = 1 << 60;
+const ICH_LR_PENDING: u64 = 1 << 62;
+const ICH_LR_ACTIVE: u64 = 1 << 63;
+const ICH_LR_STATE_MASK: u64 = 3 << 62;
+#[cfg(test)]
+const GIC_PRIVATE_INTERRUPT_COUNT: u32 = 32;
+const ICH_LR_PRIORITY_MASK: u64 = 0xff << ICH_LR_PRIORITY_SHIFT;
 
 // For use with Hyper-V synthetic interrupt controller allocated by paravisor.
 enum UhDirectOverlay {
@@ -98,6 +124,8 @@ struct CcaVtl {
     sp_el0: u64,
     sp_el1: u64,
     cpsr: u64,
+    /// Guest-programmed GIC priority mask from ICC_PMR_EL1.
+    priority_mask: u8,
 }
 
 impl CcaVtl {
@@ -106,6 +134,7 @@ impl CcaVtl {
             sp_el0: 0,
             sp_el1: 0,
             cpsr: 0,
+            priority_mask: u8::MAX,
         }
     }
 }
@@ -113,12 +142,14 @@ impl CcaVtl {
 #[derive(Inspect)]
 pub struct CcaBackedShared {
     pub(crate) cvm: UhCvmPartitionState,
+    virt_timer_ppi: u32,
 }
 
 impl CcaBackedShared {
-    pub(crate) fn new(params: BackingSharedParams<'_>) -> Result<Self, Error> {
+    pub(crate) fn new(params: BackingSharedParams<'_>, virt_timer_ppi: u32) -> Result<Self, Error> {
         Ok(Self {
             cvm: params.cvm_state.unwrap(),
+            virt_timer_ppi,
         })
     }
 }
@@ -132,6 +163,7 @@ enum ExceptionClass {
     InstructionAbort,
     SimdAccess,
     SmcError,
+    SystemRegister,
     Unknown(u8),
 }
 
@@ -142,6 +174,7 @@ impl From<u8> for ExceptionClass {
             0b0010_0000 => ExceptionClass::InstructionAbort,
             0b0000_0111 => ExceptionClass::SimdAccess,
             0b0001_0111 => ExceptionClass::SmcError,
+            0b0001_1000 => ExceptionClass::SystemRegister,
             _ => ExceptionClass::Unknown(value),
         }
     }
@@ -164,6 +197,11 @@ impl From<u64> for PlaneExitReason {
             _ => PlaneExitReason::Unknown(value),
         }
     }
+}
+
+struct CcaLocalInterruptExit {
+    system_register_trap: Option<(IssSystem, u64, u64)>,
+    virtual_timer_asserted: bool,
 }
 
 /// A wrapper around the CCA RSI plane exit structure, providing methods to
@@ -201,6 +239,85 @@ impl<'a> CcaExit<'a> {
             index => self.0.gprs.get(usize::from(index)).copied(),
         }
     }
+
+    /// Returns whether the virtual timer interrupt is enabled, unmasked, and
+    /// asserted in the returned CCA plane state.
+    fn virtual_timer_asserted(&self) -> bool {
+        self.0.cntv_ctl_el0 & (CNTV_CTL_ENABLE | CNTV_CTL_IMASK | CNTV_CTL_ISTATUS)
+            == CNTV_CTL_ENABLE | CNTV_CTL_ISTATUS
+    }
+
+    fn local_interrupt_exit(&self) -> CcaLocalInterruptExit {
+        let esr_el2 = self.esr_el2();
+        let exception_class = self.esr_el2_class();
+        let system_register_trap =
+            matches!(exception_class, ExceptionClass::SystemRegister).then(|| {
+                let iss = IssSystem::from(esr_el2.iss());
+                let value = self
+                    .gpr_or_zero_register(iss.rt())
+                    .expect("ISS Rt is a valid AArch64 register index");
+                (iss, value, self.0.esr_el2)
+            });
+
+        CcaLocalInterruptExit {
+            system_register_trap,
+            virtual_timer_asserted: self.virtual_timer_asserted(),
+        }
+    }
+}
+
+/// Injects a pending virtual interrupt into a GICv3 List Register.
+///
+/// If the interrupt is already represented by an LR, the LR is marked
+/// pending. Otherwise, an unused LR is allocated.
+///
+/// Returns `false` if no List Register is available.
+fn inject_virtual_interrupt(lrs: &mut [u64], interrupt: PendingInterrupt) -> bool {
+    if let Some(lr) = lrs.iter_mut().find(|lr| {
+        **lr & ICH_LR_STATE_MASK != 0 && **lr & ICH_LR_VINTID_MASK == u64::from(interrupt.intid)
+    }) {
+        // A new request for an active interrupt must remain pending after the
+        // guest deactivates it. This also leaves pending and active-and-pending
+        // list registers unchanged.
+        *lr |= ICH_LR_PENDING;
+        return true;
+    }
+
+    let Some(lr) = lrs.iter_mut().find(|lr| **lr & ICH_LR_STATE_MASK == 0) else {
+        return false;
+    };
+
+    *lr = u64::from(interrupt.intid)
+        | (u64::from(interrupt.priority) << ICH_LR_PRIORITY_SHIFT)
+        | if interrupt.group1 { ICH_LR_GROUP1 } else { 0 }
+        | ICH_LR_PENDING;
+    true
+}
+
+fn virtual_interrupt_is_listed(lrs: &[u64], intid: u32) -> bool {
+    lrs.iter()
+        .any(|lr| *lr & ICH_LR_STATE_MASK != 0 && *lr & ICH_LR_VINTID_MASK == u64::from(intid))
+}
+
+fn running_priority(lrs: &[u64]) -> u8 {
+    let mut running = 0xff;
+
+    for &lr in lrs {
+        // Pending interrupts are not running and therefore do not constrain
+        // which interrupt can be injected next.
+        if lr & ICH_LR_ACTIVE == 0 {
+            continue;
+        }
+
+        let priority = ((lr & ICH_LR_PRIORITY_MASK) >> ICH_LR_PRIORITY_SHIFT) as u8;
+        running = min(running, priority);
+    }
+
+    running
+}
+
+fn interrupt_priority_threshold(priority_mask: u8, lrs: &[u64]) -> u8 {
+    min(priority_mask, running_priority(lrs))
 }
 
 fn extend_mmio_read(data: [u8; size_of::<u64>()], len: usize, sign_extend: bool, sf: bool) -> u64 {
@@ -290,18 +407,19 @@ impl BackingPrivate for CcaBacked {
 
         // TODO: CCA: NEXT: move this to `init`?
         this.set_plane_enter();
+        let vtl = this.backing.cvm.exit_vtl;
 
         // Run the CCA plane.
         // This will return when the plane exits.
-        let intercepted = this
+        let has_plane_exit = this
             .runner
-            .run()
+            .run_cca_plane()
             .map_err(|e| dev.fatal_error(CcaRunVpError(e).into()))?;
 
-        // Preserve the plane context, so we can restore it later.
-        this.preserve_plane_context();
+        if has_plane_exit {
+            // Preserve the plane context, so we can restore it later.
+            this.preserve_plane_context();
 
-        if intercepted {
             // CCA: note, this is a very simplified version of the exit handling,
             // just enough to get the TMK running.
             // TODO: CCA: NEXT: document how we integrate with the wider emulation
@@ -429,6 +547,14 @@ impl BackingPrivate for CcaBacked {
                         ExceptionClass::SmcError => {
                             tracing::warn!("SmcError exception triggered, but not handled");
                         }
+                        ExceptionClass::SystemRegister => {
+                            let iss = IssSystem::from(esr_el2.iss());
+                            let value = cca_exit
+                                .gpr_or_zero_register(iss.rt())
+                                .expect("ISS Rt is a valid AArch64 register index");
+                            this.handle_system_register_trap(vtl, iss, value, cca_exit.0.esr_el2)
+                                .map_err(|e| dev.fatal_error(e.into()))?;
+                        }
                         ExceptionClass::Unknown(exception_class) => {
                             tracing::warn!(
                                 exception_class,
@@ -446,8 +572,9 @@ impl BackingPrivate for CcaBacked {
                     }
                 }
                 PlaneExitReason::Irq => {
-                    // Handle IRQ exit
-                    tracing::warn!("IRQ triggered, but not handled");
+                    let irq_exit = cca_exit.local_interrupt_exit();
+                    this.request_asserted_local_interrupts(vtl, irq_exit)
+                        .map_err(|e| dev.fatal_error(e.into()))?;
                 }
                 PlaneExitReason::Unknown(exit_reason) => {
                     tracing::warn!(exit_reason, "unsupported CCA plane exit reason");
@@ -459,16 +586,17 @@ impl BackingPrivate for CcaBacked {
     }
 
     fn process_interrupts(
-        _this: &mut UhProcessor<'_, Self>,
+        this: &mut UhProcessor<'_, Self>,
         _scan_irr: VtlArray<bool, 2>,
-        _first_scan_irr: &mut bool,
-        _dev: &impl CpuIo,
+        first_scan_irr: &mut bool,
+        dev: &impl CpuIo,
     ) -> bool {
+        let _ = dev;
+        for vtl in [GuestVtl::Vtl1, GuestVtl::Vtl0] {
+            this.poll_gic(vtl);
+        }
+        *first_scan_irr = false;
         false
-    }
-
-    fn poll_apic(_this: &mut UhProcessor<'_, Self>, _vtl: GuestVtl, _scan_irr: bool) {
-        // TODO: CCA: poll GIC?
     }
 
     fn request_extint_readiness(_this: &mut UhProcessor<'_, Self>) {
@@ -479,14 +607,6 @@ impl BackingPrivate for CcaBacked {
         // TODO: CCA: handle this for CCA untrusted synic
         unimplemented!();
     }
-
-    // fn handle_cross_vtl_interrupts(
-    //     _this: &mut UhProcessor<'_, Self>,
-    //     _dev: &impl CpuIo,
-    // ) -> Result<bool, UhRunVpError> {
-    //     // TODO: CCA: handle cross VTL interrupts when GIC support is added
-    //     Ok(false)
-    // }
 
     fn hv(&self, _vtl: GuestVtl) -> Option<&ProcessorVtlHv> {
         None
@@ -530,6 +650,197 @@ impl UhProcessor<'_, CcaBacked> {
 
     fn set_plane_enter(&mut self) {
         self.runner.cca_set_plane_enter();
+        self.runner.cca_rsi_plane_entry().gicv3_hcr |= ICH_HCR_TC;
+    }
+
+    /// Records interrupt sources reported by a CCA local IRQ exit.
+    ///
+    /// Trapped ICC SGI writes are emulated through the software GIC. Otherwise,
+    /// an asserted virtual timer is recorded as a pending PPI for this VP.
+    /// Unsupported system-register traps are returned to the caller as an
+    /// error; unrecognized local interrupt sources are ignored after tracing.
+    fn request_asserted_local_interrupts(
+        &mut self,
+        vtl: GuestVtl,
+        irq_exit: CcaLocalInterruptExit,
+    ) -> Result<(), CcaUnsupportedExit> {
+        if let Some((iss, value, esr_el2)) = irq_exit.system_register_trap {
+            self.handle_system_register_trap(vtl, iss, value, esr_el2)?;
+        } else if irq_exit.virtual_timer_asserted {
+            let intid = self.shared.virt_timer_ppi;
+
+            if !self.shared.cvm.gic.raise_ppi(self.vp_index(), intid) {
+                tracing::trace!(
+                    intid,
+                    "virtual timer PPI was already pending or VP was invalid"
+                );
+            }
+        } else {
+            tracing::trace!("CCA IRQ exit had an unrecognized local interrupt source");
+        }
+
+        Ok(())
+    }
+
+    /// Emulates a trapped write to a supported ICC register.
+    ///
+    /// SGI generation writes are forwarded to the software GIC. ICC_PMR_EL1
+    /// writes update the per-plane priority mask used when selecting pending
+    /// interrupts. Successful emulation advances the plane-entry PC past the
+    /// trapped instruction; it does not modify the guest GPR state.
+    fn handle_system_register_trap(
+        &mut self,
+        vtl: GuestVtl,
+        iss: IssSystem,
+        value: u64,
+        esr_el2: u64,
+    ) -> Result<(), CcaUnsupportedExit> {
+        let system_reg = iss.system_reg();
+
+        if iss.direction() {
+            return Err(CcaUnsupportedExit::UnsupportedSystemRegister {
+                system_reg,
+                esr_el2,
+            });
+        }
+
+        let handled = match system_reg {
+            SystemReg::ICC_PMR_EL1 => {
+                self.backing.vtls[vtl].priority_mask = value as u8;
+                true
+            }
+            SystemReg::ICC_SGI0R_EL1 | SystemReg::ICC_SGI1R_EL1 => self
+                .shared
+                .cvm
+                .gic
+                .write_sysreg(self.vp_index(), system_reg, value, |target_vp| {
+                    tracing::trace!(
+                        target_vp,
+                        ?system_reg,
+                        "GIC sysreg write raised an interrupt"
+                    );
+                }),
+            _ => false,
+        };
+
+        if !handled {
+            return Err(CcaUnsupportedExit::UnsupportedSystemRegister {
+                system_reg,
+                esr_el2,
+            });
+        }
+
+        // The trapped AArch64 instruction has been emulated. Resume at the
+        // following 4-byte instruction instead of trapping on this one again.
+        self.runner.cca_rsi_plane_entry().pc += 4;
+
+        Ok(())
+    }
+
+    /// Transfers deliverable interrupts from the software GIC into the CCA
+    /// plane-entry GIC list registers.
+    ///
+    /// This first injects pending per-VP SGIs and PPIs. For VTL0, it then
+    /// reconciles in-flight device SPIs with the returned list-register state
+    /// and injects newly deliverable SPIs. If no list register is available,
+    /// the interrupt remains pending for a later poll.
+    fn poll_gic(&mut self, vtl: GuestVtl) {
+        loop {
+            let priority_threshold = interrupt_priority_threshold(
+                self.backing.vtls[vtl].priority_mask,
+                &self.runner.cca_rsi_plane_entry().gicv3_lrs,
+            );
+            let Some(interrupt) = self
+                .shared
+                .cvm
+                .gic
+                .next_pending_private_interrupt(self.vp_index(), priority_threshold)
+            else {
+                break;
+            };
+
+            if !inject_virtual_interrupt(
+                &mut self.runner.cca_rsi_plane_entry().gicv3_lrs,
+                interrupt,
+            ) {
+                tracelimit::warn_ratelimited!(
+                    intid = interrupt.intid,
+                    priority = interrupt.priority,
+                    group1 = interrupt.group1,
+                    ?vtl,
+                    "no free CCA GIC list register; leaving interrupt pending"
+                );
+                return;
+            }
+
+            self.shared
+                .cvm
+                .gic
+                .complete_interrupt(self.vp_index(), interrupt.intid);
+            tracing::debug!(
+                intid = interrupt.intid,
+                priority = interrupt.priority,
+                group1 = interrupt.group1,
+                ?vtl,
+                "injected CCA GIC interrupt"
+            );
+        }
+
+        // Device SPIs belong to VTL0. Reconcile the model with the RMM list
+        // registers before selecting another interrupt. If a level-triggered
+        // line remains asserted after its LR is retired, it becomes eligible
+        // for injection again.
+        if vtl != GuestVtl::Vtl0 {
+            return;
+        }
+
+        let vp = self.vp_index();
+        let lrs = &self.runner.cca_rsi_plane_entry().gicv3_lrs;
+        self.shared
+            .cvm
+            .gic
+            .retain_in_flight_spis(vp, |intid| virtual_interrupt_is_listed(lrs, intid));
+
+        let priority_threshold = interrupt_priority_threshold(
+            self.backing.vtls[vtl].priority_mask,
+            &self.runner.cca_rsi_plane_entry().gicv3_lrs,
+        );
+        while let Some(interrupt) = self
+            .shared
+            .cvm
+            .gic
+            .reserve_pending_spi_interrupt(self.vp_index(), priority_threshold)
+        {
+            if !inject_virtual_interrupt(
+                &mut self.runner.cca_rsi_plane_entry().gicv3_lrs,
+                interrupt,
+            ) {
+                self.shared
+                    .cvm
+                    .gic
+                    .cancel_spi_reservation(self.vp_index(), interrupt.intid);
+                tracelimit::warn_ratelimited!(
+                    intid = interrupt.intid,
+                    priority = interrupt.priority,
+                    group1 = interrupt.group1,
+                    ?vtl,
+                    "no free CCA GIC list register; leaving shared interrupt pending"
+                );
+                return;
+            }
+
+            self.shared
+                .cvm
+                .gic
+                .mark_spi_injected(self.vp_index(), interrupt.intid);
+            tracing::debug!(
+                intid = interrupt.intid,
+                priority = interrupt.priority,
+                group1 = interrupt.group1,
+                ?vtl,
+                "injected pending CCA shared GIC interrupt"
+            );
+        }
     }
 
     // Copy the exit context to the entry context.
@@ -545,8 +856,15 @@ impl UhProcessor<'_, CcaBacked> {
         // Set the PC to the ELR_EL2 value from the exit context.
         plane_run.entry.pc = plane_run.exit.elr_el2;
 
-        // Set GICv3 HCR to the value from the exit context.
+        // Restore the interrupted PSTATE, including the IRQ mask.
+        plane_run.entry.pstate = plane_run.exit.pstate;
+
+        // Preserve the virtual GIC state across plane exits.
         plane_run.entry.gicv3_hcr = plane_run.exit.gicv3_hcr;
+        plane_run
+            .entry
+            .gicv3_lrs
+            .copy_from_slice(&plane_run.exit.gicv3_lrs);
     }
 
     // TODO: CCA: lots of stuff might be needed based on the TDX implementation, something akin to:
@@ -865,6 +1183,97 @@ impl TlbFlushLockAccess for CcaTlbLockFlushAccess<'_> {
 
     fn set_wait_for_tlb_locks(&mut self, _vtl: GuestVtl) {
         unimplemented!()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn priority_mask_defaults_to_allow_all_priorities() {
+        assert_eq!(CcaVtl::new().priority_mask, u8::MAX);
+    }
+
+    #[test]
+    fn priority_threshold_obeys_pmr_and_running_priority() {
+        const ACTIVE_PRIORITY: u64 = 0x40 << ICH_LR_PRIORITY_SHIFT;
+        let lrs = [ICH_LR_ACTIVE | ACTIVE_PRIORITY];
+
+        assert_eq!(interrupt_priority_threshold(0x80, &lrs), 0x40);
+        assert_eq!(interrupt_priority_threshold(0x20, &lrs), 0x20);
+        assert_eq!(interrupt_priority_threshold(0x80, &[0]), 0x80);
+    }
+
+    fn sgi_for(mpidr: MpidrEl1) -> GicrSgi {
+        GicrSgi::new()
+            .with_aff3(mpidr.aff3())
+            .with_aff2(mpidr.aff2())
+            .with_aff1(mpidr.aff1())
+            .with_rs(mpidr.aff0() / 16)
+            .with_target_list(1 << (mpidr.aff0() % 16))
+    }
+
+    #[test]
+    fn private_interrupt_bitmap_holds_every_private_intid() {
+        let mut gic = CcaGic::new();
+
+        for intid in 0..GIC_PRIVATE_INTERRUPT_COUNT {
+            assert_eq!(gic.request_interrupt(intid), Ok(()));
+        }
+        assert_eq!(gic.pending_mask(), u32::MAX);
+
+        const COMPLETED_INTID: u32 = 17;
+        gic.complete_interrupt(COMPLETED_INTID);
+        assert_eq!(gic.pending_mask(), u32::MAX & !(1 << COMPLETED_INTID));
+
+        assert_eq!(gic.request_interrupt(COMPLETED_INTID), Ok(()));
+        assert_eq!(gic.pending_mask(), u32::MAX);
+    }
+
+    #[test]
+    fn reinjecting_active_interrupt_marks_it_pending() {
+        const INTID: u32 = 7;
+        let mut lrs = [ICH_LR_ACTIVE | u64::from(INTID)];
+
+        assert!(inject_virtual_interrupt(
+            &mut lrs,
+            PendingInterrupt {
+                intid: INTID,
+                priority: 0x80,
+                group1: true,
+            }
+        ));
+        assert_eq!(lrs[0] & ICH_LR_STATE_MASK, ICH_LR_ACTIVE | ICH_LR_PENDING);
+    }
+
+    #[test]
+    fn sgi_target_matches_current_vp() {
+        let mpidr = MpidrEl1::new()
+            .with_aff3(4)
+            .with_aff2(3)
+            .with_aff1(2)
+            .with_aff0(17);
+
+        assert!(sgi_targets_current_vp(sgi_for(mpidr), mpidr));
+    }
+
+    #[test]
+    fn sgi_target_rejects_other_vps() {
+        let mpidr = MpidrEl1::new()
+            .with_aff3(4)
+            .with_aff2(3)
+            .with_aff1(2)
+            .with_aff0(1);
+        let matching = sgi_for(mpidr);
+
+        assert!(!sgi_targets_current_vp(matching.with_aff1(1), mpidr));
+        assert!(!sgi_targets_current_vp(
+            matching.with_target_list(1 << 2),
+            mpidr
+        ));
+        assert!(!sgi_targets_current_vp(matching.with_rs(1), mpidr));
+        assert!(!sgi_targets_current_vp(matching.with_irm(true), mpidr));
     }
 }
 

--- a/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/hardware_cvm/mod.rs
@@ -2852,6 +2852,7 @@ impl<B: HardwareIsolatedBacking> UhProcessor<'_, B> {
             // Process interrupts.
             self.update_synic(vtl, false);
 
+            #[cfg(guest_arch = "x86_64")]
             B::poll_apic(self, vtl, scan_irr[vtl] || *first_scan_irr);
         }
         *first_scan_irr = false;

--- a/openhcl/virt_mshv_vtl/src/processor/mod.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mod.rs
@@ -242,6 +242,7 @@ mod private {
         ) -> bool;
 
         /// Process any pending APIC work.
+        #[cfg(guest_arch = "x86_64")]
         fn poll_apic(this: &mut UhProcessor<'_, Self>, vtl: GuestVtl, scan_irr: bool);
 
         /// Requests the VP to exit when an external interrupt is ready to be
@@ -835,11 +836,14 @@ impl<'p, T: Backing> Processor for UhProcessor<'p, T> {
     fn flush_async_requests(&mut self) {
         if self.inner.wake_reasons.load(Ordering::Relaxed) != 0 {
             let scan_irr = self.handle_wake();
+            #[cfg(guest_arch = "x86_64")]
             for vtl in [GuestVtl::Vtl1, GuestVtl::Vtl0] {
                 if scan_irr[vtl] {
                     T::poll_apic(self, vtl, true);
                 }
             }
+            #[cfg(not(guest_arch = "x86_64"))]
+            let _ = scan_irr;
         }
         self.runner.flush_deferred_state();
     }

--- a/openhcl/virt_mshv_vtl/src/processor/mshv/arm64.rs
+++ b/openhcl/virt_mshv_vtl/src/processor/mshv/arm64.rs
@@ -257,8 +257,6 @@ impl BackingPrivate for HypervisorBackedArm64 {
         Ok(())
     }
 
-    fn poll_apic(_this: &mut UhProcessor<'_, Self>, _vtl: GuestVtl, _scan_irr: bool) {}
-
     fn process_interrupts(
         _this: &mut UhProcessor<'_, Self>,
         _scan_irr: hv1_structs::VtlArray<bool, 2>,

--- a/tmk/simple_tmk/src/aarch64/irq.rs
+++ b/tmk/simple_tmk/src/aarch64/irq.rs
@@ -1,0 +1,124 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! AArch64 specific tests.
+
+#![cfg(target_arch = "aarch64")]
+
+use crate::prelude::*;
+use core::sync::atomic::AtomicBool;
+use core::sync::atomic::Ordering::Relaxed;
+use tmk_core::aarch64;
+
+#[tmk_test]
+fn virtual_timer_irq(t: TestContext<'_>) {
+    let timer_fired = AtomicBool::new(false);
+    let timer_isr = |ctx: &mut aarch64::IrqContext| {
+        if ctx.intid == aarch64::VIRTUAL_TIMER_PPI {
+            aarch64::disable_virtual_timer();
+            timer_fired.store(true, Relaxed);
+        }
+    };
+
+    t.scope.subscope(|s| {
+        s.set_irq_handler(&timer_isr);
+        s.enable_gic_irq(aarch64::VIRTUAL_TIMER_PPI);
+
+        let frequency = aarch64::read_cntfrq();
+        let start = aarch64::read_cntvct();
+        let ticks_until_interrupt = core::cmp::max(frequency / 100, 1);
+        let timeout_ticks = core::cmp::max(frequency, ticks_until_interrupt * 10);
+
+        aarch64::set_virtual_timer_compare(start + ticks_until_interrupt);
+        s.enable_interrupts();
+
+        while !timer_fired.load(Relaxed)
+            && aarch64::read_cntvct().wrapping_sub(start) < timeout_ticks
+        {
+            aarch64::poll_interrupts();
+            core::hint::spin_loop();
+        }
+
+        s.disable_interrupts();
+        aarch64::disable_virtual_timer();
+        s.disable_gic_irq(aarch64::VIRTUAL_TIMER_PPI);
+    });
+
+    assert!(
+        timer_fired.load(Relaxed),
+        "virtual timer interrupt did not fire"
+    );
+}
+
+#[tmk_test]
+fn sgi_self_irq(t: TestContext<'_>) {
+    const TEST_SGI: u32 = 5;
+
+    let sgi_fired = AtomicBool::new(false);
+    let sgi_isr = |ctx: &mut aarch64::IrqContext| {
+        if ctx.intid == TEST_SGI {
+            sgi_fired.store(true, Relaxed);
+        }
+    };
+
+    t.scope.subscope(|s| {
+        s.set_irq_handler(&sgi_isr);
+        s.enable_gic_irq(TEST_SGI);
+        s.enable_interrupts();
+
+        aarch64::send_sgi_to_self(TEST_SGI);
+
+        let frequency = aarch64::read_cntfrq();
+        let start = aarch64::read_cntvct();
+        let timeout_ticks = core::cmp::max(frequency, 1);
+
+        while !sgi_fired.load(Relaxed) && aarch64::read_cntvct().wrapping_sub(start) < timeout_ticks
+        {
+            aarch64::poll_interrupts();
+            core::hint::spin_loop();
+        }
+
+        s.disable_interrupts();
+        s.disable_gic_irq(TEST_SGI);
+    });
+
+    assert!(sgi_fired.load(Relaxed), "self SGI interrupt did not fire");
+}
+
+#[tmk_test]
+fn spi_self_pending_irq(t: TestContext<'_>) {
+    const TEST_SPI: u32 = 32;
+
+    let spi_fired = AtomicBool::new(false);
+    let spi_isr = |ctx: &mut aarch64::IrqContext| {
+        if ctx.intid == TEST_SPI {
+            spi_fired.store(true, Relaxed);
+        }
+    };
+
+    t.scope.subscope(|s| {
+        s.set_irq_handler(&spi_isr);
+        s.enable_gic_irq(TEST_SPI);
+        s.enable_interrupts();
+
+        aarch64::pend_spi(TEST_SPI);
+
+        let frequency = aarch64::read_cntfrq();
+        let start = aarch64::read_cntvct();
+        let timeout_ticks = core::cmp::max(frequency, 1);
+
+        while !spi_fired.load(Relaxed) && aarch64::read_cntvct().wrapping_sub(start) < timeout_ticks
+        {
+            aarch64::poll_interrupts();
+            core::hint::spin_loop();
+        }
+
+        s.disable_interrupts();
+        s.disable_gic_irq(TEST_SPI);
+    });
+
+    assert!(
+        spi_fired.load(Relaxed),
+        "self-pended SPI interrupt did not fire"
+    );
+}

--- a/tmk/simple_tmk/src/aarch64/mod.rs
+++ b/tmk/simple_tmk/src/aarch64/mod.rs
@@ -9,6 +9,8 @@
     reason = "global_asm! required for AArch64 trampoline code"
 )]
 
+mod irq;
+
 use crate::prelude::*;
 use tmk_protocol as _;
 

--- a/tmk/tmk_core/src/aarch64.rs
+++ b/tmk/tmk_core/src/aarch64.rs
@@ -6,6 +6,40 @@
 #![cfg(target_arch = "aarch64")]
 
 use super::Scope;
+use core::sync::atomic::AtomicBool;
+use core::sync::atomic::Ordering::Relaxed;
+
+const GIC_DISTRIBUTOR_BASE: usize = tmk_protocol::aarch64::GIC_DISTRIBUTOR_BASE as usize;
+const GIC_REDISTRIBUTOR_BASE: usize = tmk_protocol::aarch64::GIC_REDISTRIBUTOR_BASE as usize;
+const GIC_REDISTRIBUTOR_SGI_BASE: usize = GIC_REDISTRIBUTOR_BASE + 0x1_0000;
+
+const GICD_CTLR: usize = GIC_DISTRIBUTOR_BASE;
+const GICD_IGROUPR0: usize = GIC_DISTRIBUTOR_BASE + 0x80;
+const GICD_ISENABLER0: usize = GIC_DISTRIBUTOR_BASE + 0x100;
+const GICD_ICENABLER0: usize = GIC_DISTRIBUTOR_BASE + 0x180;
+const GICD_ISPENDR0: usize = GIC_DISTRIBUTOR_BASE + 0x200;
+const GICD_IPRIORITYR0: usize = GIC_DISTRIBUTOR_BASE + 0x400;
+const GICR_WAKER: usize = GIC_REDISTRIBUTOR_BASE + 0x14;
+const GICR_IGROUPR0: usize = GIC_REDISTRIBUTOR_SGI_BASE + 0x80;
+const GICR_ISENABLER0: usize = GIC_REDISTRIBUTOR_SGI_BASE + 0x100;
+const GICR_ICENABLER0: usize = GIC_REDISTRIBUTOR_SGI_BASE + 0x180;
+const GICR_IPRIORITYR0: usize = GIC_REDISTRIBUTOR_SGI_BASE + 0x400;
+
+const GIC_SPECIAL_INTID: u32 = 1020;
+const DAIF_IRQ_MASK: u64 = 1 << 7;
+const GICD_CTLR_ENABLE_GRP1_AND_ARE: u32 = (1 << 1) | (1 << 4);
+
+/// GIC interrupt ID used by the architectural virtual timer.
+pub const VIRTUAL_TIMER_PPI: u32 = tmk_protocol::aarch64::VIRTUAL_TIMER_PPI;
+
+static ARCH_INITIALIZED: AtomicBool = AtomicBool::new(false);
+static mut IRQ_HANDLER: [usize; 2] = [0; 2];
+
+/// A context passed to the IRQ handler.
+pub struct IrqContext {
+    /// The GIC interrupt ID being handled.
+    pub intid: u32,
+}
 
 #[cfg(minimal_rt)]
 mod entry {
@@ -46,11 +80,532 @@ mod entry {
     static mut STACK: Stack = Stack([0; STACK_SIZE]);
 }
 
-pub(super) struct ArchScopeState;
+core::arch::global_asm! {
+    ".balign 2048",
+    ".globl {exception_vectors}",
+    "{exception_vectors}:",
+    "b unexpected_exception",
+    ".org {exception_vectors} + 0x080",
+    "b irq_exception",
+    ".org {exception_vectors} + 0x100",
+    "b unexpected_exception",
+    ".org {exception_vectors} + 0x180",
+    "b unexpected_exception",
+    ".org {exception_vectors} + 0x200",
+    "b unexpected_exception",
+    ".org {exception_vectors} + 0x280",
+    "b irq_exception",
+    ".org {exception_vectors} + 0x300",
+    "b unexpected_exception",
+    ".org {exception_vectors} + 0x380",
+    "b unexpected_exception",
+    ".org {exception_vectors} + 0x400",
+    "b unexpected_exception",
+    ".org {exception_vectors} + 0x480",
+    "b irq_exception",
+    ".org {exception_vectors} + 0x500",
+    "b unexpected_exception",
+    ".org {exception_vectors} + 0x580",
+    "b unexpected_exception",
+    ".org {exception_vectors} + 0x600",
+    "b unexpected_exception",
+    ".org {exception_vectors} + 0x680",
+    "b irq_exception",
+    ".org {exception_vectors} + 0x700",
+    "b unexpected_exception",
+    ".org {exception_vectors} + 0x780",
+    "b unexpected_exception",
 
-impl Scope<'_, '_> {
+    "irq_exception:",
+    // IRQs are asynchronous, so preserve the complete integer and FP/SIMD
+    // context rather than only the registers that are callee-saved by AAPCS64.
+    // The 784-byte frame remains 16-byte aligned: 256 bytes for GPRs, 512
+    // bytes for q0-q31, and 16 bytes for FPCR and FPSR.
+    "sub sp, sp, #784",
+    // Preserve the interrupted general-purpose register context.
+    "stp x0, x1, [sp, #0]",
+    "stp x2, x3, [sp, #16]",
+    "stp x4, x5, [sp, #32]",
+    "stp x6, x7, [sp, #48]",
+    "stp x8, x9, [sp, #64]",
+    "stp x10, x11, [sp, #80]",
+    "stp x12, x13, [sp, #96]",
+    "stp x14, x15, [sp, #112]",
+    "stp x16, x17, [sp, #128]",
+    "stp x18, x19, [sp, #144]",
+    "stp x20, x21, [sp, #160]",
+    "stp x22, x23, [sp, #176]",
+    "stp x24, x25, [sp, #192]",
+    "stp x26, x27, [sp, #208]",
+    "stp x28, x29, [sp, #224]",
+    "str x30, [sp, #240]",
+    // Preserve the interrupted SIMD and floating-point register context.
+    "stp q0, q1, [sp, #256]",
+    "stp q2, q3, [sp, #288]",
+    "stp q4, q5, [sp, #320]",
+    "stp q6, q7, [sp, #352]",
+    "stp q8, q9, [sp, #384]",
+    "stp q10, q11, [sp, #416]",
+    "stp q12, q13, [sp, #448]",
+    "stp q14, q15, [sp, #480]",
+    "stp q16, q17, [sp, #512]",
+    "stp q18, q19, [sp, #544]",
+    "stp q20, q21, [sp, #576]",
+    "stp q22, q23, [sp, #608]",
+    "stp q24, q25, [sp, #640]",
+    "stp q26, q27, [sp, #672]",
+    "stp q28, q29, [sp, #704]",
+    "stp q30, q31, [sp, #736]",
+    // Preserve the floating-point control and status registers.
+    "mrs x0, fpcr",
+    "str x0, [sp, #768]",
+    "mrs x0, fpsr",
+    "str x0, [sp, #776]",
+    "bl {irq_handler}",
+    // Restore the floating-point control and status registers.
+    "ldr x0, [sp, #768]",
+    "msr fpcr, x0",
+    "ldr x0, [sp, #776]",
+    "msr fpsr, x0",
+    // Restore the interrupted SIMD and floating-point register context.
+    "ldp q30, q31, [sp, #736]",
+    "ldp q28, q29, [sp, #704]",
+    "ldp q26, q27, [sp, #672]",
+    "ldp q24, q25, [sp, #640]",
+    "ldp q22, q23, [sp, #608]",
+    "ldp q20, q21, [sp, #576]",
+    "ldp q18, q19, [sp, #544]",
+    "ldp q16, q17, [sp, #512]",
+    "ldp q14, q15, [sp, #480]",
+    "ldp q12, q13, [sp, #448]",
+    "ldp q10, q11, [sp, #416]",
+    "ldp q8, q9, [sp, #384]",
+    "ldp q6, q7, [sp, #352]",
+    "ldp q4, q5, [sp, #320]",
+    "ldp q2, q3, [sp, #288]",
+    "ldp q0, q1, [sp, #256]",
+    // Restore the interrupted general-purpose register context.
+    "ldr x30, [sp, #240]",
+    "ldp x28, x29, [sp, #224]",
+    "ldp x26, x27, [sp, #208]",
+    "ldp x24, x25, [sp, #192]",
+    "ldp x22, x23, [sp, #176]",
+    "ldp x20, x21, [sp, #160]",
+    "ldp x18, x19, [sp, #144]",
+    "ldp x16, x17, [sp, #128]",
+    "ldp x14, x15, [sp, #112]",
+    "ldp x12, x13, [sp, #96]",
+    "ldp x10, x11, [sp, #80]",
+    "ldp x8, x9, [sp, #64]",
+    "ldp x6, x7, [sp, #48]",
+    "ldp x4, x5, [sp, #32]",
+    "ldp x2, x3, [sp, #16]",
+    "ldp x0, x1, [sp, #0]",
+    "add sp, sp, #784",
+    "eret",
+
+    "unexpected_exception:",
+    "b {unexpected_exception_handler}",
+    exception_vectors = sym EXCEPTION_VECTORS,
+    irq_handler = sym irq_handler,
+    unexpected_exception_handler = sym unexpected_exception_handler,
+}
+
+unsafe extern "C" {
+    safe static EXCEPTION_VECTORS: u8;
+}
+
+pub(super) struct ArchScopeState {
+    old_irq_handler: Option<[usize; 2]>,
+    interrupts_enabled: bool,
+}
+
+impl<'scope> Scope<'scope, '_> {
+    /// Initializes the architecture-specific state for a new scope.
+    ///
+    /// Installs the EL1 exception vector table on first use and records the
+    /// current IRQ delivery state so that [`Self::arch_reset`] can restore it.
     pub(super) fn arch_init() -> ArchScopeState {
-        ArchScopeState
+        let interrupts_enabled = are_interrupts_enabled();
+        arch_init_once();
+        ArchScopeState {
+            old_irq_handler: None,
+            interrupts_enabled,
+        }
     }
-    pub(super) fn arch_reset(&mut self) {}
+
+    /// Restores the IRQ handler and IRQ delivery state saved by this scope.
+    pub(super) fn arch_reset(&mut self) {
+        if let Some(handler) = self.arch.old_irq_handler.take() {
+            let _disable = disable_guarded();
+            // SAFETY: IRQ_HANDLER is not concurrently accessed while IRQs are disabled.
+            unsafe { IRQ_HANDLER = handler };
+        }
+        if self.arch.interrupts_enabled {
+            enable_interrupts();
+        } else {
+            disable_interrupts();
+        }
+    }
+
+    /// Saves the currently installed IRQ handler once for later restoration.
+    fn save_irq_handler(&mut self) {
+        if self.arch.old_irq_handler.is_some() {
+            return;
+        }
+        let _disable = disable_guarded();
+        // SAFETY: IRQ_HANDLER is not concurrently modified while IRQs are disabled.
+        self.arch.old_irq_handler = Some(unsafe { IRQ_HANDLER });
+    }
+
+    /// Sets the IRQ handler.
+    ///
+    /// This is reverted when the scope ends.
+    pub fn set_irq_handler(&mut self, handler: &'scope (dyn Send + Fn(&mut IrqContext))) {
+        self.save_irq_handler();
+        let _disable = disable_guarded();
+        // SAFETY: IRQ_HANDLER is not concurrently modified while IRQs are disabled.
+        unsafe {
+            IRQ_HANDLER =
+                core::mem::transmute::<&(dyn Send + Fn(&mut IrqContext)), [usize; 2]>(handler)
+        };
+    }
+
+    /// Enables a GIC interrupt.
+    pub fn enable_gic_irq(&self, intid: u32) {
+        enable_gic_for_current_vp();
+        if intid < 32 {
+            write_reg32(GICR_IGROUPR0, read_reg32(GICR_IGROUPR0) | (1 << intid));
+
+            let priority_address = GICR_IPRIORITYR0 + (intid as usize & !3);
+            let priority_shift = (intid & 3) * 8;
+            let priority = read_reg32(priority_address) & !(0xff << priority_shift);
+            write_reg32(priority_address, priority | (0x80 << priority_shift));
+            write_reg32(GICR_ISENABLER0, 1 << intid);
+        } else {
+            assert!(intid < GIC_SPECIAL_INTID, "SPI INTID must be below 1020");
+            let word = intid as usize / 32;
+            let mask = 1 << (intid & 31);
+            write_reg32(
+                GICD_IGROUPR0 + word * 4,
+                read_reg32(GICD_IGROUPR0 + word * 4) | mask,
+            );
+
+            let priority_address = GICD_IPRIORITYR0 + (intid as usize & !3);
+            let priority_shift = (intid & 3) * 8;
+            let priority = read_reg32(priority_address) & !(0xff << priority_shift);
+            write_reg32(priority_address, priority | (0x80 << priority_shift));
+            write_reg32(GICD_ISENABLER0 + word * 4, mask);
+        }
+        memory_barrier();
+    }
+
+    /// Disables a GIC interrupt.
+    pub fn disable_gic_irq(&self, intid: u32) {
+        if intid < 32 {
+            write_reg32(GICR_ICENABLER0, 1 << intid);
+        } else {
+            assert!(intid < GIC_SPECIAL_INTID, "SPI INTID must be below 1020");
+            let word = intid as usize / 32;
+            write_reg32(GICD_ICENABLER0 + word * 4, 1 << (intid & 31));
+        }
+        memory_barrier();
+    }
+
+    /// Enables IRQ delivery.
+    ///
+    /// This is reverted when the scope ends.
+    pub fn enable_interrupts(&self) {
+        enable_interrupts();
+    }
+
+    /// Disables IRQ delivery and returns true if it was previously enabled.
+    ///
+    /// This is reverted when the scope ends.
+    pub fn disable_interrupts(&self) -> bool {
+        disable_interrupts()
+    }
+}
+
+/// Reads the virtual counter frequency.
+pub fn read_cntfrq() -> u64 {
+    let value;
+    // SAFETY: reading CNTFRQ_EL0 is side-effect free.
+    unsafe {
+        core::arch::asm!("mrs {value}, CNTFRQ_EL0", value = out(reg) value);
+    }
+    value
+}
+
+/// Reads the virtual counter.
+pub fn read_cntvct() -> u64 {
+    let value;
+    // SAFETY: reading CNTVCT_EL0 is side-effect free.
+    unsafe {
+        core::arch::asm!("isb; mrs {value}, CNTVCT_EL0", value = out(reg) value);
+    }
+    value
+}
+
+/// Arms the virtual timer to fire at `count`.
+pub fn set_virtual_timer_compare(count: u64) {
+    // SAFETY: programming the virtual timer is expected in TMK tests.
+    unsafe {
+        core::arch::asm!(
+            "msr CNTV_CVAL_EL0, {count}",
+            "msr CNTV_CTL_EL0, {control}",
+            "isb",
+            count = in(reg) count,
+            control = in(reg) 1u64,
+        );
+    }
+}
+
+/// Disables the virtual timer.
+pub fn disable_virtual_timer() {
+    // SAFETY: programming the virtual timer is expected in TMK tests.
+    unsafe {
+        core::arch::asm!(
+            "msr CNTV_CTL_EL0, {control}",
+            "isb",
+            control = in(reg) 0u64,
+        );
+    }
+}
+
+/// Polls the emulated GIC while waiting for an interrupt.
+///
+/// This gives VMMs that emulate the GIC a regular exit on which to observe
+/// changes to interrupt sources that are managed outside the guest.
+pub fn poll_interrupts() {
+    let _ = read_reg32(GICD_CTLR);
+}
+
+/// Sends a Group 1 SGI to the current VP.
+pub fn send_sgi_to_self(intid: u32) {
+    assert!(intid < 16, "SGI INTID must be in the range 0..16");
+
+    let mpidr = read_mpidr();
+    let aff0 = mpidr & 0xff;
+    let aff1 = (mpidr >> 8) & 0xff;
+    let aff2 = (mpidr >> 16) & 0xff;
+    let aff3 = (mpidr >> 32) & 0xff;
+
+    assert!(aff0 < 16, "simple SGI target list only supports Aff0 < 16");
+
+    let value =
+        (aff3 << 48) | (aff2 << 32) | (u64::from(intid) << 24) | (aff1 << 16) | (1u64 << aff0);
+
+    // SAFETY: programming ICC_SGI1R_EL1 is expected for SGI tests.
+    unsafe {
+        core::arch::asm!(
+            "msr ICC_SGI1R_EL1, {value}",
+            "isb",
+            value = in(reg) value,
+        );
+    }
+}
+
+/// Sets the pending bit for a GIC SPI through GICD_ISPENDR.
+pub fn pend_spi(intid: u32) {
+    assert!(
+        (32..GIC_SPECIAL_INTID).contains(&intid),
+        "SPI INTID must be in 32..1020"
+    );
+    let word = intid as usize / 32;
+    write_reg32(GICD_ISPENDR0 + word * 4, 1 << (intid & 31));
+    memory_barrier();
+}
+
+#[cfg_attr(not(minimal_rt), expect(dead_code))]
+/// Handles a Group 1 IRQ delivered through the EL1 exception vector.
+///
+/// Acknowledges the highest-priority pending interrupt, invokes the registered
+/// scoped handler, and signals end-of-interrupt to the GIC.
+extern "C" fn irq_handler() {
+    let intid = read_icc_iar1();
+    if intid >= GIC_SPECIAL_INTID {
+        return;
+    }
+
+    let handler = {
+        // SAFETY: IRQ_HANDLER is changed only while IRQs are disabled.
+        let handler = unsafe { IRQ_HANDLER };
+        // SAFETY: this is the underlying type stored by set_irq_handler.
+        unsafe {
+            core::mem::transmute::<[usize; 2], Option<&(dyn Send + Fn(&mut IrqContext))>>(handler)
+        }
+    };
+
+    let Some(handler) = handler else {
+        panic!("unhandled IRQ {intid}");
+    };
+
+    handler(&mut IrqContext { intid });
+    write_icc_eoir1(intid);
+}
+
+#[cfg_attr(not(minimal_rt), expect(dead_code))]
+/// Reports an exception for which TMK does not install a dedicated handler.
+///
+/// Reads the EL1 exception registers and panics without returning to the vector.
+extern "C" fn unexpected_exception_handler() -> ! {
+    let esr: u64;
+    let elr: u64;
+    let far: u64;
+    // SAFETY: reading exception syndrome registers is side-effect free.
+    unsafe {
+        core::arch::asm!(
+            "mrs {esr}, ESR_EL1",
+            "mrs {elr}, ELR_EL1",
+            "mrs {far}, FAR_EL1",
+            esr = out(reg) esr,
+            elr = out(reg) elr,
+            far = out(reg) far,
+        );
+    }
+    panic!("unexpected exception: esr={esr:#x}, elr={elr:#x}, far={far:#x}");
+}
+
+/// Performs the one-time installation of the EL1 exception vector table.
+///
+/// IRQ delivery is masked before `VBAR_EL1` is updated.
+fn arch_init_once() {
+    if ARCH_INITIALIZED.swap(true, Relaxed) {
+        return;
+    }
+
+    disable_interrupts();
+    // SAFETY: installing the EL1 exception vector is expected during TMK init.
+    unsafe {
+        core::arch::asm!(
+            "msr VBAR_EL1, {vectors}",
+            "isb",
+            vectors = in(reg) &EXCEPTION_VECTORS as *const u8 as u64,
+        );
+    }
+}
+
+/// Enables the GIC distributor, redistributor, and CPU interface for this VP.
+fn enable_gic_for_current_vp() {
+    write_reg32(GICD_CTLR, GICD_CTLR_ENABLE_GRP1_AND_ARE);
+
+    let waker = read_reg32(GICR_WAKER) & !(1 << 1);
+    write_reg32(GICR_WAKER, waker);
+    while read_reg32(GICR_WAKER) & (1 << 2) != 0 {
+        core::hint::spin_loop();
+    }
+
+    // SAFETY: programming the GIC CPU system-register interface is expected in TMK tests.
+    unsafe {
+        core::arch::asm!(
+            "msr ICC_SRE_EL1, {sre}",
+            "isb",
+            "msr ICC_PMR_EL1, {pmr}",
+            "msr ICC_IGRPEN1_EL1, {enable}",
+            "isb",
+            sre = in(reg) 1u64,
+            pmr = in(reg) 0xffu64,
+            enable = in(reg) 1u64,
+        );
+    }
+}
+
+/// Acknowledges and returns the highest-priority pending Group 1 interrupt ID.
+fn read_icc_iar1() -> u32 {
+    let value: u64;
+    // SAFETY: reading ICC_IAR1_EL1 acknowledges the pending interrupt.
+    unsafe {
+        core::arch::asm!("mrs {value}, ICC_IAR1_EL1", value = out(reg) value);
+    }
+    value as u32
+}
+
+/// Signals completion of a Group 1 interrupt to the GIC CPU interface.
+fn write_icc_eoir1(intid: u32) {
+    // SAFETY: writing ICC_EOIR1_EL1 completes handling of `intid`.
+    unsafe {
+        core::arch::asm!("msr ICC_EOIR1_EL1, {value}", value = in(reg) intid as u64);
+    }
+}
+
+/// Reads the affinity information for the current processing element.
+fn read_mpidr() -> u64 {
+    let value: u64;
+    // SAFETY: reading MPIDR_EL1 is side-effect free.
+    unsafe {
+        core::arch::asm!("mrs {value}, MPIDR_EL1", value = out(reg) value);
+    }
+    value
+}
+
+/// Performs a volatile 32-bit read from a GIC MMIO register.
+fn read_reg32(address: usize) -> u32 {
+    // SAFETY: callers pass known GIC MMIO register addresses.
+    unsafe { (address as *const u32).read_volatile() }
+}
+
+/// Performs a volatile 32-bit write to a GIC MMIO register.
+fn write_reg32(address: usize, value: u32) {
+    // SAFETY: callers pass known GIC MMIO register addresses.
+    unsafe { (address as *mut u32).write_volatile(value) }
+}
+
+/// Ensures prior memory accesses and system-register changes are observable.
+fn memory_barrier() {
+    // SAFETY: a barrier has no memory-safety requirements.
+    unsafe {
+        core::arch::asm!("dsb sy", "isb");
+    }
+}
+
+#[must_use]
+struct DisableGuard(bool);
+
+/// Masks IRQ delivery until the returned guard is dropped.
+///
+/// The guard restores IRQ delivery if it was enabled when the guard was created.
+fn disable_guarded() -> DisableGuard {
+    DisableGuard(disable_interrupts())
+}
+
+impl Drop for DisableGuard {
+    /// Restores IRQ delivery if it was enabled when this guard was created.
+    fn drop(&mut self) {
+        if self.0 {
+            enable_interrupts();
+        }
+    }
+}
+
+/// Masks IRQ delivery and reports whether it was previously enabled.
+fn disable_interrupts() -> bool {
+    let enabled = are_interrupts_enabled();
+    if enabled {
+        // SAFETY: disabling IRQs is always memory safe.
+        unsafe {
+            core::arch::asm!("msr daifset, #2");
+        }
+    }
+    enabled
+}
+
+/// Unmasks IRQ delivery at the current exception level.
+fn enable_interrupts() {
+    // SAFETY: callers ensure an IRQ handler is installed first.
+    unsafe {
+        core::arch::asm!("msr daifclr, #2", "isb");
+    }
+}
+
+// I = 1 → IRQs are masked/disabled
+// I = 0 → IRQs are unmasked/enabled
+/// Returns whether IRQ exceptions are currently unmasked.
+fn are_interrupts_enabled() -> bool {
+    let daif: u64;
+    // SAFETY: reading DAIF is side-effect free.
+    unsafe {
+        core::arch::asm!("mrs {daif}, DAIF", daif = out(reg) daif);
+    }
+    daif & DAIF_IRQ_MASK == 0
 }

--- a/tmk/tmk_core/src/lib.rs
+++ b/tmk/tmk_core/src/lib.rs
@@ -7,7 +7,8 @@
 // UNSAFETY: needed to write low-level TMK code.
 #![expect(unsafe_code)]
 
-mod aarch64;
+#[cfg(target_arch = "aarch64")]
+pub mod aarch64;
 pub mod x86_64;
 
 #[cfg(target_arch = "aarch64")]
@@ -31,7 +32,6 @@ pub struct TestContext<'scope> {
 /// A virtual processor scope, used to interact with the virtual processor
 /// in a (relatively) memory safe way.
 pub struct Scope<'scope, 'env: 'scope> {
-    #[cfg_attr(target_arch = "aarch64", expect(dead_code))]
     arch: arch::ArchScopeState,
     _scope: PhantomData<&'scope mut &'scope ()>,
     _env: PhantomData<&'env mut &'env ()>,

--- a/tmk/tmk_protocol/src/lib.rs
+++ b/tmk/tmk_protocol/src/lib.rs
@@ -13,6 +13,26 @@ use zerocopy::IntoBytes;
 use zerocopy::KnownLayout;
 use zerocopy::TryFromBytes;
 
+/// Fixed AArch64 platform configuration used by `tmk_vmm` and AArch64 TMKs.
+pub mod aarch64 {
+    /// Guest MMIO base address of the GICv3 distributor.
+    ///
+    /// The distributor occupies a 64-KiB frame starting at `0xff00_0000`.
+    pub const GIC_DISTRIBUTOR_BASE: u64 = 0xff00_0000;
+    /// Guest MMIO base address of the first GICv3 redistributor.
+    ///
+    /// Each VP uses a 128-KiB redistributor region containing one 64-KiB
+    /// redistributor frame and one 64-KiB SGI/PPI frame.
+    pub const GIC_REDISTRIBUTOR_BASE: u64 = 0xff02_0000;
+    /// Architectural virtual timer PPI.
+    pub const VIRTUAL_TIMER_PPI: u32 = 20;
+    /// Total number of GIC interrupts exposed by the test platform.
+    ///
+    /// This provides SGIs 0-15, PPIs 16-31, and SPIs 32-255. Architectural
+    /// INTIDs 256-1019 are not implemented by this test platform.
+    pub const GIC_INTERRUPT_COUNT: u32 = 256;
+}
+
 /// Start input from the VMM to the TMK.
 #[repr(C)]
 #[derive(Debug, IntoBytes, Immutable)]

--- a/tmk/tmk_vmm/Cargo.toml
+++ b/tmk/tmk_vmm/Cargo.toml
@@ -9,11 +9,13 @@ rust-version.workspace = true
 [dependencies]
 tmk_protocol.workspace = true
 
+aarch64defs.workspace = true
 hvdef.workspace = true
 loader.workspace = true
 guestmem.workspace = true
 page_table.workspace = true
 virt.workspace = true
+virt_support_gic.workspace = true
 vm_topology.workspace = true
 vmcore.workspace = true
 vm_loader.workspace = true

--- a/tmk/tmk_vmm/src/paravisor_vmm.rs
+++ b/tmk/tmk_vmm/src/paravisor_vmm.rs
@@ -109,6 +109,11 @@ async fn start_vp(
     mut runner: RunnerBuilder,
     isolation: virt::IsolationType,
 ) -> anyhow::Result<std::thread::JoinHandle<()>> {
+    #[cfg(guest_arch = "aarch64")]
+    if let Some(gic) = vp.gic_v3_model() {
+        runner.set_gic(gic);
+    }
+
     let vp_thread = std::thread::spawn(move || {
         let pool = pal_uring::IoUringPool::new("vp", 256).unwrap();
         let driver = pool.client().initiator().clone();

--- a/tmk/tmk_vmm/src/run.rs
+++ b/tmk/tmk_vmm/src/run.rs
@@ -19,9 +19,13 @@ use virt::StopVpSource;
 use virt::VpIndex;
 use virt::io::CpuIo;
 use virt::vp::AccessVpState as _;
+#[cfg(guest_arch = "aarch64")]
+use virt_support_gic::GicV3Model;
 use vm_topology::memory::MemoryLayout;
 use vm_topology::processor::ProcessorTopology;
 use vm_topology::processor::TopologyBuilder;
+#[cfg(guest_arch = "aarch64")]
+use vm_topology::processor::aarch64::GicVersion;
 use vmcore::vmtime::VmTime;
 use vmcore::vmtime::VmTimeKeeper;
 use vmcore::vmtime::VmTimeSource;
@@ -218,14 +222,14 @@ impl CommonState {
         #[cfg(guest_arch = "aarch64")]
         let processor_topology =
             TopologyBuilder::new_aarch64(vm_topology::processor::arch::Aarch64PlatformConfig {
-                gic_distributor_base: 0xff000000,
-                gic_version: vm_topology::processor::aarch64::GicVersion::V3 {
-                    redistributors_base: 0xff020000,
+                gic_distributor_base: tmk_protocol::aarch64::GIC_DISTRIBUTOR_BASE,
+                gic_version: GicVersion::V3 {
+                    redistributors_base: tmk_protocol::aarch64::GIC_REDISTRIBUTOR_BASE,
                 },
                 gic_msi: vm_topology::processor::aarch64::GicMsiController::None,
                 pmu_gsiv: None,
-                virt_timer_ppi: 20, // DEFAULT_VIRT_TIMER_PPI
-                gic_nr_irqs: 256,
+                virt_timer_ppi: tmk_protocol::aarch64::VIRTUAL_TIMER_PPI,
+                gic_nr_irqs: tmk_protocol::aarch64::GIC_INTERRUPT_COUNT,
             })
             .build(1)
             .context("failed to build processor topology")?;
@@ -377,6 +381,9 @@ impl RunContext<'_> {
     ) -> anyhow::Result<TestResult> {
         let (event_send, mut event_recv) = mesh::channel();
 
+        #[cfg(guest_arch = "aarch64")]
+        let gic = Arc::new(GicV3Model::new(&self.state.processor_topology)?);
+
         // Load the TMK.
         let tmk = fs_err::File::open(&self.state.opts.tmk).context("failed to open tmk")?;
         let regs = {
@@ -411,6 +418,8 @@ impl RunContext<'_> {
                 Arc::clone(&regs),
                 guest_memory.clone(),
                 event_send.clone(),
+                #[cfg(guest_arch = "aarch64")]
+                gic,
             ),
         )
         .await?;
@@ -454,6 +463,8 @@ struct IoHandler<'a> {
     guest_memory: &'a GuestMemory,
     event_send: &'a mesh::Sender<VpEvent>,
     stop: &'a StopVpSource,
+    #[cfg(guest_arch = "aarch64")]
+    gic: &'a GicV3Model,
 }
 
 fn widen(d: &[u8]) -> u64 {
@@ -463,8 +474,16 @@ fn widen(d: &[u8]) -> u64 {
 }
 
 impl CpuIo for IoHandler<'_> {
-    fn is_mmio(&self, _address: u64) -> bool {
-        false
+    fn is_mmio(&self, address: u64) -> bool {
+        #[cfg(guest_arch = "aarch64")]
+        {
+            self.gic.contains(address)
+        }
+        #[cfg(not(guest_arch = "aarch64"))]
+        {
+            let _ = address;
+            false
+        }
     }
 
     fn acknowledge_pic_interrupt(&self) -> Option<u8> {
@@ -476,6 +495,10 @@ impl CpuIo for IoHandler<'_> {
     }
 
     async fn read_mmio(&self, vp: VpIndex, address: u64, data: &mut [u8]) {
+        #[cfg(guest_arch = "aarch64")]
+        if self.gic.read(address, data) {
+            return;
+        }
         tracing::info!(vp = vp.index(), address, "read mmio");
         data.fill(!0);
     }
@@ -491,9 +514,14 @@ impl CpuIo for IoHandler<'_> {
                     "failed to handle command"
                 );
             }
-        } else {
-            tracing::info!(vp = vp.index(), address, data = widen(data), "write mmio");
+            return;
         }
+
+        #[cfg(guest_arch = "aarch64")]
+        if self.gic.write(address, data) {
+            return;
+        }
+        tracing::info!(vp = vp.index(), address, data = widen(data), "write mmio");
     }
 
     async fn read_io(&self, vp: VpIndex, port: u16, data: &mut [u8]) {
@@ -567,6 +595,8 @@ pub struct RunnerBuilder {
     regs: Arc<virt::InitialRegs>,
     guest_memory: GuestMemory,
     event_send: mesh::Sender<VpEvent>,
+    #[cfg(guest_arch = "aarch64")]
+    gic: Arc<GicV3Model>,
 }
 
 impl RunnerBuilder {
@@ -575,13 +605,21 @@ impl RunnerBuilder {
         regs: Arc<virt::InitialRegs>,
         guest_memory: GuestMemory,
         event_send: mesh::Sender<VpEvent>,
+        #[cfg(guest_arch = "aarch64")] gic: Arc<GicV3Model>,
     ) -> Self {
         Self {
             vp_index,
             regs,
             guest_memory,
             event_send,
+            #[cfg(guest_arch = "aarch64")]
+            gic,
         }
+    }
+
+    #[cfg(guest_arch = "aarch64")]
+    pub fn set_gic(&mut self, gic: Arc<GicV3Model>) {
+        self.gic = gic;
     }
 
     pub fn build<P: Processor>(&mut self, mut vp: P) -> anyhow::Result<Runner<'_, P>> {
@@ -614,6 +652,8 @@ impl RunnerBuilder {
             vp_index: self.vp_index,
             guest_memory: &self.guest_memory,
             event_send: &self.event_send,
+            #[cfg(guest_arch = "aarch64")]
+            gic: &self.gic,
         })
     }
 }
@@ -623,6 +663,8 @@ pub struct Runner<'a, P> {
     vp_index: VpIndex,
     guest_memory: &'a GuestMemory,
     event_send: &'a mesh::Sender<VpEvent>,
+    #[cfg(guest_arch = "aarch64")]
+    gic: &'a GicV3Model,
 }
 
 impl<P: Processor> Runner<'_, P> {
@@ -636,6 +678,8 @@ impl<P: Processor> Runner<'_, P> {
                     guest_memory: self.guest_memory,
                     event_send: self.event_send,
                     stop: &stop,
+                    #[cfg(guest_arch = "aarch64")]
+                    gic: self.gic,
                 },
             )
             .await;

--- a/vm/aarch64/aarch64defs/src/rsi.rs
+++ b/vm/aarch64/aarch64defs/src/rsi.rs
@@ -89,11 +89,12 @@ pub struct cca_rsi_plane_exit {
     pub gicv3_lrs: [u64; RSI_PLANE_GIC_NUM_LRS],
     pub gicv3_misr: u64,
     pub gicv3_vmcr: u64,
+    pub pad4: [u8; 0x100 - (3 + RSI_PLANE_GIC_NUM_LRS) * 8],
     pub cntp_ctl_el0: u64,
     pub cntp_cval_el0: u64,
     pub cntv_ctl_el0: u64,
     pub cntv_cval_el0: u64,
-    pub pad4: [u8; 0x100 - (7 + RSI_PLANE_GIC_NUM_LRS) * 8],
+    pub pad5: [u8; 0x100 - 4 * 8],
 }
 
 /// Combined RSI plane run page layout.
@@ -108,5 +109,7 @@ pub struct cca_rsi_plane_run {
 
 const _: () = assert!(size_of::<cca_realm_config>() == 0x1000);
 const _: () = assert!(size_of::<cca_rsi_plane_entry>() == 0x300);
-const _: () = assert!(size_of::<cca_rsi_plane_exit>() == 0x400);
+const _: () = assert!(size_of::<cca_rsi_plane_exit>() == 0x500);
+const _: () = assert!(core::mem::offset_of!(cca_rsi_plane_exit, cntp_ctl_el0) == 0x400);
+const _: () = assert!(core::mem::offset_of!(cca_rsi_plane_exit, cntv_ctl_el0) == 0x410);
 const _: () = assert!(size_of::<cca_rsi_plane_run>() == 0x1000);

--- a/vmm_core/virt/src/aarch64/gic_software_device.rs
+++ b/vmm_core/virt/src/aarch64/gic_software_device.rs
@@ -20,6 +20,12 @@ impl GicSoftwareDevice {
     pub fn new(irqcon: Arc<dyn ControlGic>) -> Self {
         Self { irqcon }
     }
+
+    pub fn signal_msi_gicv3(&self, _devid: Option<u32>, _address: u64, data: u32) {
+        if SPI_RANGE.contains(&data) {
+            self.irqcon.pulse_spi_irq(data);
+        }
+    }
 }
 
 #[derive(Debug, Error)]

--- a/vmm_core/virt/src/irqcon.rs
+++ b/vmm_core/virt/src/irqcon.rs
@@ -33,6 +33,12 @@ pub trait IoApicRouting: Send + Sync {
 pub trait ControlGic: Send + Sync {
     /// Sets the assertion state of a GICv3 SPI.
     fn set_spi_irq(&self, irq_id: u32, high: bool);
+
+    /// Pulse for a GICv3 SPI. This is equivalent to asserting and then deasserting the interrupt.
+    fn pulse_spi_irq(&self, irq_id: u32) {
+        self.set_spi_irq(irq_id, true);
+        self.set_spi_irq(irq_id, false);
+    }
 }
 
 // The number of IRQ lines for the interrupt controller.

--- a/vmm_core/virt_support_gic/Cargo.toml
+++ b/vmm_core/virt_support_gic/Cargo.toml
@@ -15,6 +15,7 @@ inspect.workspace = true
 tracelimit.workspace = true
 
 parking_lot.workspace = true
+thiserror.workspace = true
 tracing.workspace = true
 
 [lints]

--- a/vmm_core/virt_support_gic/src/lib.rs
+++ b/vmm_core/virt_support_gic/src/lib.rs
@@ -9,7 +9,169 @@
 pub use gicd::Distributor;
 pub use gicr::Redistributor;
 
+#[derive(Clone, Copy, Debug)]
+pub struct PendingInterrupt {
+    pub intid: u32,
+    pub priority: u8,
+    pub group1: bool,
+}
+
+use aarch64defs::SystemReg;
+use memory_range::MemoryRange;
+use parking_lot::Mutex;
+use vm_topology::processor::ProcessorTopology;
+use vm_topology::processor::VpIndex;
+use vm_topology::processor::aarch64::Aarch64Topology;
+use vm_topology::processor::aarch64::GicVersion;
+
+#[derive(Debug, thiserror::Error)]
+pub enum GicV3ModelError {
+    #[error("software GIC requires GICv3")]
+    UnsupportedGicVersion,
+    #[error("GIC redistributor range overflowed")]
+    RedistributorRangeOverflow,
+    #[error("GIC distributor range overflowed")]
+    DistributorRangeOverflow,
+}
+
+pub struct GicV3Model {
+    distributor: Distributor,
+    redistributors: Vec<Mutex<Redistributor>>,
+    distributor_range: MemoryRange,
+    redistributor_range: MemoryRange,
+}
+
+impl GicV3Model {
+    pub fn new(topology: &ProcessorTopology<Aarch64Topology>) -> Result<Self, GicV3ModelError> {
+        let redistributors_base = match topology.gic_version() {
+            GicVersion::V3 {
+                redistributors_base,
+            } => redistributors_base,
+            GicVersion::V2 { .. } => return Err(GicV3ModelError::UnsupportedGicVersion),
+        };
+        let redistributors_size = aarch64defs::GIC_REDISTRIBUTOR_SIZE
+            .checked_mul(u64::from(topology.vp_count()))
+            .ok_or(GicV3ModelError::RedistributorRangeOverflow)?;
+        let redistributors_end = redistributors_base
+            .checked_add(redistributors_size)
+            .ok_or(GicV3ModelError::RedistributorRangeOverflow)?;
+        let redistributor_range = MemoryRange::new(redistributors_base..redistributors_end);
+        let distributor_base = topology.gic_distributor_base();
+        let distributor_end = distributor_base
+            .checked_add(aarch64defs::GIC_DISTRIBUTOR_SIZE)
+            .ok_or(GicV3ModelError::DistributorRangeOverflow)?;
+        let distributor_range = MemoryRange::new(distributor_base..distributor_end);
+
+        let mut distributor = Distributor::new(
+            distributor_base,
+            redistributor_range,
+            topology.gic_nr_irqs(),
+        );
+
+        let mut redistributors: Vec<Mutex<Redistributor>> = vec![];
+        let vp_count = topology.vp_count() as usize;
+        for (index, vp) in topology.vps_arch().enumerate() {
+            let gicr = distributor.add_redistributor(vp.mpidr.into(), index + 1 == vp_count);
+            redistributors.push(Mutex::new(gicr));
+        }
+
+        Ok(Self {
+            distributor,
+            redistributors,
+            distributor_range,
+            redistributor_range,
+        })
+    }
+
+    pub fn contains(&self, address: u64) -> bool {
+        self.distributor_range.contains_addr(address)
+            || self.redistributor_range.contains_addr(address)
+    }
+
+    pub fn read(&self, address: u64, data: &mut [u8]) -> bool {
+        self.distributor.read(address, data)
+    }
+
+    pub fn write(&self, address: u64, data: &[u8]) -> bool {
+        self.distributor.write(address, data)
+    }
+
+    pub fn set_spi_irq(&self, intid: u32, high: bool) -> Vec<VpIndex> {
+        self.distributor.set_spi_irq(intid, high)
+    }
+
+    pub fn mark_spi_injected(&self, vp: VpIndex, intid: u32) {
+        self.distributor.mark_spi_injected(vp, intid);
+    }
+
+    pub fn cancel_spi_reservation(&self, vp: VpIndex, intid: u32) {
+        self.distributor.cancel_spi_reservation(vp, intid);
+    }
+
+    pub fn retain_in_flight_spis(&self, vp: VpIndex, is_in_flight: impl FnMut(u32) -> bool) {
+        self.distributor.retain_in_flight_spis(vp, is_in_flight);
+    }
+
+    pub fn write_sysreg(
+        &self,
+        vp: VpIndex,
+        reg: SystemReg,
+        value: u64,
+        wake: impl FnMut(usize),
+    ) -> bool {
+        let Some(gicr) = self.redistributors.get(vp.index() as usize) else {
+            return false;
+        };
+        let mut gicr = gicr.lock();
+        self.distributor.write_sysreg(&mut gicr, reg, value, wake)
+    }
+
+    pub fn next_pending_interrupt(
+        &self,
+        vp: VpIndex,
+        running_priority: u8,
+    ) -> Option<PendingInterrupt> {
+        self.distributor
+            .next_pending_interrupt(vp, running_priority)
+    }
+
+    pub fn next_pending_private_interrupt(
+        &self,
+        vp: VpIndex,
+        running_priority: u8,
+    ) -> Option<PendingInterrupt> {
+        self.distributor.next_private_interrupt(vp, running_priority)
+    }
+
+    pub fn next_pending_spi_interrupt(
+        &self,
+        vp: VpIndex,
+        running_priority: u8,
+    ) -> Option<PendingInterrupt> {
+        self.distributor
+            .next_pending_spi_interrupt(vp, running_priority)
+    }
+
+    pub fn reserve_pending_spi_interrupt(
+        &self,
+        vp: VpIndex,
+        running_priority: u8,
+    ) -> Option<PendingInterrupt> {
+        self.distributor
+            .reserve_pending_spi_interrupt(vp, running_priority)
+    }
+
+    pub fn raise_ppi(&self, vp: VpIndex, intid: u32) -> bool {
+        self.distributor.raise_ppi(vp, intid)
+    }
+
+    pub fn complete_interrupt(&self, vp: VpIndex, intid: u32) {
+        self.distributor.clear_pending(vp.index() as usize, intid);
+    }
+}
+
 mod gicd {
+    use super::PendingInterrupt;
     use super::Redistributor;
     use super::gicr::SharedState;
     use aarch64defs::MpidrEl1;
@@ -37,8 +199,20 @@ mod gicd {
 
     #[derive(Debug, Inspect)]
     struct DistributorState {
+        /// Level-triggered SPI input lines currently asserted by devices.
+        #[inspect(iter_by_index)]
+        asserted: Vec<u32>,
         #[inspect(iter_by_index)]
         pending: Vec<u32>,
+        /// Bitmap of 32-INTID words that contain pending or asserted SPIs.
+        pending_word_summary: u32,
+        /// SPIs reserved for injection or represented in a CCA GIC list
+        /// register, indexed by INTID.
+        #[inspect(iter_by_index)]
+        in_flight: Vec<Option<u32>>,
+        /// Reserved or in-flight SPI INTIDs owned by each VP.
+        #[inspect(skip)]
+        in_flight_by_vp: Vec<Vec<u32>>,
         #[inspect(iter_by_index)]
         active: Vec<u32>,
         #[inspect(iter_by_index)]
@@ -56,11 +230,16 @@ mod gicd {
     }
 
     impl Distributor {
-        pub fn new(gicd_base: u64, gicr_range: MemoryRange, max_spis: u32) -> Self {
-            let n = (max_spis as usize + 1) / 32;
+        pub fn new(gicd_base: u64, gicr_range: MemoryRange, interrupt_count: u32) -> Self {
+            let n = interrupt_count.div_ceil(32) as usize;
+            assert!(n <= u32::BITS as usize);
             Self {
                 state: Mutex::new(DistributorState {
+                    asserted: vec![0; n],
                     pending: vec![0; n],
+                    pending_word_summary: 0,
+                    in_flight: vec![None; n * 32],
+                    in_flight_by_vp: Vec::new(),
                     active: vec![0; n],
                     group: vec![0; n],
                     enable: vec![0; n],
@@ -70,7 +249,7 @@ mod gicd {
                     enable_grp0: false,
                     enable_grp1: false,
                 }),
-                max_spi_intid: 32 + max_spis - 1,
+                max_spi_intid: interrupt_count.saturating_sub(1),
                 gicr: Default::default(),
                 gicd_range: MemoryRange::new(
                     gicd_base..gicd_base + aarch64defs::GIC_DISTRIBUTOR_SIZE,
@@ -83,6 +262,10 @@ mod gicd {
             let mpidr = mpidr & u64::from(MpidrEl1::AFFINITY_MASK);
             let (gicr, state) = Redistributor::new(self.gicr.len(), mpidr, last);
             self.gicr.push(state);
+            self.state
+                .lock()
+                .in_flight_by_vp
+                .push(Vec::with_capacity(16));
             assert!(
                 (self.gicr.len() as u64)
                     <= self.gicr_range.len() / aarch64defs::GIC_REDISTRIBUTOR_SIZE
@@ -98,17 +281,318 @@ mod gicd {
             }
         }
 
-        pub fn set_pending(&self, intid: u32, pending: bool) -> Option<u32> {
-            let v = &mut self.state.lock().pending[intid as usize / 32];
-            let mask = 1 << (intid & 31);
-            if (*v & mask != 0) != pending {
+        pub fn set_spi_irq(&self, intid: u32, high: bool) -> Vec<VpIndex> {
+            if intid < 32 || intid > self.max_spi_intid {
+                tracelimit::warn_ratelimited!(intid, high, "invalid GIC SPI assertion");
+                return Vec::new();
+            }
+
+            let mut state = self.state.lock();
+            let changed = Self::set_bit(&mut state.asserted, intid, high);
+            Self::update_pending_word_summary(&mut state, intid as usize / 32);
+            if changed && high && Self::edge_triggered(&state, intid) {
+                Self::set_pending_locked(&mut state, intid, true);
+            }
+            if !changed || !high {
+                return Vec::new();
+            }
+
+            self.target_vps_for_spi(&state, intid)
+        }
+
+        pub fn mark_spi_injected(&self, vp: VpIndex, intid: u32) {
+            if intid < 32 || intid > self.max_spi_intid {
+                tracelimit::warn_ratelimited!(intid, "invalid injected GIC SPI");
+                return;
+            }
+
+            let mut state = self.state.lock();
+            Self::set_pending_locked(&mut state, intid, false);
+            Self::set_in_flight_locked(&mut state, vp, intid);
+        }
+
+        pub fn cancel_spi_reservation(&self, vp: VpIndex, intid: u32) {
+            if intid < 32 || intid > self.max_spi_intid {
+                tracelimit::warn_ratelimited!(intid, "invalid GIC SPI reservation cancellation");
+                return;
+            }
+
+            let mut state = self.state.lock();
+            if state.in_flight[intid as usize] == Some(vp.index()) {
+                state.in_flight[intid as usize] = None;
+                if let Some(owned) = state.in_flight_by_vp.get_mut(vp.index() as usize) {
+                    owned.retain(|owned_intid| *owned_intid != intid);
+                }
+            }
+        }
+
+        pub fn retain_in_flight_spis(
+            &self,
+            vp: VpIndex,
+            mut is_in_flight: impl FnMut(u32) -> bool,
+        ) {
+            let mut state = self.state.lock();
+            let vp_index = vp.index() as usize;
+            let DistributorState {
+                in_flight,
+                in_flight_by_vp,
+                ..
+            } = &mut *state;
+            let Some(owned) = in_flight_by_vp.get_mut(vp_index) else {
+                return;
+            };
+            owned.retain(|intid| {
+                let retain = is_in_flight(*intid);
+                if !retain && in_flight[*intid as usize] == Some(vp.index()) {
+                    in_flight[*intid as usize] = None;
+                }
+                retain
+            });
+        }
+
+        pub fn next_pending_interrupt(
+            &self,
+            vp: VpIndex,
+            running_priority: u8,
+        ) -> Option<PendingInterrupt> {
+            let private = self.next_private_interrupt(vp, running_priority);
+            let spi = self.next_spi_interrupt(vp, running_priority);
+
+            match (private, spi) {
+                (Some(a), Some(b)) if interrupt_precedes(a, b) => Some(a),
+                (Some(_), Some(b)) => Some(b),
+                (Some(a), None) => Some(a),
+                (None, Some(b)) => Some(b),
+                (None, None) => None,
+            }
+        }
+
+        pub fn next_pending_private_interrupt(
+            &self,
+            vp: VpIndex,
+            pending: u32,
+            running_priority: u8,
+        ) -> Option<PendingInterrupt> {
+            if !self.state.lock().enable_grp1 {
+                return None;
+            }
+
+            self.gicr
+                .get(vp.index() as usize)?
+                .select_private_interrupt(pending, running_priority)
+        }
+
+        pub fn next_pending_spi_interrupt(
+            &self,
+            vp: VpIndex,
+            running_priority: u8,
+        ) -> Option<PendingInterrupt> {
+            self.next_spi_interrupt(vp, running_priority)
+        }
+
+        pub fn reserve_pending_spi_interrupt(
+            &self,
+            vp: VpIndex,
+            running_priority: u8,
+        ) -> Option<PendingInterrupt> {
+            let mut state = self.state.lock();
+            let interrupt = self.next_spi_interrupt_locked(&state, vp, running_priority)?;
+            // Reserve while still holding the selection lock so another VP
+            // cannot select the same IRM-routed SPI.
+            Self::set_in_flight_locked(&mut state, vp, interrupt.intid);
+            Some(interrupt)
+        }
+
+        pub fn next_private_interrupt(
+            &self,
+            vp: VpIndex,
+            running_priority: u8,
+        ) -> Option<PendingInterrupt> {
+            if !self.state.lock().enable_grp1 {
+                return None;
+            }
+
+            self.gicr
+                .get(vp.index() as usize)?
+                .next_private_interrupt(running_priority)
+        }
+
+        pub fn clear_pending(&self, vp_index: usize, intid: u32) {
+            if intid < 32 {
+                if let Some(gicr) = self.gicr.get(vp_index) {
+                    gicr.clear_pending(intid);
+                }
+            } else {
+                let mut state = self.state.lock();
+                Self::set_pending_locked(&mut state, intid, false);
+            }
+        }
+
+        fn next_spi_interrupt(
+            &self,
+            vp: VpIndex,
+            running_priority: u8,
+        ) -> Option<PendingInterrupt> {
+            let state = self.state.lock();
+            self.next_spi_interrupt_locked(&state, vp, running_priority)
+        }
+
+        fn next_spi_interrupt_locked(
+            &self,
+            state: &DistributorState,
+            vp: VpIndex,
+            running_priority: u8,
+        ) -> Option<PendingInterrupt> {
+            if !state.enable_grp1 {
+                return None;
+            }
+
+            let mut best = None;
+            let mut ready_words = state.pending_word_summary & !1;
+            while ready_words != 0 {
+                let word = ready_words.trailing_zeros() as usize;
+                ready_words &= ready_words - 1;
+                let mut candidates = (state.pending[word] | state.asserted[word])
+                    & state.enable[word]
+                    & !state.active[word]
+                    & state.group[word];
+                while candidates != 0 {
+                    let bit = candidates.trailing_zeros();
+                    candidates &= candidates - 1;
+
+                    let intid = word as u32 * 32 + bit;
+                    let mask = 1 << bit;
+                    let pending = state.pending[word] & mask != 0;
+                    let level_asserted =
+                        state.asserted[word] & mask != 0 && !Self::edge_triggered(&state, intid);
+                    if !pending && !level_asserted {
+                        continue;
+                    }
+                    if intid > self.max_spi_intid
+                        || state.in_flight[intid as usize].is_some()
+                        || !self.spi_targets_vp(&state, intid, vp)
+                    {
+                        continue;
+                    }
+
+                    let priority = Self::priority(&state.priority, intid);
+                    if priority >= running_priority {
+                        continue;
+                    }
+
+                    let interrupt = PendingInterrupt {
+                        intid,
+                        priority,
+                        group1: true,
+                    };
+                    if best.is_none_or(|current| interrupt_precedes(interrupt, current)) {
+                        best = Some(interrupt);
+                    }
+                }
+            }
+
+            best
+        }
+
+        fn set_pending_locked(state: &mut DistributorState, intid: u32, pending: bool) -> bool {
+            let changed = Self::set_bit(&mut state.pending, intid, pending);
+            if changed {
+                Self::update_pending_word_summary(state, intid as usize / 32);
                 tracing::debug!(intid, pending, "set pending");
             }
-            if pending {
-                *v |= mask;
+            changed
+        }
+
+        fn update_pending_word_summary(state: &mut DistributorState, word: usize) {
+            let mask = 1 << word;
+            if state.pending[word] | state.asserted[word] != 0 {
+                state.pending_word_summary |= mask;
+            } else {
+                state.pending_word_summary &= !mask;
+            }
+        }
+
+        fn set_in_flight_locked(state: &mut DistributorState, vp: VpIndex, intid: u32) {
+            let vp_index = vp.index() as usize;
+            if state.in_flight[intid as usize] == Some(vp.index()) {
+                return;
+            }
+
+            if let Some(previous_vp) = state.in_flight[intid as usize] {
+                if let Some(owned) = state.in_flight_by_vp.get_mut(previous_vp as usize) {
+                    owned.retain(|owned_intid| *owned_intid != intid);
+                }
+            }
+            state.in_flight[intid as usize] = Some(vp.index());
+            state.in_flight_by_vp[vp_index].push(intid);
+        }
+
+        fn set_bit(bits: &mut [u32], intid: u32, value: bool) -> bool {
+            let Some(word) = bits.get_mut(intid as usize / 32) else {
+                return false;
+            };
+
+            let mask = 1 << (intid & 31);
+            let changed = (*word & mask != 0) != value;
+            if value {
+                *word |= mask;
+            } else {
+                *word &= !mask;
+            }
+            changed
+        }
+
+        /// Returns whether `intid` is configured as edge-triggered in GICD_ICFGR.
+        /// Each INTID uses two bits: bit 1 selects edge (1) or level (0), while bit 0 is RES0.
+        /// 31 30 | 29 28 | ... | 5 4 | 3 2 | 1 0
+        /// ------|-------|-----|-----|-----|------
+        ///  IRQ15| IRQ14 | ... | IRQ2| IRQ1| IRQ0
+        /// trigger bit = 0 → level-triggered
+        /// trigger bit = 1 → edge-triggered
+        /// each word describes 16 interrupts
+        fn edge_triggered(state: &DistributorState, intid: u32) -> bool {
+            let word = state.cfg.get(intid as usize / 16).copied().unwrap_or(0);
+            let shift = (intid % 16) * 2 + 1;
+            word & (1 << shift) != 0
+        }
+
+        fn priority(priority: &[u32], intid: u32) -> u8 {
+            let word = priority.get(intid as usize / 4).copied().unwrap_or(0);
+            let shift = (intid % 4) * 8;
+            ((word >> shift) & 0xff) as u8
+        }
+
+        fn target_vps_for_spi(&self, state: &DistributorState, intid: u32) -> Vec<VpIndex> {
+            self.gicr
+                .iter()
+                .enumerate()
+                .filter_map(|(index, _)| {
+                    let vp = VpIndex::new(index as u32);
+                    self.spi_targets_vp(state, intid, vp).then_some(vp)
+                })
+                .collect()
+        }
+
+        fn spi_targets_vp(&self, state: &DistributorState, intid: u32, vp: VpIndex) -> bool {
+            let Some(gicr) = self.gicr.get(vp.index() as usize) else {
+                return false;
+            };
+            let route = state.route.get(intid as usize).copied().unwrap_or(0);
+            if route & (1 << 31) != 0 {
+                return true;
+            }
+
+            let mpidr = gicr.mpidr;
+            u64::from(mpidr.aff0()) == (route & 0xff)
+                && u64::from(mpidr.aff1()) == ((route >> 8) & 0xff)
+                && u64::from(mpidr.aff2()) == ((route >> 16) & 0xff)
+                && u64::from(mpidr.aff3()) == ((route >> 32) & 0xff)
+        }
+
+        pub fn set_pending(&self, intid: u32, pending: bool) -> Option<u32> {
+            if Self::set_pending_locked(&mut self.state.lock(), intid, pending) && pending {
                 Some(0)
             } else {
-                *v &= !mask;
                 None
             }
         }
@@ -149,6 +633,7 @@ mod gicd {
                 *p &= !(1 << v);
                 *a |= 1 << v;
                 let intid = i as u32 * 32 + v;
+                Self::update_pending_word_summary(state, i);
                 tracing::debug!(intid, "gicd ack");
                 intid
             } else {
@@ -252,6 +737,26 @@ mod gicd {
                         }
                     }
                 }
+                r if GicdRegister::ISPENDR.contains(&r.0) => {
+                    let n = (r.0 & 0x7f) / 4;
+                    if n != 0 {
+                        let mut state = self.state.lock();
+                        if let Some(pending) = state.pending.get_mut(n as usize) {
+                            *pending |= value;
+                            Self::update_pending_word_summary(&mut state, n as usize);
+                        }
+                    }
+                }
+                r if GicdRegister::ICPENDR.contains(&r.0) => {
+                    let n = (r.0 & 0x7f) / 4;
+                    if n != 0 {
+                        let mut state = self.state.lock();
+                        if let Some(pending) = state.pending.get_mut(n as usize) {
+                            *pending &= !value;
+                            Self::update_pending_word_summary(&mut state, n as usize);
+                        }
+                    }
+                }
                 r if GicdRegister::ICFGR.contains(&r.0) => {
                     let n = (r.0 & 0xff) / 4;
                     if n >= 2 {
@@ -264,8 +769,8 @@ mod gicd {
                 r if GicdRegister::IPRIORITYR.contains(&r.0) => {
                     let n = (r.0 & 0x3ff) / 4;
                     if n >= 8 {
-                        if let Some(cfg) = self.state.lock().cfg.get_mut(n as usize) {
-                            *cfg = value;
+                        if let Some(priority) = self.state.lock().priority.get_mut(n as usize) {
+                            *priority = value;
                         }
                     }
                 }
@@ -494,9 +999,259 @@ mod gicd {
             }
         }
     }
+
+    fn interrupt_precedes(a: PendingInterrupt, b: PendingInterrupt) -> bool {
+        a.priority < b.priority || (a.priority == b.priority && a.intid < b.intid)
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+        use aarch64defs::gic::GicrSgiRegister;
+
+        const TEST_SPI: u32 = 32;
+
+        fn test_distributor() -> Distributor {
+            let mut distributor = Distributor::new(
+                0,
+                MemoryRange::new(
+                    aarch64defs::GIC_DISTRIBUTOR_SIZE
+                        ..aarch64defs::GIC_DISTRIBUTOR_SIZE
+                            + 2 * aarch64defs::GIC_REDISTRIBUTOR_SIZE,
+                ),
+                64,
+            );
+            distributor.add_redistributor(0, true);
+
+            let mut state = distributor.state.lock();
+            state.enable_grp1 = true;
+            state.enable[1] |= 1;
+            state.group[1] |= 1;
+            drop(state);
+
+            distributor
+        }
+
+        fn write_gicr_sgi(distributor: &Distributor, register: u16, value: u32) {
+            let address = aarch64defs::GIC_DISTRIBUTOR_SIZE
+                + aarch64defs::GIC_REDISTRIBUTOR_FRAME_SIZE
+                + u64::from(register);
+            assert!(distributor.write(address, &value.to_ne_bytes()));
+        }
+
+        fn set_private_priority(distributor: &Distributor, intid: u32, priority: u8) {
+            let register = GicrSgiRegister::IPRIORITYR0.0 + (intid / 4 * 4) as u16;
+            let value = u32::from(priority) << ((intid % 4) * 8);
+            write_gicr_sgi(distributor, register, value);
+        }
+
+        #[test]
+        fn level_spi_is_redelivered_until_deasserted() {
+            let distributor = test_distributor();
+            let vp = VpIndex::new(0);
+
+            // A newly asserted level-sensitive line wakes its target VP and
+            // makes the SPI eligible for injection.
+            assert_eq!(distributor.set_spi_irq(TEST_SPI, true), [vp]);
+            assert_eq!(
+                distributor
+                    .next_pending_spi_interrupt(vp, u8::MAX)
+                    .map(|interrupt| interrupt.intid),
+                Some(TEST_SPI)
+            );
+
+            // Once the SPI is represented in an LR, do not select it again
+            // while that delivery remains in flight.
+            distributor.mark_spi_injected(vp, TEST_SPI);
+            assert!(
+                distributor
+                    .next_pending_spi_interrupt(vp, u8::MAX)
+                    .is_none()
+            );
+
+            // Reporting the INTID as still present in an LR preserves its
+            // in-flight state and continues to suppress duplicate injection.
+            distributor.retain_in_flight_spis(vp, |intid| intid == TEST_SPI);
+            assert!(
+                distributor
+                    .next_pending_spi_interrupt(vp, u8::MAX)
+                    .is_none()
+            );
+
+            // Simulate guest EOI followed by LR retirement. The device line
+            // is still asserted, so the level-sensitive SPI is eligible again.
+            distributor.retain_in_flight_spis(vp, |_| false);
+            assert_eq!(
+                distributor
+                    .next_pending_spi_interrupt(vp, u8::MAX)
+                    .map(|interrupt| interrupt.intid),
+                Some(TEST_SPI)
+            );
+
+            // After the second injection, the device deasserts its line. Once
+            // that LR retires, the SPI must not be delivered again.
+            distributor.mark_spi_injected(vp, TEST_SPI);
+            assert!(distributor.set_spi_irq(TEST_SPI, false).is_empty());
+            distributor.retain_in_flight_spis(vp, |_| false);
+            assert!(
+                distributor
+                    .next_pending_spi_interrupt(vp, u8::MAX)
+                    .is_none()
+            );
+        }
+
+        #[test]
+        fn deasserting_line_does_not_clear_software_pending_spi() {
+            let distributor = test_distributor();
+            let vp = VpIndex::new(0);
+
+            assert_eq!(distributor.set_pending(TEST_SPI, true), Some(0));
+            assert!(distributor.set_spi_irq(TEST_SPI, false).is_empty());
+            assert_eq!(
+                distributor
+                    .next_pending_spi_interrupt(vp, u8::MAX)
+                    .map(|interrupt| interrupt.intid),
+                Some(TEST_SPI)
+            );
+        }
+
+        #[test]
+        fn pending_word_summary_tracks_pending_and_asserted_spis() {
+            let distributor = test_distributor();
+            let word_mask = 1 << (TEST_SPI / 32);
+
+            assert_eq!(distributor.state.lock().pending_word_summary & word_mask, 0);
+            assert_eq!(distributor.set_pending(TEST_SPI, true), Some(0));
+            assert_ne!(distributor.state.lock().pending_word_summary & word_mask, 0);
+            assert_eq!(distributor.set_pending(TEST_SPI, false), None);
+            assert_eq!(distributor.state.lock().pending_word_summary & word_mask, 0);
+
+            assert_eq!(distributor.set_spi_irq(TEST_SPI, true), [VpIndex::new(0)]);
+            assert_ne!(distributor.state.lock().pending_word_summary & word_mask, 0);
+            assert!(distributor.set_spi_irq(TEST_SPI, false).is_empty());
+            assert_eq!(distributor.state.lock().pending_word_summary & word_mask, 0);
+        }
+
+        #[test]
+        fn edge_spi_is_latched_until_injected() {
+            let distributor = test_distributor();
+            let vp = VpIndex::new(0);
+            distributor.state.lock().cfg[2] |= 1 << 1;
+
+            assert_eq!(distributor.set_spi_irq(TEST_SPI, true), [vp]);
+            assert!(distributor.set_spi_irq(TEST_SPI, false).is_empty());
+            assert_eq!(
+                distributor
+                    .next_pending_spi_interrupt(vp, u8::MAX)
+                    .map(|interrupt| interrupt.intid),
+                Some(TEST_SPI)
+            );
+
+            distributor.mark_spi_injected(vp, TEST_SPI);
+            distributor.retain_in_flight_spis(vp, |_| false);
+            assert!(
+                distributor
+                    .next_pending_spi_interrupt(vp, u8::MAX)
+                    .is_none()
+            );
+        }
+
+        #[test]
+        fn irm_spi_reservation_is_exclusive_and_can_be_cancelled() {
+            let mut distributor = test_distributor();
+            let vp0 = VpIndex::new(0);
+            let vp1 = VpIndex::new(1);
+            distributor.add_redistributor(1, true);
+            distributor.state.lock().route[TEST_SPI as usize] = 1 << 31;
+
+            assert_eq!(distributor.set_spi_irq(TEST_SPI, true), [vp0, vp1]);
+            assert_eq!(
+                distributor
+                    .reserve_pending_spi_interrupt(vp0, u8::MAX)
+                    .map(|interrupt| interrupt.intid),
+                Some(TEST_SPI)
+            );
+            assert_eq!(distributor.state.lock().in_flight_by_vp[0], [TEST_SPI]);
+            assert!(
+                distributor
+                    .reserve_pending_spi_interrupt(vp1, u8::MAX)
+                    .is_none()
+            );
+
+            distributor.cancel_spi_reservation(vp0, TEST_SPI);
+            assert!(distributor.state.lock().in_flight_by_vp[0].is_empty());
+            assert_eq!(
+                distributor
+                    .reserve_pending_spi_interrupt(vp1, u8::MAX)
+                    .map(|interrupt| interrupt.intid),
+                Some(TEST_SPI)
+            );
+        }
+
+        #[test]
+        fn private_interrupts_obey_enable_and_priority() {
+            const TEST_SGI: u32 = 5;
+            const TEST_PPI: u32 = 20;
+
+            let distributor = test_distributor();
+            let vp = VpIndex::new(0);
+            let both_pending = (1 << TEST_SGI) | (1 << TEST_PPI);
+
+            // A requested private interrupt is not deliverable until its
+            // redistributor enable and Group 1 bits are both set.
+            assert!(
+                distributor
+                    .next_pending_private_interrupt(vp, both_pending, u8::MAX)
+                    .is_none()
+            );
+            write_gicr_sgi(&distributor, GicrSgiRegister::IGROUPR0.0, both_pending);
+            assert!(
+                distributor
+                    .next_pending_private_interrupt(vp, both_pending, u8::MAX)
+                    .is_none()
+            );
+            write_gicr_sgi(&distributor, GicrSgiRegister::ISENABLER0.0, both_pending);
+
+            set_private_priority(&distributor, TEST_SGI, 0x40);
+            set_private_priority(&distributor, TEST_PPI, 0x80);
+
+            // A priority equal to the PMR threshold is masked. Raising the
+            // threshold admits the SGI and preserves its programmed priority.
+            assert!(
+                distributor
+                    .next_pending_private_interrupt(vp, both_pending, 0x40)
+                    .is_none()
+            );
+            let interrupt = distributor
+                .next_pending_private_interrupt(vp, both_pending, 0x41)
+                .unwrap();
+            assert_eq!((interrupt.intid, interrupt.priority), (TEST_SGI, 0x40));
+
+            // With only the PPI requested, its independently programmed
+            // priority is subject to the same PMR threshold.
+            let ppi_pending = 1 << TEST_PPI;
+            assert!(
+                distributor
+                    .next_pending_private_interrupt(vp, ppi_pending, 0x80)
+                    .is_none()
+            );
+            let interrupt = distributor
+                .next_pending_private_interrupt(vp, ppi_pending, 0x81)
+                .unwrap();
+            assert_eq!((interrupt.intid, interrupt.priority), (TEST_PPI, 0x80));
+
+            distributor.state.lock().enable_grp1 = false;
+            assert!(
+                distributor
+                    .next_pending_private_interrupt(vp, both_pending, u8::MAX)
+                    .is_none()
+            );
+        }
+    }
 }
 
 mod gicr {
+    use super::PendingInterrupt;
     use aarch64defs::MpidrEl1;
     use aarch64defs::gic::GicrCtlr;
     use aarch64defs::gic::GicrRdRegister;
@@ -541,6 +1296,55 @@ mod gicr {
     }
 
     impl SharedState {
+        pub(crate) fn next_private_interrupt(
+            &self,
+            running_priority: u8,
+        ) -> Option<PendingInterrupt> {
+            let pending = self.pending.load(Ordering::Relaxed);
+            self.select_private_interrupt(pending, running_priority)
+        }
+
+        pub(crate) fn select_private_interrupt(
+            &self,
+            pending: u32,
+            running_priority: u8,
+        ) -> Option<PendingInterrupt> {
+            let state = self.mutable.lock();
+            let deliverable = pending & state.enable & !state.active & state.group;
+
+            let mut best: Option<PendingInterrupt> = None;
+            for intid in 0..32 {
+                if deliverable & (1 << intid) == 0 {
+                    continue;
+                }
+
+                /*
+                intid 0..3   -> priority[0]
+                intid 4..7   -> priority[1]
+                intid 8..11  -> priority[2]
+                */
+                let word = state.priority[(intid / 4) as usize];
+                let priority = ((word >> ((intid % 4) * 8)) & 0xff) as u8;
+                if priority >= running_priority {
+                    continue;
+                }
+
+                let interrupt = PendingInterrupt {
+                    intid,
+                    priority,
+                    group1: true,
+                };
+                if best.is_none_or(|current| {
+                    priority < current.priority
+                        || (priority == current.priority && intid < current.intid)
+                }) {
+                    best = Some(interrupt);
+                }
+            }
+
+            best
+        }
+
         pub fn raise(&self, intid: u32) -> bool {
             let mask = 1 << intid;
             self.pending.fetch_or(mask, Ordering::Relaxed) & mask == 0
@@ -744,6 +1548,13 @@ mod gicr {
             }
             tracing::debug!(?address, data, "gicr sgi write32");
             true
+        }
+
+        pub fn clear_pending(&self, intid: u32) {
+            debug_assert!(intid < 32);
+
+            self.pending
+                .fetch_and(!(1 << intid), Ordering::Relaxed);
         }
     }
 


### PR DESCRIPTION
Add the initial ARM GICv3 interrupt-delivery framework for CCA lower planes. Route virtual timer PPIs, self-generated SGIs, and shared SPIs through a partition-owned GIC model and inject eligible interrupts through the RMM GIC list registers.

Previously, CCA IRQ exits were only logged, trapped GIC accesses did not provide a complete interrupt path, and local interrupt sources could be inserted into an LR without respecting the guest-programmed GIC enable and priority state.

CCA interrupt injection
-----------------------

Add a common CCA virtual-interrupt representation containing an INTID, priority, group, and pending state.

Preserve the GIC list registers returned by the RMM and inject pending software-backed Group 1 interrupts into the first free LR. Avoid adding a duplicate LR when the same INTID is already pending or active.

Enable ICH_HCR_EL2.TC for plane entry and encode software LRs with:

* the virtual INTID in bits 31:0
* the guest-programmed priority in bits 55:48
* Group 1 in bit 60
* HW clear in bit 61
* Pending state in bits 63:62

Leave EOI-maintenance disabled because the CCA backend does not yet implement the GIC maintenance-interrupt path.

Use an invalid exit-reason sentinel to distinguish a real plane exit from a host wakeup, and preserve the RMM-returned plane and LR context before processing the exit.

Virtual timer PPI
-----------------

Handle PlaneExitReason::Irq and recognize an asserted architectural virtual timer from the RMM-provided CNTV_CTL_EL0 state.

Request the timer PPI only when:

* ENABLE is set
* IMASK is clear
* ISTATUS is set

Obtain the virtual timer INTID from ProcessorTopology instead of hardcoding PPI 20. This is required because the RMM timer exit reports the timer source but does not provide an INTID.

Queue the timer as a private interrupt and pass it through the shared GIC redistributor selection path before LR injection. Delivery therefore now observes:

* distributor Group 1 enable
* GICR_IGROUPR0
* GICR_ISENABLER0
* GICR active state
* the PPI priority programmed through GICR_IPRIORITYR
* the priority threshold programmed through ICC_PMR_EL1

Decode trapped ICC_PMR_EL1 writes and retain the current priority mask for each CCA VTL. This fixes timer PPIs bypassing guest GIC enable and priority configuration.

SGI
---

Decode synchronous ICC_SGI1R_EL1 system-register traps and queue the requested self-SGI rather than injecting it directly.

Advance the lower-plane PC after emulating ICC_SGI1R_EL1 and ICC_PMR_EL1 writes so that the trapped instruction is not executed again after re-entry.

Route queued SGIs through the same private-interrupt selection used by PPIs. SGI delivery therefore also observes the redistributor enable, Group 1, active, programmed priority, and ICC_PMR_EL1 state.

Add a TMK self-SGI test using INTID 5 and the Group 1 system-register interface.

SPI
---

Create a partition-owned GicV3Model for CCA and expose it to the VP runner so that device interrupt assertion, CCA interrupt polling, and guest GIC MMIO emulation operate on the same state.

Implement the CCA ControlGic::set_spi_irq path. Record the device line level, determine the target VPs from GICD_IROUTER state, and wake those VPs through the interrupt-controller wake reason when a line is newly asserted.

Track SPI state independently as:

* software pending state
* external line assertion level
* active state
* LR/in-flight ownership

Select a shared interrupt only when it is pending or asserted, enabled, assigned to Group 1, inactive, routed to the current VP, not already in flight, and has a priority that passes ICC_PMR_EL1.

Preserve an edge-triggered SPI request after the source line falls by latching it in the pending state until successful LR injection.

Preserve the asserted state of a level-triggered SPI after injection. When the RMM retires its LR, clear only the in-flight ownership. If the device line remains asserted, make the SPI eligible for injection again. Stop redelivery only after the device deasserts the line.

This fixes level-triggered SPIs being lost after their first injection and EOI.

Support guest software pending and clearing through GICD_ISPENDR and GICD_ICPENDR. Deasserting a device line does not clear an independently created software-pending request.

GIC model and TMK support
-------------------------

Extend the reusable GICv3 model with the distributor and redistributor state needed by the CCA paths, including:

* Group 1 distributor enable
* interrupt group and enable state
* pending, active, and trigger configuration
* per-INTID priorities
* SPI routing
* GICR SGI/PPI enable, group, pending, active, and priority state
* priority-based private and shared interrupt selection
* MMIO reads and writes for the supported GICD/GICR registers

Define a common TMK AArch64 platform layout:

* GICD at 0xff00_0000
* GICR at 0xff02_0000
* virtual timer PPI 20
* 256 exposed INTIDs: SGI 0-15, PPI 16-31, and SPI 32-255

Add minimal EL1 IRQ support to tmk_core:

* install an aligned VBAR_EL1 exception-vector table
* save and restore registers around IRQ handling
* provide scoped IRQ callback registration
* configure GIC Group 1, interrupt enable, and priority state
* program ICC_SRE_EL1, ICC_PMR_EL1, and ICC_IGRPEN1_EL1
* acknowledge through ICC_IAR1_EL1
* complete through ICC_EOIR1_EL1
* mask and unmask IRQs through DAIF
* provide virtual timer, self-SGI, and software-pending SPI helpers

Route TMK GIC MMIO accesses to the same partition GicV3Model used by the CCA VP. Add tests for:

* architectural virtual timer PPI delivery
* self-targeted SGI delivery
* software-pended SPI 32 delivery
* level-triggered SPI redelivery until deassertion
* edge-triggered SPI pending latching
* preservation of software-pending state across line deassertion
* SGI/PPI enable and priority filtering

Correct the RSI plane-exit layout so the timer state starts at its ABI-defined 0x400 offset and assert the resulting structure offsets and sizes.

Known limitations
-------------------------

This is an initial CCA IRQ implementation, not a complete GICv3 implementation.

* PlaneExitReason::Irq currently recognizes only the architectural virtual timer. PMU, physical timer, and other local PPI sources are not identified or mapped.
* SGI support is limited to the single-VP/self-target test path. Full ICC_SGI1R_EL1 affinity routing, target lists, broadcast behavior, and multi-VP delivery are not implemented or validated.
* The SPI end-to-end test uses GICD_ISPENDR to create a software-pending SPI. It does not validate a real emulated device asserting and deasserting ControlGic::set_spi_irq through the complete device/VMM/ Realm path.
* Level- and edge-triggered device SPI behavior is covered by GIC model unit tests, but still needs end-to-end device validation, including routing, VP wakeup, EOI/LR retirement, and repeated level delivery.
* The TMK platform currently creates one VP and exposes only INTIDs 0-255. INTIDs 256-1019 are not implemented by this test platform.
* Only the GIC register subset required by the current tests is implemented. Group 0, complete security-state behavior, ITS/MSI/LPI, and full architectural GICv3 semantics are not supported.
* LR allocation is first-free. There is no LR eviction, maintenance interrupt handling, or complete priority-preemption model.
* Private pending storage is bounded, and running-priority, binary-point, and nested-interrupt behavior are not fully modeled.
* GIC EOI-maintenance events, cross-VTL interrupts, and the CCA untrusted-SynIC interrupt path remain unimplemented.
* MMIO polling in the TMK tests is a workaround for current RMM/FVP notification behavior rather than the final asynchronous delivery mechanism.
* Unsupported CCA IRQ sources are traced and ignored, while unsupported system-register traps terminate the VP.

IRQ tests
-------------------------
Add TMK tests covering the initial CCA interrupt-delivery paths:

* Virtual timer PPI: program CNTV_CVAL_EL0, wait for virtual timer PPI 20,
      verify delivery through the GIC, and disable the timer in the IRQ handler.

* Self-targeted SGI: generate Group 1 SGI 5 through ICC_SGI1R_EL1 and verify
      that it is delivered to the current VP.

* Software-pended SPI: set SPI 32 pending through GICD_ISPENDR and verify
      delivery through the distributor and GIC list-register path.

    Install the CCA emulation environment once with:

        cargo xflowey cca-tests --install-emu

    Build and run the CCA runtime test, including these TMK IRQ tests, with:

        cargo xflowey cca-tests

    To build the test artifacts without running the emulator, use:

        cargo xflowey cca-tests --build-only

    Note taht "Software-pended SPI” is intentionally precise: this test does not
    exercise a real emulated device asserting an SPI line.

Test results
-------------------------
INFO test: test passed, name: "aarch64::irq::virtual_timer_irq"
INFO test: test passed, name: "aarch64::irq::spi_self_pending_irq"
INFO test: test passed, name: "aarch64::irq::sgi_self_irq"

Signed-off-by: Wei Ding <b-weiding@microsoft.com>
Signed-off-by: Ben Aram <b-bearam@microsoft.com>
Signed-off-by: Jiong Wang <b-jiongwang@microsoft.com>