### PR TITLE
openvmm, virt_kvm: support cca isolated partitions based on the v15 KVM patch series

### DIFF
--- a/Guide/src/reference/openvmm/management/cli.md
+++ b/Guide/src/reference/openvmm/management/cli.md
@@ -88,13 +88,18 @@ as well as the generated CLI help (via `cargo run -- --help`).
   --hypervisor kvm
   ```
 * `--isolation <MODE>`: Enable a confidential or isolated VM mode.
-  Supported modes include `vbs` and, for `x86_64` guests on KVM, `snp`.
+  Supported modes include `vbs`, `snp` for `x86_64` KVM guests, and `cca` for
+  `aarch64` KVM guests.
 
   SNP support is currently limited to Linux direct boot and is intended for
   bring-up. It does not support UEFI, Hyper-V enlightenments, VTL2, VMBus,
   or hugetlb-backed memory. In addition to the minimal emulated chipset and
   serial console, optional devices are limited to virtio devices attached
   through PCIe.
+
+  CCA support requires device-tree Linux direct boot with shared userspace RAM
+  backing. It does not support Hyper-V enlightenments, VTL2, VMBus, hugetlb
+  memory, assigned devices, vhost-user devices, PCIe hotplug, or CXL.
 * `--nested-virt`: Expose hardware virtualization (VMX/SVM) to the guest so it
   can run its own hypervisor (Hyper-V, KVM, etc.). Only supported on `x86_64`,
   and only by backends that support nested virtualization (currently WHP and

--- a/openvmm/membacking/src/memory_manager/mod.rs
+++ b/openvmm/membacking/src/memory_manager/mod.rs
@@ -708,6 +708,14 @@ pub struct GuestMemoryClient {
     mapping_manager: MappingManagerClient,
 }
 
+#[derive(Debug, Error)]
+pub enum AliasedGuestMemoryError {
+    #[error("failed to create guest memory mapper")]
+    Mapper(#[from] VaMapperError),
+    #[error("failed to create aliased guest memory")]
+    MultiRegion(#[from] guestmem::MultiRegionError),
+}
+
 impl GuestMemoryClient {
     /// Retrieves a [`GuestMemory`] object to access guest memory from this
     /// process.
@@ -720,6 +728,23 @@ impl GuestMemoryClient {
             "ram",
             self.mapping_manager.new_mapper(false).await?,
         ))
+    }
+
+    /// Retrieves a [`GuestMemory`] object that aliases the lower GPA range at
+    /// `alias_bit`.
+    pub async fn aliased_guest_memory(
+        &self,
+        debug_name: impl Into<Arc<str>>,
+        alias_bit: u64,
+    ) -> Result<GuestMemory, AliasedGuestMemoryError> {
+        Ok(GuestMemory::new_multi_region(
+            debug_name,
+            alias_bit,
+            vec![
+                Some(self.mapping_manager.new_mapper(false).await?),
+                Some(self.mapping_manager.new_mapper(false).await?),
+            ],
+        )?)
     }
 }
 
@@ -1147,7 +1172,6 @@ mod tests {
             assert_eq!(buf, pattern_b);
         });
     }
-
     /// Builds a manager with a single THP-enabled shared RAM backing and
     /// returns a [`GuestMemory`] over the **primary** mapper. Soft large pages
     /// (the Windows deferred-protect scheme that maps guest RAM read-only until
@@ -1209,5 +1233,28 @@ mod tests {
             .unwrap();
         assert_eq!(locked.pages()[0][0].load(Ordering::SeqCst), 0);
         drop(locked);
+    }
+    #[test]
+    fn test_aliased_guest_memory() {
+        DefaultPool::run_with(|_| async {
+            let page = SparseMapping::page_size() as u64;
+            let range = MemoryRange::new(0..4 * page);
+            let (mgr, _gm) = build_and_get_memory(&[&[range]]).await;
+            let alias_bit = 8 * page;
+            let gm = mgr
+                .client()
+                .aliased_guest_memory("aliased", alias_bit)
+                .await
+                .unwrap();
+
+            let pattern = vec![0x5A; page as usize];
+            gm.write_at(alias_bit + page, &pattern).unwrap();
+
+            let mut buf = vec![0u8; page as usize];
+            gm.read_at(page, &mut buf).unwrap();
+            assert_eq!(buf, pattern);
+
+            assert!(gm.read_at(alias_bit + range.end(), &mut buf).is_err());
+        });
     }
 }

--- a/openvmm/openvmm_core/src/worker/dispatch.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch.rs
@@ -69,6 +69,7 @@ use openvmm_defs::config::DeviceVtl;
 use openvmm_defs::config::GicConfig;
 use openvmm_defs::config::HypervisorConfig;
 use openvmm_defs::config::LoadMode;
+use openvmm_defs::config::MemoryConfig;
 use openvmm_defs::config::NumaTopology;
 use openvmm_defs::config::PcieDeviceConfig;
 use openvmm_defs::config::PcieIommuConfig;
@@ -975,6 +976,72 @@ struct GenericInitiatorSource {
     vnode: u32,
 }
 
+fn validate_cca_memory_config(vnode: usize, memory: &MemoryConfig) -> anyhow::Result<()> {
+    if memory.hugepages {
+        anyhow::bail!("node {vnode}: KVM CCA guest_memfd does not support hugetlb memory");
+    }
+    if memory.private_memory {
+        anyhow::bail!("node {vnode}: KVM CCA guest_memfd requires shared userspace memory backing");
+    }
+    Ok(())
+}
+
+fn validate_cca_pcie_resource(resource_id: &str) -> anyhow::Result<()> {
+    if resource_id != "virtio" {
+        anyhow::bail!(
+            "KVM CCA guest_memfd only supports in-process virtio devices on PCIe root ports"
+        );
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod cca_validation_tests {
+    use super::validate_cca_memory_config;
+    use super::validate_cca_pcie_resource;
+    use openvmm_defs::config::MemoryConfig;
+    use test_with_tracing::test;
+
+    fn memory_config() -> MemoryConfig {
+        MemoryConfig {
+            mem_size: 1024 * 1024,
+            prefetch_memory: false,
+            private_memory: false,
+            transparent_hugepages: false,
+            hugepages: false,
+            hugepage_size: None,
+            host_numa_node: None,
+        }
+    }
+
+    #[test]
+    fn cca_memory_rejects_hugetlb_and_private_backing() {
+        let mut memory = memory_config();
+        memory.hugepages = true;
+        assert!(
+            validate_cca_memory_config(0, &memory)
+                .unwrap_err()
+                .to_string()
+                .contains("hugetlb")
+        );
+
+        memory.hugepages = false;
+        memory.private_memory = true;
+        assert!(
+            validate_cca_memory_config(0, &memory)
+                .unwrap_err()
+                .to_string()
+                .contains("shared userspace memory")
+        );
+    }
+
+    #[test]
+    fn cca_pcie_rejects_non_virtio_resources() {
+        validate_cca_pcie_resource("virtio").unwrap();
+        assert!(validate_cca_pcie_resource("vfio").is_err());
+    }
+}
+
 impl InitializedVm {
     /// Creates and initializes a VM using the given backend.
     async fn new(
@@ -1265,6 +1332,104 @@ impl InitializedVm {
                 )
             ) {
                 anyhow::bail!("KVM SNP guest_memfd does not support VMGS disks");
+            }
+        }
+
+        if cfg.hypervisor.with_isolation == Some(openvmm_defs::config::IsolationType::Cca) {
+            if shared_memory.is_some() {
+                anyhow::bail!("KVM CCA guest_memfd does not support restart memory backing");
+            }
+            if !matches!(
+                cfg.load_mode,
+                LoadMode::Linux {
+                    boot_mode: openvmm_defs::config::LinuxDirectBootMode::DeviceTree,
+                    ..
+                }
+            ) {
+                anyhow::bail!(
+                    "KVM CCA guest_memfd currently only supports device tree Linux direct boot"
+                );
+            }
+            if cfg.hypervisor.with_hv {
+                anyhow::bail!("KVM CCA guest_memfd does not support Hyper-V enlightenments");
+            }
+            if cfg.hypervisor.with_vtl2.is_some() {
+                anyhow::bail!("KVM CCA guest_memfd does not support VTL2");
+            }
+            if cfg.chipset.with_hyperv_vga {
+                anyhow::bail!("KVM CCA guest_memfd does not support Hyper-V VGA");
+            }
+            if cfg.chipset_capabilities.with_i440bx_host_pci_bridge {
+                anyhow::bail!("KVM CCA guest_memfd does not support the i440BX host PCI bridge");
+            }
+            let only_supported_chipset_devices = cfg
+                .chipset_devices
+                .iter()
+                .all(|device| matches!(device.resource.id(), "serial_pl011" | "missing-dev"));
+            if !only_supported_chipset_devices {
+                anyhow::bail!("KVM CCA guest_memfd only supports PL011 serial chipset devices");
+            }
+            if cfg.vmbus.is_some() || cfg.vtl2_vmbus.is_some() || !cfg.vmbus_devices.is_empty() {
+                anyhow::bail!("KVM CCA guest_memfd does not support VMBus");
+            }
+            if !cfg.virtio_devices.is_empty() {
+                anyhow::bail!(
+                    "KVM CCA guest_memfd only supports virtio devices on PCIe root ports"
+                );
+            }
+            if !cfg.pcie_switches.is_empty() {
+                anyhow::bail!("KVM CCA guest_memfd does not support PCIe switches");
+            }
+            if !cfg.pcie_generic_initiators.is_empty() {
+                anyhow::bail!("KVM CCA guest_memfd does not support PCIe generic initiators");
+            }
+            if !cfg.vpci_devices.is_empty() {
+                anyhow::bail!("KVM CCA guest_memfd does not support VPCI devices");
+            }
+            if !cfg.pci_chipset_devices.is_empty() || cfg.isa_dma_controller.is_some() {
+                anyhow::bail!("KVM CCA guest_memfd does not support legacy PCI or ISA DMA devices");
+            }
+            if cfg.framebuffer.is_some() || cfg.vga_firmware.is_some() || cfg.debugger_rpc.is_some()
+            {
+                anyhow::bail!("KVM CCA guest_memfd does not support this VM configuration");
+            }
+            let unsupported_pcie_root_complex =
+                cfg.pcie_root_complexes.iter().any(|root_complex| {
+                    root_complex.cxl.is_some()
+                        || root_complex.iommu.is_some()
+                        || root_complex
+                            .ports
+                            .iter()
+                            .any(|port| port.hotplug || port.cxl)
+                });
+            if unsupported_pcie_root_complex {
+                anyhow::bail!(
+                    "KVM CCA guest_memfd does not support PCIe hotplug, CXL, or IOMMU root ports"
+                );
+            }
+            for device in &cfg.pcie_devices {
+                validate_cca_pcie_resource(device.resource.id())?;
+            }
+            for (vnode, node) in cfg.numa.nodes.iter().enumerate() {
+                if let Some(memory) = &node.mem {
+                    validate_cca_memory_config(vnode, memory)?;
+                }
+            }
+            if !cfg.floppy_disks.is_empty()
+                || !cfg.ide_disks.is_empty()
+                || !cfg.virtio_devices.is_empty()
+            {
+                anyhow::bail!("KVM CCA guest_memfd does not support disks");
+            }
+            if matches!(
+                cfg.vmgs,
+                Some(
+                    VmgsResource::Disk(_)
+                        | VmgsResource::ReprovisionOnFailure(_)
+                        | VmgsResource::Reprovision(_)
+                )
+            ) {
+                anyhow::bail!("KVM CCA guest_memfd does not support VMGS disks");
             }
         }
 
@@ -3836,6 +4001,13 @@ impl LoadedVm {
                     }
                     VmRpc::AddPcieDevice(rpc) => {
                         rpc.handle_failable(async |(port_name, resource)| {
+                            if self.inner.hypervisor_cfg.with_isolation
+                                == Some(openvmm_defs::config::IsolationType::Cca)
+                            {
+                                anyhow::bail!(
+                                    "KVM CCA guest_memfd does not support runtime PCI device addition"
+                                );
+                            }
                             // Find the root complex and its index for the named port.
                             let (rc_idx, rc) = self.inner.pcie_root_complexes.iter()
                                 .enumerate()

--- a/openvmm/openvmm_core/src/worker/dispatch.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch.rs
@@ -445,6 +445,9 @@ pub(crate) struct InitializedVm {
     vmtime_source: VmTimeSource,
     memory_manager: GuestMemoryManager,
     gm: GuestMemory,
+    device_gm: GuestMemory,
+    #[cfg(guest_arch = "aarch64")]
+    shared_gpa_bit: Option<u64>,
     cfg: Manifest,
     mem_layout: MemoryLayout,
     resolved_pcie_root_complex_ranges: Vec<ResolvedPcieRootComplexRanges>,
@@ -771,6 +774,9 @@ struct LoadedVmInner {
     _vmtime: SpawnedUnit<VmTimeKeeper>,
     memory_manager: GuestMemoryManager,
     gm: GuestMemory,
+    _device_gm: GuestMemory,
+    #[cfg(guest_arch = "aarch64")]
+    shared_gpa_bit: Option<u64>,
     vtl0_hvsock_relay: Option<HvsockRelay>,
     vtl2_hvsock_relay: Option<HvsockRelay>,
     vmbus_server: Option<VmbusServerHandle>,
@@ -1371,6 +1377,45 @@ impl InitializedVm {
             .guest_memory()
             .await
             .context("failed to get guest memory")?;
+        #[cfg(guest_arch = "aarch64")]
+        let shared_gpa_bit =
+            if cfg.hypervisor.with_isolation == Some(openvmm_defs::config::IsolationType::Cca) {
+                let shared_bit = platform_info
+                    .shared_gpa_bit
+                    .context("missing CCA shared GPA bit")?;
+                anyhow::ensure!(
+                    shared_bit.is_power_of_two(),
+                    "CCA shared GPA bit must be a power of two"
+                );
+                anyhow::ensure!(
+                    max_addr <= shared_bit,
+                    "guest memory layout overlaps CCA shared GPA alias region"
+                );
+                Some(shared_bit)
+            } else {
+                None
+            };
+        let device_gm = {
+            #[cfg(guest_arch = "aarch64")]
+            {
+                if let Some(shared_bit) = shared_gpa_bit {
+                    // TODO: Confirm Arm CCA pSMMU semantics for whether devices
+                    // should accept low IPAs, high/shared IPAs, or both, then
+                    // update this aliasing behavior to match.
+                    memory_manager
+                        .client()
+                        .aliased_guest_memory("shared-ram", shared_bit)
+                        .await
+                        .context("failed to get CCA device guest memory")?
+                } else {
+                    gm.clone()
+                }
+            }
+            #[cfg(not(guest_arch = "aarch64"))]
+            {
+                gm.clone()
+            }
+        };
         let mut cpuid = Vec::new();
 
         // Add in Hyper-V VMM CPUID leaves.
@@ -1422,6 +1467,9 @@ impl InitializedVm {
             vmtime_source,
             memory_manager,
             gm,
+            device_gm,
+            #[cfg(guest_arch = "aarch64")]
+            shared_gpa_bit,
             cfg,
             mem_layout,
             resolved_pcie_root_complex_ranges,
@@ -1453,6 +1501,9 @@ impl InitializedVm {
             vmtime_source,
             memory_manager,
             gm,
+            device_gm,
+            #[cfg(guest_arch = "aarch64")]
+            shared_gpa_bit,
             cfg,
             mem_layout,
             resolved_pcie_root_complex_ranges,
@@ -2553,7 +2604,7 @@ impl InitializedVm {
             let chipset_builder = &chipset_builder;
             let driver_source = &driver_source;
             let resolver = &resolver;
-            let gm = &gm;
+            let gm = &device_gm;
             let partition = &partition;
             let mapper = &mapper;
             let port_info = &port_info;
@@ -2667,16 +2718,17 @@ impl InitializedVm {
                 .vmbus_max_version
                 .map(vmbus_core::MaxVersionInfo::new);
             let vmbus_driver = driver_source.simple();
-            let vmbus = VmbusServer::builder(vmbus_driver.clone(), synic.clone(), gm.clone())
-                .hvsock_notify(Some(hvsock_channel.server_half))
-                .external_server(vtl2_request_send)
-                .use_message_redirect(vmbus_cfg.vtl2_redirect)
-                .max_version(vmbus_max_version)
-                .max_restore_version(vmbus_max_version)
-                .delay_max_version(matches!(cfg.load_mode, LoadMode::Uefi { .. }))
-                .enable_mnf(true)
-                .build()
-                .context("failed to create vmbus server")?;
+            let vmbus =
+                VmbusServer::builder(vmbus_driver.clone(), synic.clone(), device_gm.clone())
+                    .hvsock_notify(Some(hvsock_channel.server_half))
+                    .external_server(vtl2_request_send)
+                    .use_message_redirect(vmbus_cfg.vtl2_redirect)
+                    .max_version(vmbus_max_version)
+                    .max_restore_version(vmbus_max_version)
+                    .delay_max_version(matches!(cfg.load_mode, LoadMode::Uefi { .. }))
+                    .enable_mnf(true)
+                    .build()
+                    .context("failed to create vmbus server")?;
 
             // Start the vmbus kernel proxy if it's in use.
             #[cfg(windows)]
@@ -2691,7 +2743,7 @@ impl InitializedVm {
                         .vtl2_server(vtl2_vmbus.as_ref().map(|server| {
                             vmbus_server::ProxyServerInfo::new(server.control().clone())
                         }))
-                        .memory(Some(&gm))
+                        .memory(Some(&device_gm))
                         .build()
                         .await
                         .context("failed to start the vmbus proxy")?,
@@ -2792,7 +2844,7 @@ impl InitializedVm {
                                 .transpose()
                                 .context("vpci device vnode exceeds 65535")?,
                         },
-                        gm.clone(),
+                        device_gm.clone(),
                         |device_id| {
                             let hv_device = partition.new_virtual_device(
                                 match dev_cfg.vtl {
@@ -2923,7 +2975,7 @@ impl InitializedVm {
                     let mmio_start = virtio_mmio_region.start() + virtio_mmio_index as u64 * 0x1000;
                     virtio_mmio_index += 1;
                     let id = format!("{id}-{mmio_start}");
-                    let gm = gm.clone();
+                    let gm = device_gm.clone();
                     chipset_builder.arc_mutex_device(id).try_add(|services| {
                         VirtioMmioDevice::new(
                             device.0,
@@ -2957,7 +3009,7 @@ impl InitializedVm {
                             VirtioPciDevice::new(
                                 device.0,
                                 &driver_source.simple(),
-                                gm.clone(),
+                                device_gm.clone(),
                                 PciInterruptModel::IntX(
                                     PciInterruptPin::IntA,
                                     services.new_line(IRQ_LINE_SET, "interrupt", pci_inta_line),
@@ -3048,6 +3100,9 @@ impl InitializedVm {
                 _vmtime: vmtime,
                 memory_manager,
                 gm,
+                _device_gm: device_gm,
+                #[cfg(guest_arch = "aarch64")]
+                shared_gpa_bit,
                 vtl0_hvsock_relay,
                 vtl2_hvsock_relay,
                 vmbus_server,
@@ -3238,6 +3293,7 @@ impl LoadedVmInner {
                     cmdline,
                     mem_layout: &self.mem_layout,
                     isolation: self.hypervisor_cfg.with_isolation,
+                    shared_gpa_bit: None,
                     snp_c_bit: self.partition.caps().snp_c_bit,
                 };
                 super::vm_loaders::linux::load_linux_x86(
@@ -3277,14 +3333,31 @@ impl LoadedVmInner {
             } => {
                 use openvmm_defs::config::LinuxDirectBootMode;
 
+                let shared_gpa_bit = if self.hypervisor_cfg.with_isolation
+                    == Some(openvmm_defs::config::IsolationType::Cca)
+                {
+                    Some(self.shared_gpa_bit.context("missing CCA shared GPA bit")?)
+                } else {
+                    None
+                };
                 let kernel_config = super::vm_loaders::linux::KernelConfig {
                     kernel,
                     initrd,
                     cmdline,
                     mem_layout: &self.mem_layout,
                     isolation: self.hypervisor_cfg.with_isolation,
+                    shared_gpa_bit,
                     snp_c_bit: None,
                 };
+
+                if self.hypervisor_cfg.with_isolation
+                    == Some(openvmm_defs::config::IsolationType::Cca)
+                    && boot_mode == LinuxDirectBootMode::Acpi
+                {
+                    anyhow::bail!(
+                        "CCA isolation currently only supports device tree Linux direct boot"
+                    );
+                }
 
                 let build_acpi = if boot_mode == LinuxDirectBootMode::Acpi {
                     Some(|rsdp_gpa: u64| {

--- a/openvmm/openvmm_core/src/worker/vm_loaders/linux.rs
+++ b/openvmm/openvmm_core/src/worker/vm_loaders/linux.rs
@@ -225,6 +225,11 @@ fn build_dt(
 
     let num_cpus = processor_topology.vps().len();
     let shared_gpa_bit = cfg.shared_gpa_bit;
+    // TODO: Linux arm64_rsi_is_protected() queries RIPAS for addresses that
+    // already contain the Realm shared IPA bit, causing RSI_ERROR_INPUT and a
+    // WARN_ON during device probing. Keep the shared address because earlycon
+    // maps the DT address directly. Revisit once Linux handles shared IPAs
+    // without issuing an RSI_IPA_STATE_GET request.
     let shared_addr = |addr| shared_gpa_bit.map_or(addr, |bit| addr | bit);
 
     use vm_topology::processor::aarch64::GicMsiController;

--- a/openvmm/openvmm_core/src/worker/vm_loaders/linux.rs
+++ b/openvmm/openvmm_core/src/worker/vm_loaders/linux.rs
@@ -55,6 +55,7 @@ pub struct KernelConfig<'a> {
     pub cmdline: &'a str,
     pub mem_layout: &'a MemoryLayout,
     pub isolation: Option<IsolationType>,
+    pub shared_gpa_bit: Option<u64>,
     pub snp_c_bit: Option<u8>,
 }
 
@@ -223,6 +224,8 @@ fn build_dt(
     const SMMU_SIZE: u64 = 0x2_0000;
 
     let num_cpus = processor_topology.vps().len();
+    let shared_gpa_bit = cfg.shared_gpa_bit;
+    let shared_addr = |addr| shared_gpa_bit.map_or(addr, |bit| addr | bit);
 
     use vm_topology::processor::aarch64::GicMsiController;
     use vm_topology::processor::aarch64::GicVersion;
@@ -355,7 +358,14 @@ fn build_dt(
     let psci = root_builder
         .start_node("psci")?
         .add_str(p_compatible, "arm,psci-0.2")?
-        .add_str(p_method, "hvc")?;
+        .add_str(
+            p_method,
+            if cfg.isolation == Some(IsolationType::Cca) {
+                "smc"
+            } else {
+                "hvc"
+            },
+        )?;
     root_builder = psci.end_node()?;
 
     // Add a memory node for each RAM range.
@@ -497,7 +507,8 @@ fn build_dt(
     const PCI_SPACE_MEM64: u32 = 0x03000000; // 64-bit prefetchable MMIO
 
     for bridge in pcie_host_bridges {
-        let name = format!("pcie@{:x}", bridge.ecam_range.start());
+        let ecam_start = shared_addr(bridge.ecam_range.start());
+        let name = format!("pcie@{:x}", ecam_start);
 
         // The `ranges` property encodes translations from PCI MMIO address
         // space to CPU physical address space.  Each entry is 7 cells:
@@ -507,28 +518,30 @@ fn build_dt(
         let mut ranges: Vec<u32> = Vec::new();
 
         let low_start = bridge.low_mmio.start();
+        let low_cpu_start = shared_addr(low_start);
         let low_len = bridge.low_mmio.len();
         if low_len > 0 {
             ranges.extend_from_slice(&[
                 PCI_SPACE_MEM32,
                 0,
                 low_start as u32,
-                (low_start >> 32) as u32,
-                (low_start & 0xFFFF_FFFF) as u32,
+                (low_cpu_start >> 32) as u32,
+                (low_cpu_start & 0xFFFF_FFFF) as u32,
                 (low_len >> 32) as u32,
                 (low_len & 0xFFFF_FFFF) as u32,
             ]);
         }
 
         let high_start = bridge.high_mmio.start();
+        let high_cpu_start = shared_addr(high_start);
         let high_len = bridge.high_mmio.len();
         if high_len > 0 {
             ranges.extend_from_slice(&[
                 PCI_SPACE_MEM64,
                 (high_start >> 32) as u32,
                 (high_start & 0xFFFF_FFFF) as u32,
-                (high_start >> 32) as u32,
-                (high_start & 0xFFFF_FFFF) as u32,
+                (high_cpu_start >> 32) as u32,
+                (high_cpu_start & 0xFFFF_FFFF) as u32,
                 (high_len >> 32) as u32,
                 (high_len & 0xFFFF_FFFF) as u32,
             ]);
@@ -541,7 +554,7 @@ fn build_dt(
             .add_str(p_compatible, "pci-host-ecam-generic")?
             .add_str(p_device_type, "pci")?
             .add_u32(p_linux_pci_domain, bridge.segment as u32)?
-            .add_u64_array(p_reg, &[bridge.ecam_range.start(), bridge.ecam_range.len()])?
+            .add_u64_array(p_reg, &[ecam_start, bridge.ecam_range.len()])?
             .add_u32_array(
                 p_bus_range,
                 &[bridge.start_bus as u32, bridge.end_bus as u32],
@@ -591,14 +604,15 @@ fn build_dt(
             (PL011_SERIAL0_BASE, PL011_SERIAL0_IRQ),
             (PL011_SERIAL1_BASE, PL011_SERIAL1_IRQ),
         ] {
-            let name = format!("uart@{:x}", serial_base);
+            let guest_serial_base = shared_addr(serial_base);
+            let name = format!("uart@{:x}", guest_serial_base);
             soc = soc
                 .start_node(name.as_ref())?
                 .add_str_array(p_compatible, &["arm,sbsa-uart", "arm,primecell"])?
                 .add_str_array(p_clock_names, &["apb_pclk"])?
                 .add_u32(p_clocks, PHANDLE_APB_PCLK)?
                 .add_u32(p_interrupt_parent, PHANDLE_GIC)?
-                .add_u64_array(p_reg, &[serial_base, 0x1000])?
+                .add_u64_array(p_reg, &[guest_serial_base, 0x1000])?
                 .add_u32(p_current_speed, PL011_BAUD)?
                 .add_u32(p_arm_periph_id, PL011_PERIPH_ID)?
                 .add_u32_array(
@@ -619,9 +633,9 @@ fn build_dt(
         .add_u64_array(
             p_ranges,
             &[
-                chipset_low_mmio.start(),
+                shared_addr(chipset_low_mmio.start()),
                 chipset_low_mmio.len(),
-                chipset_high_mmio.start(),
+                shared_addr(chipset_high_mmio.start()),
                 chipset_high_mmio.len(),
             ],
         )?
@@ -645,7 +659,7 @@ fn build_dt(
     if enable_serial {
         chosen = chosen.add_str(
             p_stdout_path,
-            format!("/hvlite/uart@{PL011_SERIAL0_BASE:x}").as_str(),
+            format!("/openvmm/uart@{:x}", shared_addr(PL011_SERIAL0_BASE)).as_str(),
         )?;
     }
 

--- a/openvmm/openvmm_entry/src/cli_args.rs
+++ b/openvmm/openvmm_entry/src/cli_args.rs
@@ -1397,6 +1397,29 @@ impl Options {
                 anyhow::bail!("SNP isolation currently does not support hugetlb memory");
             }
         }
+        #[cfg(guest_arch = "aarch64")]
+        if matches!(self.isolation, Some(IsolationCli::Cca)) {
+            if self.memory.hugepages
+                || self
+                    .numa
+                    .as_ref()
+                    .is_some_and(|nodes| nodes.iter().any(|node| node.memory.hugepages))
+            {
+                anyhow::bail!("CCA isolation currently does not support hugetlb memory");
+            }
+            if self.private_memory()
+                || self
+                    .numa
+                    .as_ref()
+                    .is_some_and(|nodes| nodes.iter().any(|node| node.memory.shared == Some(false)))
+            {
+                anyhow::bail!("CCA isolation requires shared userspace memory backing");
+            }
+            #[cfg(target_os = "linux")]
+            if !self.vhost_user.is_empty() {
+                anyhow::bail!("CCA isolation currently does not support vhost-user devices");
+            }
+        }
         Ok(())
     }
 }
@@ -2797,6 +2820,8 @@ pub enum GicMsiCli {
 pub enum IsolationCli {
     Vbs,
     Snp,
+    #[cfg(guest_arch = "aarch64")]
+    Cca,
 }
 
 #[derive(Debug, Copy, Clone, PartialEq)]
@@ -4986,6 +5011,69 @@ mod tests {
         .unwrap();
 
         opt.validate_isolation_options().unwrap();
+    }
+
+    #[cfg(guest_arch = "aarch64")]
+    #[test]
+    fn test_isolation_options_reject_cca_hugepages() {
+        for args in [
+            vec![
+                "openvmm",
+                "--isolation",
+                "cca",
+                "--memory",
+                "size=1G,hugepages=on",
+            ],
+            vec![
+                "openvmm",
+                "--isolation",
+                "cca",
+                "--numa",
+                "size=1G,hugepages=on",
+            ],
+        ] {
+            let opt = Options::try_parse_from(args).unwrap();
+            assert_eq!(
+                opt.validate_isolation_options().unwrap_err().to_string(),
+                "CCA isolation currently does not support hugetlb memory"
+            );
+        }
+    }
+
+    #[cfg(guest_arch = "aarch64")]
+    #[test]
+    fn test_isolation_options_reject_cca_private_memory() {
+        let opt = Options::try_parse_from([
+            "openvmm",
+            "--isolation",
+            "cca",
+            "--memory",
+            "size=1G,shared=off",
+        ])
+        .unwrap();
+
+        assert_eq!(
+            opt.validate_isolation_options().unwrap_err().to_string(),
+            "CCA isolation requires shared userspace memory backing"
+        );
+    }
+
+    #[cfg(all(guest_arch = "aarch64", target_os = "linux"))]
+    #[test]
+    fn test_isolation_options_reject_cca_vhost_user() {
+        let opt = Options::try_parse_from([
+            "openvmm",
+            "--isolation",
+            "cca",
+            "--vhost-user",
+            "/tmp/vhost.sock,type=blk,pcie_port=port0",
+        ])
+        .unwrap();
+
+        assert_eq!(
+            opt.validate_isolation_options().unwrap_err().to_string(),
+            "CCA isolation currently does not support vhost-user devices"
+        );
     }
 
     #[test]

--- a/openvmm/openvmm_entry/src/lib.rs
+++ b/openvmm/openvmm_entry/src/lib.rs
@@ -1635,6 +1635,8 @@ async fn vm_config_from_command_line(
                 Some(openvmm_defs::config::IsolationType::Vbs)
             }
             cli_args::IsolationCli::Snp => Some(openvmm_defs::config::IsolationType::Snp),
+            #[cfg(guest_arch = "aarch64")]
+            cli_args::IsolationCli::Cca => Some(openvmm_defs::config::IsolationType::Cca),
         }
     } else {
         None
@@ -2041,6 +2043,7 @@ async fn vm_config_from_command_line(
     storage.build_config(&mut cfg, &mut resources, opt.scsi_sub_channels)?;
     resources.serial_driver = Some(serial_driver);
     validate_snp_config(&cfg)?;
+    validate_cca_config(&cfg)?;
     Ok((cfg, resources))
 }
 
@@ -2092,6 +2095,86 @@ fn validate_snp_config(cfg: &Config) -> anyhow::Result<()> {
     }
 
     Ok(())
+}
+
+fn validate_cca_config(cfg: &Config) -> anyhow::Result<()> {
+    if cfg.hypervisor.with_isolation != Some(openvmm_defs::config::IsolationType::Cca) {
+        return Ok(());
+    }
+
+    #[cfg(not(guest_arch = "aarch64"))]
+    {
+        anyhow::bail!("CCA isolation currently only supports aarch64 guests");
+    }
+
+    #[cfg(guest_arch = "aarch64")]
+    {
+        if !matches!(cfg.load_mode, LoadMode::Linux { .. }) {
+            anyhow::bail!("CCA isolation currently only supports Linux direct boot");
+        }
+        if cfg.hypervisor.with_hv {
+            anyhow::bail!("CCA isolation currently does not support Hyper-V enlightenments");
+        }
+        if cfg.hypervisor.with_vtl2.is_some() {
+            anyhow::bail!("CCA isolation currently does not support VTL2");
+        }
+        if cfg.vmbus.is_some() || cfg.vtl2_vmbus.is_some() || !cfg.vmbus_devices.is_empty() {
+            anyhow::bail!("CCA isolation currently does not support VMBus devices");
+        }
+        if !matches!(
+            cfg.load_mode,
+            LoadMode::Linux {
+                boot_mode: openvmm_defs::config::LinuxDirectBootMode::DeviceTree,
+                ..
+            }
+        ) {
+            anyhow::bail!("CCA isolation currently only supports device tree Linux direct boot");
+        }
+        if !cfg.virtio_devices.is_empty() {
+            anyhow::bail!(
+                "CCA isolation currently only supports virtio devices on PCIe root ports"
+            );
+        }
+        if !cfg.pcie_switches.is_empty() {
+            anyhow::bail!("CCA isolation currently does not support PCIe switches");
+        }
+        let unsupported_pcie_root_complex = cfg.pcie_root_complexes.iter().any(|root_complex| {
+            root_complex.cxl.is_some()
+                || root_complex
+                    .ports
+                    .iter()
+                    .any(|port| port.hotplug || port.cxl)
+        });
+        if unsupported_pcie_root_complex {
+            anyhow::bail!(
+                "CCA isolation currently does not support PCIe hotplug or CXL root ports"
+            );
+        }
+
+        let only_supported_chipset_devices = cfg
+            .chipset_devices
+            .iter()
+            .all(|device| matches!(device.resource.id(), "serial_pl011" | "missing-dev"));
+        let only_virtio_pcie_devices = cfg
+            .pcie_devices
+            .iter()
+            .all(|device| device.resource.id() == "virtio");
+        if !cfg.floppy_disks.is_empty()
+            || !cfg.ide_disks.is_empty()
+            || !cfg.virtio_devices.is_empty()
+            || !only_virtio_pcie_devices
+            || !cfg.vpci_devices.is_empty()
+            || !only_supported_chipset_devices
+            || !cfg.pci_chipset_devices.is_empty()
+        {
+            anyhow::bail!("CCA isolation currently only supports virtio devices");
+        }
+        if cfg.framebuffer.is_some() || cfg.vga_firmware.is_some() || cfg.debugger_rpc.is_some() {
+            anyhow::bail!("CCA isolation currently does not support this VM configuration");
+        }
+
+        Ok(())
+    }
 }
 
 /// Gets the terminal to use for externally launched console windows.

--- a/vm/kvm/src/lib.rs
+++ b/vm/kvm/src/lib.rs
@@ -176,7 +176,10 @@ const KVM_X86_SNP_VM_UAPI: libc::c_int = 4;
 pub const KVM_MEMORY_EXIT_FLAG_PRIVATE_UAPI: u64 = 1 << 3;
 
 #[cfg(target_arch = "aarch64")]
-pub const KVM_CAP_ARM_RMI_UAPI: u32 = 249;
+pub const KVM_CAP_ARM_RMI_V14_UAPI: u32 = 249;
+pub const KVM_CAP_GUEST_MEMFD_MEMORY_ATTRIBUTES_UAPI: u32 = 250;
+#[cfg(target_arch = "aarch64")]
+pub const KVM_CAP_ARM_RMI_UAPI: u32 = 251;
 #[cfg(target_arch = "aarch64")]
 pub const KVM_ARM_RMI_POPULATE_FLAGS_MEASURE_UAPI: u32 = 1 << 0;
 #[cfg(target_arch = "aarch64")]
@@ -481,6 +484,20 @@ impl Kvm {
     pub fn new_vm(&self, vm_type: VmType) -> Result<Partition> {
         let raw_vm_type = self.raw_vm_type(vm_type)?;
         self.new_vm_with_type(raw_vm_type)
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    pub fn new_realm_vm_with_max_ipa_size(&self, max_ipa_bits: u8) -> Result<(Partition, u8)> {
+        for ipa_bits in (32..=max_ipa_bits).rev() {
+            match self.new_vm(VmType::Realm { ipa_bits }) {
+                Ok(vm) => return Ok((vm, ipa_bits)),
+                Err(Error::CreateVm(nix::errno::Errno::EINVAL)) => {}
+                Err(err) => return Err(err),
+            }
+        }
+        Err(Error::UnsupportedVmType(VmType::Realm {
+            ipa_bits: max_ipa_bits,
+        }))
     }
 
     fn raw_vm_type(&self, vm_type: VmType) -> Result<libc::c_int> {

--- a/vmm_core/virt/src/generic.rs
+++ b/vmm_core/virt/src/generic.rs
@@ -66,6 +66,8 @@ pub struct PlatformInfo {
     /// How the physical SMMU implementation selects the IOVA range reserved
     /// for device-assignment MSI writes.
     pub device_assignment_msi_iova: DeviceAssignmentMsiIova,
+    /// The CCA shared IPA bit, if available.
+    pub shared_gpa_bit: Option<u64>,
 }
 
 /// Selection policy for the device-assignment MSI IOVA reservation.

--- a/vmm_core/virt_hvf/src/lib.rs
+++ b/vmm_core/virt_hvf/src/lib.rs
@@ -108,6 +108,7 @@ impl virt::Hypervisor for HvfHypervisor {
             supports_gic_v3: true,
             supports_its: false,
             device_assignment_msi_iova: virt::DeviceAssignmentMsiIova::Unsupported,
+            shared_gpa_bit: None,
         }
     }
 

--- a/vmm_core/virt_kvm/src/arch/aarch64/mod.rs
+++ b/vmm_core/virt_kvm/src/arch/aarch64/mod.rs
@@ -523,6 +523,11 @@ impl virt::Processor for KvmProcessor<'_> {
                 } else {
                     // Run the VP.
                     if self.partition.caps.isolation == virt::IsolationType::Cca {
+                        if self.partition.cca_fatal.load(Ordering::Acquire) {
+                            return Err(
+                                dev.fatal_error(KvmRunVpError::CcaMemoryCleanupFailed.into())
+                            );
+                        }
                         match *self.partition.cca_launch_state.lock() {
                             crate::CcaLaunchState::Populated => {}
                             crate::CcaLaunchState::Failed => {
@@ -934,6 +939,7 @@ impl virt::ProtoPartition for KvmProtoPartition<'_> {
             kvm: self.vm,
             memory: Default::default(),
             cca_launch_state: Mutex::new(crate::CcaLaunchState::NotStarted),
+            cca_fatal: false.into(),
             shared_gpa_bit: (self.config.isolation == virt::IsolationType::Cca)
                 .then_some(1_u64 << (self.ipa_size - 1)),
             memory_backing_mode,

--- a/vmm_core/virt_kvm/src/arch/aarch64/mod.rs
+++ b/vmm_core/virt_kvm/src/arch/aarch64/mod.rs
@@ -27,6 +27,7 @@ use core::panic;
 use hvdef::Vtl;
 use inspect::Inspect;
 use inspect::InspectMut;
+use kvm::KVM_CAP_ARM_RMI_UAPI;
 use kvm::KVM_CAP_ARM_VM_IPA_SIZE;
 use kvm::KVM_DEV_ARM_VGIC_CTRL_INIT;
 use kvm::KVM_DEV_ARM_VGIC_GRP_ADDR;
@@ -227,6 +228,8 @@ pub struct Kvm {
     kvm: kvm::Kvm,
     supports_gic_v3: bool,
     supports_its: bool,
+    ipa_size: u8,
+    cca_ipa_size: Option<u8>,
 }
 
 impl Kvm {
@@ -240,6 +243,31 @@ impl Kvm {
         // Probe GIC version by creating a throwaway VM and attempting to
         // create a GICv3 device. If that fails, try GICv2.
         let kvm = kvm::Kvm::from(file);
+        let ipa_size = match kvm
+            .check_extension(KVM_CAP_ARM_VM_IPA_SIZE)
+            .map_err(kvm::Error::CheckExtension)?
+        {
+            v if v > 0 => v as u8,
+            _ => 40,
+        };
+        let cca_ipa_size = if kvm
+            .check_extension(KVM_CAP_ARM_RMI_UAPI)
+            .map_err(kvm::Error::CheckExtension)?
+            != 0
+        {
+            match kvm.new_realm_vm_with_max_ipa_size(ipa_size) {
+                Ok((_probe_realm, cca_ipa_size)) => Some(cca_ipa_size),
+                Err(err) => {
+                    tracing::warn!(
+                        error = &err as &dyn std::error::Error,
+                        "failed to probe KVM CCA Realm IPA size"
+                    );
+                    None
+                }
+            }
+        } else {
+            None
+        };
         let probe_vm = kvm.new_vm(kvm::VmType::Default)?;
         let supports_gic_v3 = if probe_vm
             .test_create_device(kvm_device_type_KVM_DEV_TYPE_ARM_VGIC_V3)
@@ -255,7 +283,12 @@ impl Kvm {
             return Err(KvmError::NoGic);
         };
 
-        tracing::info!(supports_gic_v3, "detected KVM GIC version");
+        tracing::info!(
+            supports_gic_v3,
+            host_ipa_size = ipa_size,
+            ?cca_ipa_size,
+            "detected KVM GIC version and IPA sizes"
+        );
 
         // Probe ITS support: only available with GICv3.
         let supports_its = supports_gic_v3
@@ -269,6 +302,8 @@ impl Kvm {
             kvm,
             supports_gic_v3,
             supports_its,
+            ipa_size,
+            cca_ipa_size,
         })
     }
 }
@@ -481,10 +516,42 @@ impl virt::Processor for KvmProcessor<'_> {
                     self.runner.complete_exit()
                 } else {
                     // Run the VP.
+                    if self.partition.caps.isolation == virt::IsolationType::Cca {
+                        match *self.partition.cca_launch_state.lock() {
+                            crate::CcaLaunchState::Populated => {}
+                            crate::CcaLaunchState::Failed => {
+                                return Err(
+                                    dev.fatal_error(KvmRunVpError::CcaPopulationFailed.into())
+                                );
+                            }
+                            crate::CcaLaunchState::NotStarted
+                            | crate::CcaLaunchState::Populating => {
+                                return Err(dev.fatal_error(KvmRunVpError::CcaNotPopulated.into()));
+                            }
+                        }
+                    }
                     self.runner.run()
                 };
 
-                let exit = exit.map_err(|err| dev.fatal_error(KvmRunVpError::Run(err).into()))?;
+                let exit = match exit {
+                    Ok(exit) => exit,
+                    Err(kvm::Error::RunMemoryFault {
+                        flags, gpa, size, ..
+                    }) if self.partition.caps.isolation == virt::IsolationType::Cca => {
+                        match self.partition.handle_cca_ripas_change(gpa, size, flags) {
+                            Ok(()) => {
+                                pending_exit = false;
+                                continue;
+                            }
+                            Err(err) => {
+                                return Err(dev.fatal_error(err.into()));
+                            }
+                        }
+                    }
+                    Err(err) => {
+                        return Err(dev.fatal_error(KvmRunVpError::from_kvm_run_error(err).into()));
+                    }
+                };
                 pending_exit = true;
                 match exit {
                     kvm::Exit::Interrupted => {
@@ -792,6 +859,9 @@ impl virt::ProtoPartition for KvmProtoPartition<'_> {
             GicVersion::V3 {
                 redistributors_base,
             } => self.add_gicv3(redistributors_base)?,
+            GicVersion::V2 { .. } if self.config.isolation == virt::IsolationType::Cca => {
+                return Err(KvmError::CcaRequiresGicV3);
+            }
             GicVersion::V2 { cpu_interface_base } => self.add_gicv2(cpu_interface_base)?,
         };
 
@@ -822,23 +892,37 @@ impl virt::ProtoPartition for KvmProtoPartition<'_> {
                 pfr0 & 0xf == 2
             };
             PartitionCapabilities {
-                isolation: virt::IsolationType::None,
+                isolation: self.config.isolation,
                 vendor: Vendor::ARM,
                 supports_aarch32_el0,
             }
         };
 
+        let ram_ranges: Vec<_> = config
+            .mem_layout
+            .ram()
+            .iter()
+            .map(|range| range.range)
+            .chain(config.mem_layout.vtl2_range())
+            .collect();
+        let memory_backing_mode = match self.config.isolation {
+            virt::IsolationType::None => KvmMemoryBackingMode::Userspace,
+            virt::IsolationType::Cca => KvmMemoryBackingMode::guest_memfd(
+                &self.vm,
+                ram_ranges.iter().copied(),
+                crate::memory::KvmGuestMemfdPrivateState::GuestMemfdDefault,
+            )?,
+            virt::IsolationType::Vbs | virt::IsolationType::Snp | virt::IsolationType::Tdx => {
+                unreachable!()
+            }
+        };
+
         let partition = Arc::new(KvmPartitionInner {
             kvm: self.vm,
+            cca_launch_state: Mutex::new(crate::CcaLaunchState::NotStarted),
             memory: Default::default(),
-            memory_backing_mode: KvmMemoryBackingMode::Userspace,
-            ram_ranges: config
-                .mem_layout
-                .ram()
-                .iter()
-                .map(|range| range.range)
-                .chain(config.mem_layout.vtl2_range())
-                .collect(),
+            memory_backing_mode,
+            ram_ranges,
             hv1_enabled: self.config.hv_config.is_some(),
             gm: config.guest_memory.clone(),
             vps: self
@@ -889,6 +973,16 @@ impl virt::Partition for KvmPartition {
         &self,
     ) -> Option<&dyn virt::ResetPartition<Error = <Self as virt::Hv1>::Error>> {
         None
+    }
+
+    fn supports_initial_page_acceptance(
+        &self,
+    ) -> Option<&dyn virt::AcceptInitialPages<Error = <Self as virt::Hv1>::Error>> {
+        matches!(
+            self.inner.memory_backing_mode,
+            KvmMemoryBackingMode::GuestMemfd(_)
+        )
+        .then_some(self)
     }
 
     fn caps(&self) -> &PartitionCapabilities {
@@ -1118,6 +1212,15 @@ impl virt::PartitionAccessState for KvmPartition {
     }
 }
 
+fn map_cca_capability_error(err: crate::memory::MemoryError) -> KvmError {
+    match err {
+        crate::memory::MemoryError::Kvm(kvm::Error::MissingCapability(capability)) => {
+            KvmError::MissingCcaCapability(capability)
+        }
+        err => err.into(),
+    }
+}
+
 impl virt::Hypervisor for Kvm {
     type ProtoPartition<'a> = KvmProtoPartition<'a>;
     type Partition = KvmPartition;
@@ -1138,8 +1241,29 @@ impl virt::Hypervisor for Kvm {
         &'a mut self,
         config: ProtoPartitionConfig<'a>,
     ) -> Result<Self::ProtoPartition<'a>, Self::Error> {
-        if config.isolation.is_isolated() {
-            return Err(KvmError::IsolationNotSupported);
+        match config.isolation {
+            virt::IsolationType::None => {}
+            virt::IsolationType::Cca => {
+                if config.hv_config.is_some() {
+                    return Err(KvmError::UnsupportedIsolationConfiguration(
+                        "CCA does not support Hyper-V enlightenments or VTL2",
+                    ));
+                }
+                if !self.supports_gic_v3 {
+                    return Err(KvmError::CcaRequiresGicV3);
+                }
+                if self
+                    .kvm
+                    .check_extension(KVM_CAP_ARM_RMI_UAPI)
+                    .map_err(kvm::Error::CheckExtension)?
+                    == 0
+                {
+                    return Err(KvmError::MissingCcaCapability("KVM_CAP_ARM_RMI"));
+                }
+            }
+            virt::IsolationType::Vbs | virt::IsolationType::Snp | virt::IsolationType::Tdx => {
+                return Err(KvmError::IsolationNotSupported);
+            }
         }
 
         if let Some(hv_config) = &config.hv_config {
@@ -1148,16 +1272,28 @@ impl virt::Hypervisor for Kvm {
             }
         }
 
-        let ipa_size = match self
-            .kvm
-            .check_extension(KVM_CAP_ARM_VM_IPA_SIZE)
-            .map_err(kvm::Error::CheckExtension)?
-        {
-            v if v > 0 => v as u8,
-            _ => 40,
+        let ipa_size = match config.isolation {
+            virt::IsolationType::Cca => self
+                .cca_ipa_size
+                .ok_or(KvmError::MissingCcaCapability("KVM_CAP_ARM_RMI"))?,
+            _ => self.ipa_size,
         };
 
-        let vm = self.kvm.new_vm(kvm::VmType::Default)?;
+        let vm = match config.isolation {
+            virt::IsolationType::None => self.kvm.new_vm(kvm::VmType::Default)?,
+            virt::IsolationType::Cca => {
+                let vm = self.kvm.new_vm(kvm::VmType::Realm { ipa_bits: ipa_size })?;
+                crate::memory::check_private_memory_extensions(
+                    &vm,
+                    crate::memory::KvmGuestMemfdPrivateState::GuestMemfdDefault,
+                )
+                .map_err(map_cca_capability_error)?;
+                vm
+            }
+            virt::IsolationType::Vbs | virt::IsolationType::Snp | virt::IsolationType::Tdx => {
+                unreachable!()
+            }
+        };
 
         Ok(KvmProtoPartition {
             vm,

--- a/vmm_core/virt_kvm/src/arch/aarch64/mod.rs
+++ b/vmm_core/virt_kvm/src/arch/aarch64/mod.rs
@@ -416,10 +416,12 @@ impl virt::vp::AccessVpState for &'_ mut KvmProcessor<'_> {
         set_reg(KvmRegisterId::X28, value.x28)?;
         set_reg(KvmRegisterId::X29, value.fp)?;
         set_reg(KvmRegisterId::X30, value.lr)?;
-        set_reg(KvmRegisterId::SP, value.sp_el0)?;
         set_reg(KvmRegisterId::PC, value.pc)?;
-        set_reg(KvmRegisterId::SP_EL1, value.sp_el1)?;
-        set_reg(KvmRegisterId::PSTATE, value.cpsr)?;
+        if self.partition.caps.isolation != virt::IsolationType::Cca {
+            set_reg(KvmRegisterId::SP, value.sp_el0)?;
+            set_reg(KvmRegisterId::SP_EL1, value.sp_el1)?;
+            set_reg(KvmRegisterId::PSTATE, value.cpsr)?;
+        }
 
         Ok(())
     }
@@ -445,6 +447,10 @@ impl virt::vp::AccessVpState for &'_ mut KvmProcessor<'_> {
     }
 
     fn set_system_registers(&mut self, value: &SystemRegisters) -> Result<(), Self::Error> {
+        if self.partition.caps.isolation == virt::IsolationType::Cca {
+            return Ok(());
+        }
+
         let set_reg = |id: KvmRegisterId, value: u64| -> Result<(), KvmError> {
             // tracing::warn!("set_sreg: {:?}({:#x}) = {:x}", id, id.0, value);
             self.kvm.set_reg64(id.into(), value).map_err(KvmError::Kvm)
@@ -558,16 +564,24 @@ impl virt::Processor for KvmProcessor<'_> {
                         pending_exit = false;
                     }
                     kvm::Exit::MmioWrite { address, data } => {
-                        dev.write_mmio(self.vpindex, address, data).await
+                        dev.write_mmio(self.vpindex, self.partition.mmio_address(address), data)
+                            .await
                     }
                     kvm::Exit::MmioRead { address, data } => {
-                        dev.read_mmio(self.vpindex, address, data).await
+                        dev.read_mmio(self.vpindex, self.partition.mmio_address(address), data)
+                            .await
                     }
                     kvm::Exit::Shutdown => {
                         return Err(VpHaltReason::TripleFault { vtl: Vtl::Vtl0 });
                     }
                     kvm::Exit::InternalError { error, .. } => {
                         return Err(dev.fatal_error(KvmRunVpError::InternalError(error).into()));
+                    }
+                    kvm::Exit::EmulationFailure { instruction_bytes } => {
+                        tracing::error!(?instruction_bytes, "KVM reported an emulation failure");
+                        return Err(dev.fatal_error(
+                            KvmRunVpError::UnhandledExit(format!("{exit:?}")).into(),
+                        ));
                     }
                     kvm::Exit::FailEntry {
                         hardware_entry_failure_reason,
@@ -597,7 +611,6 @@ impl virt::Processor for KvmProcessor<'_> {
                             }
                         }
                     }
-                    _ => panic!("unhandled exit: {:?}", exit),
                 }
             }
         }
@@ -919,8 +932,10 @@ impl virt::ProtoPartition for KvmProtoPartition<'_> {
 
         let partition = Arc::new(KvmPartitionInner {
             kvm: self.vm,
-            cca_launch_state: Mutex::new(crate::CcaLaunchState::NotStarted),
             memory: Default::default(),
+            cca_launch_state: Mutex::new(crate::CcaLaunchState::NotStarted),
+            shared_gpa_bit: (self.config.isolation == virt::IsolationType::Cca)
+                .then_some(1_u64 << (self.ipa_size - 1)),
             memory_backing_mode,
             ram_ranges,
             hv1_enabled: self.config.hv_config.is_some(),
@@ -1077,6 +1092,20 @@ impl virt::irqcon::ControlGic for KvmPartitionInner {
     }
 }
 
+impl KvmPartitionInner {
+    /// Removes the CCA shared-address bit before routing an MMIO access.
+    ///
+    /// Realm guests use the shared bit to select the host-visible alias of a
+    /// device address, while KVM routing entries contain the underlying IPA.
+    fn mmio_address(&self, address: u64) -> u64 {
+        if let Some(shared_bit) = self.shared_gpa_bit {
+            address & (shared_bit - 1)
+        } else {
+            address
+        }
+    }
+}
+
 impl virt::Aarch64Partition for KvmPartition {
     fn control_gic(&self, vtl: Vtl) -> Arc<dyn virt::irqcon::ControlGic> {
         assert!(vtl == Vtl::Vtl0);
@@ -1212,15 +1241,6 @@ impl virt::PartitionAccessState for KvmPartition {
     }
 }
 
-fn map_cca_capability_error(err: crate::memory::MemoryError) -> KvmError {
-    match err {
-        crate::memory::MemoryError::Kvm(kvm::Error::MissingCapability(capability)) => {
-            KvmError::MissingCcaCapability(capability)
-        }
-        err => err.into(),
-    }
-}
-
 impl virt::Hypervisor for Kvm {
     type ProtoPartition<'a> = KvmProtoPartition<'a>;
     type Partition = KvmPartition;
@@ -1234,6 +1254,9 @@ impl virt::Hypervisor for Kvm {
             device_assignment_msi_iova: virt::DeviceAssignmentMsiIova::Fixed(
                 memory_range::MemoryRange::new(0x0800_0000..0x0810_0000),
             ),
+            // TODO: Revisit whether CCA should share an abstraction with SNP's
+            // vtom/shared-GPA-boundary model instead of using a separate field.
+            shared_gpa_bit: self.cca_ipa_size.map(|ipa_size| 1_u64 << (ipa_size - 1)),
         }
     }
 
@@ -1300,5 +1323,14 @@ impl virt::Hypervisor for Kvm {
             config,
             ipa_size,
         })
+    }
+}
+
+fn map_cca_capability_error(err: crate::memory::MemoryError) -> KvmError {
+    match err {
+        crate::memory::MemoryError::Kvm(kvm::Error::MissingCapability(capability)) => {
+            KvmError::MissingCcaCapability(capability)
+        }
+        err => err.into(),
     }
 }

--- a/vmm_core/virt_kvm/src/arch/x86_64/mod.rs
+++ b/vmm_core/virt_kvm/src/arch/x86_64/mod.rs
@@ -517,9 +517,11 @@ impl ProtoPartition for KvmProtoPartition<'_> {
             .collect();
         let memory_backing_mode = match self.config.isolation {
             virt::IsolationType::None => KvmMemoryBackingMode::Userspace,
-            virt::IsolationType::Snp => {
-                KvmMemoryBackingMode::guest_memfd(&self.vm, ram_ranges.iter().copied(), true)?
-            }
+            virt::IsolationType::Snp => KvmMemoryBackingMode::guest_memfd(
+                &self.vm,
+                ram_ranges.iter().copied(),
+                crate::memory::KvmGuestMemfdPrivateState::VmAttributes,
+            )?,
             virt::IsolationType::Vbs | virt::IsolationType::Tdx | virt::IsolationType::Cca => {
                 unreachable!()
             }

--- a/vmm_core/virt_kvm/src/cca.rs
+++ b/vmm_core/virt_kvm/src/cca.rs
@@ -1,0 +1,162 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Arm CCA Realm population support for KVM partitions.
+//!
+//! Loader-provided private pages are copied from their userspace mappings into
+//! Realm memory with `KVM_ARM_RMI_POPULATE`. KVM may report partial progress by
+//! updating the ioctl argument, so population continues until each range is
+//! complete. Runtime RIPAS changes are handled by the memory module.
+
+use crate::KvmError;
+use crate::KvmPartition;
+use crate::KvmPartitionInner;
+use crate::memory::private_memory_range_from_slots;
+use virt::InitialPageImportType;
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+/// Progress of the one-shot Realm initial population sequence.
+pub(crate) enum CcaLaunchState {
+    /// No population request has been issued.
+    NotStarted,
+    /// Population is in progress.
+    Populating,
+    /// Every initial private range was populated successfully.
+    Populated,
+    /// Population failed and cannot be retried on this partition.
+    Failed,
+}
+
+impl virt::AcceptInitialPages for KvmPartition {
+    type Error = KvmError;
+
+    fn accept_initial_pages(&self, pages: &[virt::InitialPageImport]) -> Result<(), Self::Error> {
+        self.inner.cca_populate_initial_pages(pages)
+    }
+}
+
+impl KvmPartitionInner {
+    /// Populates initial Realm pages once and records the terminal state.
+    fn cca_populate_initial_pages(
+        &self,
+        pages: &[virt::InitialPageImport],
+    ) -> Result<(), KvmError> {
+        {
+            let mut state = self.cca_launch_state.lock();
+            match *state {
+                CcaLaunchState::NotStarted => *state = CcaLaunchState::Populating,
+                CcaLaunchState::Populating => return Err(KvmError::CcaPopulateInProgress),
+                CcaLaunchState::Populated => return Ok(()),
+                CcaLaunchState::Failed => return Err(KvmError::CcaPopulateFailed),
+            }
+        }
+
+        tracing::info!(page_ranges = pages.len(), "starting CCA initial population");
+        match self.cca_populate_initial_pages_inner(pages) {
+            Ok(()) => {
+                *self.cca_launch_state.lock() = CcaLaunchState::Populated;
+                tracing::info!("finished CCA initial population");
+                Ok(())
+            }
+            Err(err) => {
+                *self.cca_launch_state.lock() = CcaLaunchState::Failed;
+                tracing::error!(
+                    error = &err as &dyn std::error::Error,
+                    "failed CCA initial population"
+                );
+                Err(err)
+            }
+        }
+    }
+
+    /// Populates all supported initial imports, honoring partial ioctl progress.
+    fn cca_populate_initial_pages_inner(
+        &self,
+        pages: &[virt::InitialPageImport],
+    ) -> Result<(), KvmError> {
+        crate::memory::check_private_memory_extensions(
+            &self.kvm,
+            crate::memory::KvmGuestMemfdPrivateState::GuestMemfdDefault,
+        )
+        .map_err(map_cca_capability_error)?;
+
+        let pages = pages.to_vec();
+
+        let memory = self.memory.lock();
+        for page in &pages {
+            let flags = cca_populate_flags(page.import_type)?;
+            let private_range = private_memory_range_from_slots(page.range, &memory.ranges)
+                .map_err(map_cca_private_range_error)?;
+            let segments = crate::memory::guest_memfd_range_segments(page.range, &memory.ranges)
+                .map_err(map_cca_private_range_error)?;
+            let mut populate = kvm::KvmArmRmiPopulate {
+                base: private_range.gpa.start(),
+                size: private_range.gpa.len(),
+                source_uaddr: private_range.hva as u64,
+                flags,
+                reserved: 0,
+            };
+
+            while populate.size != 0 {
+                let previous = populate;
+                tracing::trace!(
+                    gpa = populate.base,
+                    len = populate.size,
+                    source_uaddr = populate.source_uaddr,
+                    flags = populate.flags,
+                    import_type = ?page.import_type,
+                    tag = page.tag,
+                    "KVM_ARM_RMI_POPULATE"
+                );
+                self.kvm.arm_rmi_populate(&mut populate)?;
+                if populate.size >= previous.size {
+                    return Err(KvmError::CcaPopulateNoProgress);
+                }
+            }
+            self.discard_stale_private_memory_backing(&segments, true, "CCA initial population")?;
+        }
+
+        Ok(())
+    }
+}
+
+/// Returns the RMI populate flags for a loader import type.
+fn cca_populate_flags(import_type: InitialPageImportType) -> Result<u32, KvmError> {
+    match import_type {
+        InitialPageImportType::Normal => Ok(kvm::KVM_ARM_RMI_POPULATE_FLAGS_MEASURE_UAPI),
+        InitialPageImportType::NormalUnmeasured => Ok(0),
+        InitialPageImportType::Shared
+        | InitialPageImportType::VpContext
+        | InitialPageImportType::Secrets
+        | InitialPageImportType::Cpuid
+        | InitialPageImportType::CpuidExtendedState => {
+            Err(KvmError::UnsupportedCcaPageImportType(import_type))
+        }
+    }
+}
+
+/// Converts a generic private-slot lookup failure into a CCA population error.
+fn map_cca_private_range_error(err: crate::memory::MemoryError) -> KvmError {
+    match err {
+        crate::memory::MemoryError::InvalidPrivateMemoryRange => KvmError::InvalidCcaPopulateRange,
+        err => err.into(),
+    }
+}
+
+/// Converts generic memory-conversion validation errors into CCA exit errors.
+pub(crate) fn map_cca_conversion_error(err: crate::memory::MemoryError) -> KvmError {
+    match err {
+        crate::memory::MemoryError::InvalidMapGpaRange => KvmError::InvalidCcaMemoryFault,
+        err => err.into(),
+    }
+}
+
+/// Converts private-memory capability errors into CCA-specific errors.
+fn map_cca_capability_error(err: crate::memory::MemoryError) -> KvmError {
+    match err {
+        crate::memory::MemoryError::Kvm(kvm::Error::MissingCapability(capability)) => {
+            KvmError::MissingCcaCapability(capability)
+        }
+        err => err.into(),
+    }
+}

--- a/vmm_core/virt_kvm/src/lib.rs
+++ b/vmm_core/virt_kvm/src/lib.rs
@@ -137,6 +137,8 @@ struct KvmPartitionInner {
     #[inspect(skip)]
     cca_launch_state: Mutex<CcaLaunchState>,
     #[cfg(guest_arch = "aarch64")]
+    cca_fatal: std::sync::atomic::AtomicBool,
+    #[cfg(guest_arch = "aarch64")]
     shared_gpa_bit: Option<u64>,
     memory: Mutex<KvmMemoryRangeState>,
     memory_backing_mode: KvmMemoryBackingMode,
@@ -207,6 +209,9 @@ enum KvmRunVpError {
     #[cfg(guest_arch = "aarch64")]
     #[error("CCA initial page population failed")]
     CcaPopulationFailed,
+    #[cfg(guest_arch = "aarch64")]
+    #[error("CCA partition is in a fatal memory-cleanup state")]
+    CcaMemoryCleanupFailed,
     #[error("unhandled system event type: {0:#x}")]
     UnhandledSystemEvent(u32),
     #[cfg(guest_arch = "x86_64")]
@@ -254,6 +259,14 @@ pub struct KvmProcessorBinder {
 }
 
 impl KvmPartitionInner {
+    #[cfg(guest_arch = "aarch64")]
+    fn mark_cca_fatal(&self) {
+        self.cca_fatal.store(true, Ordering::Release);
+        for vp in &self.vps {
+            self.kvm.vp(vp.vp_info().base.vp_index.index()).force_exit();
+        }
+    }
+
     #[cfg(guest_arch = "x86_64")]
     fn bsp(&self) -> &KvmVpInner {
         &self.vps[0]

--- a/vmm_core/virt_kvm/src/lib.rs
+++ b/vmm_core/virt_kvm/src/lib.rs
@@ -10,6 +10,8 @@
 #![expect(clippy::undocumented_unsafe_blocks)]
 
 mod arch;
+#[cfg(guest_arch = "aarch64")]
+mod cca;
 mod gsi;
 mod memory;
 #[cfg(guest_arch = "x86_64")]
@@ -40,6 +42,8 @@ pub fn is_available() -> Result<bool, KvmError> {
 }
 
 use arch::KvmVpInner;
+#[cfg(guest_arch = "aarch64")]
+use cca::CcaLaunchState;
 #[cfg(guest_arch = "x86_64")]
 use snp::SnpLaunchState;
 use std::sync::atomic::Ordering;
@@ -69,6 +73,28 @@ pub enum KvmError {
     InvalidState(&'static str),
     #[error("unsupported isolation configuration: {0}")]
     UnsupportedIsolationConfiguration(&'static str),
+    #[error("missing KVM CCA capability: {0}")]
+    MissingCcaCapability(&'static str),
+    #[error("CCA realm VMs require GICv3")]
+    CcaRequiresGicV3,
+    #[error("unsupported CCA initial page import type: {0:?}")]
+    UnsupportedCcaPageImportType(virt::InitialPageImportType),
+    #[error("CCA initial page population is already in progress")]
+    CcaPopulateInProgress,
+    #[error("CCA initial page population previously failed")]
+    CcaPopulateFailed,
+    #[error("CCA initial population range is not page aligned")]
+    UnalignedCcaPopulateRange,
+    #[error("CCA initial population range is not contained in guest_memfd private memory")]
+    InvalidCcaPopulateRange,
+    #[error("KVM_ARM_RMI_POPULATE returned without making progress")]
+    CcaPopulateNoProgress,
+    #[cfg(guest_arch = "aarch64")]
+    #[error("invalid CCA memory fault")]
+    InvalidCcaMemoryFault,
+    #[cfg(guest_arch = "aarch64")]
+    #[error("unsupported CCA memory fault flags: {0:#x}")]
+    UnsupportedCcaMemoryFaultFlags(u64),
     #[error("misaligned gic base address")]
     Misaligned,
     #[error("host does not support GICv2 or GICv3")]
@@ -107,6 +133,9 @@ struct KvmPartitionInner {
     #[cfg(guest_arch = "x86_64")]
     #[inspect(skip)]
     snp_launch_state: Mutex<SnpLaunchState>,
+    #[cfg(guest_arch = "aarch64")]
+    #[inspect(skip)]
+    cca_launch_state: Mutex<CcaLaunchState>,
     memory: Mutex<KvmMemoryRangeState>,
     memory_backing_mode: KvmMemoryBackingMode,
     #[inspect(iter_by_index)]
@@ -162,6 +191,21 @@ enum KvmRunVpError {
     InvalidVpState,
     #[error("failed to run VP")]
     Run(#[source] kvm::Error),
+    #[cfg(guest_arch = "aarch64")]
+    #[error(
+        "unsupported KVM memory fault/RIPAS change: flags={flags:#x}, gpa={gpa:#x}, size={size:#x}"
+    )]
+    UnsupportedMemoryFault { flags: u64, gpa: u64, size: u64 },
+    #[cfg(guest_arch = "aarch64")]
+    #[expect(dead_code)]
+    #[error("unhandled KVM exit: {0}")]
+    UnhandledExit(String),
+    #[cfg(guest_arch = "aarch64")]
+    #[error("CCA initial page population has not completed")]
+    CcaNotPopulated,
+    #[cfg(guest_arch = "aarch64")]
+    #[error("CCA initial page population failed")]
+    CcaPopulationFailed,
     #[error("unhandled system event type: {0:#x}")]
     UnhandledSystemEvent(u32),
     #[cfg(guest_arch = "x86_64")]
@@ -179,6 +223,27 @@ enum KvmRunVpError {
     #[cfg(guest_arch = "x86_64")]
     #[error("failed to inject an extint interrupt")]
     ExtintInterrupt(#[source] kvm::Error),
+}
+
+impl KvmRunVpError {
+    /// Preserves CCA memory-fault details when converting a KVM run error.
+    #[cfg(guest_arch = "aarch64")]
+    fn from_kvm_run_error(err: kvm::Error) -> Self {
+        match err {
+            kvm::Error::RunMemoryFault {
+                flags, gpa, size, ..
+            } => {
+                tracelimit::warn_ratelimited!(
+                    flags,
+                    gpa,
+                    size,
+                    "unsupported KVM memory fault/RIPAS change"
+                );
+                KvmRunVpError::UnsupportedMemoryFault { flags, gpa, size }
+            }
+            err => KvmRunVpError::Run(err),
+        }
+    }
 }
 
 pub struct KvmProcessorBinder {

--- a/vmm_core/virt_kvm/src/lib.rs
+++ b/vmm_core/virt_kvm/src/lib.rs
@@ -136,6 +136,8 @@ struct KvmPartitionInner {
     #[cfg(guest_arch = "aarch64")]
     #[inspect(skip)]
     cca_launch_state: Mutex<CcaLaunchState>,
+    #[cfg(guest_arch = "aarch64")]
+    shared_gpa_bit: Option<u64>,
     memory: Mutex<KvmMemoryRangeState>,
     memory_backing_mode: KvmMemoryBackingMode,
     #[inspect(iter_by_index)]
@@ -197,7 +199,6 @@ enum KvmRunVpError {
     )]
     UnsupportedMemoryFault { flags: u64, gpa: u64, size: u64 },
     #[cfg(guest_arch = "aarch64")]
-    #[expect(dead_code)]
     #[error("unhandled KVM exit: {0}")]
     UnhandledExit(String),
     #[cfg(guest_arch = "aarch64")]

--- a/vmm_core/virt_kvm/src/memory.rs
+++ b/vmm_core/virt_kvm/src/memory.rs
@@ -8,13 +8,15 @@
 //! selects the appropriate backing when a range is mapped, validates private
 //! launch ranges, and discards stale contents when ownership changes.
 
+#[cfg(guest_arch = "aarch64")]
+use crate::KvmError;
 use crate::KvmPartition;
 use crate::KvmPartitionInner;
+#[cfg(guest_arch = "aarch64")]
+use crate::cca::map_cca_conversion_error;
 use inspect::Inspect;
 use memory_range::MemoryRange;
-#[cfg(guest_arch = "x86_64")]
 use std::fs::File;
-#[cfg(guest_arch = "x86_64")]
 use std::os::fd::AsRawFd;
 use std::sync::Arc;
 use thiserror::Error;
@@ -45,7 +47,7 @@ pub(crate) struct KvmMemoryRange {
     host_addr: *mut u8,
     range: MemoryRange,
     guest_memfd_offset: Option<u64>,
-    private_attributes_set: bool,
+    private_state: Option<KvmGuestMemfdPrivateState>,
 }
 
 unsafe impl Sync for KvmMemoryRange {}
@@ -67,9 +69,8 @@ pub(crate) struct KvmPrivateMemoryRange {
     pub(crate) hva: *mut u8,
 }
 
-#[cfg(guest_arch = "x86_64")]
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
-struct KvmMemoryRangeSegment {
+pub(crate) struct KvmMemoryRangeSegment {
     range: MemoryRange,
     host_addr: *mut u8,
     guest_memfd_offset: u64,
@@ -81,12 +82,10 @@ struct KvmMemoryRangeSegment {
 pub(crate) enum KvmMemoryBackingMode {
     /// Register only the caller-provided userspace mapping.
     Userspace,
-    #[cfg(guest_arch = "x86_64")]
     /// Register shared userspace and private guestmemfd backing for RAM.
     GuestMemfd(KvmGuestMemfdBacking),
 }
 
-#[cfg(guest_arch = "x86_64")]
 #[derive(Debug, Inspect)]
 /// Partition-owned guestmemfd and its packed mapping of guest RAM ranges.
 pub(crate) struct KvmGuestMemfdBacking {
@@ -94,46 +93,57 @@ pub(crate) struct KvmGuestMemfdBacking {
     file: File,
     #[inspect(iter_by_index)]
     ranges: Vec<KvmGuestMemfdRange>,
-    initial_private: bool,
+    private_state: KvmGuestMemfdPrivateState,
 }
 
-#[cfg(guest_arch = "x86_64")]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Inspect)]
+pub(crate) enum KvmGuestMemfdPrivateState {
+    #[cfg(guest_arch = "x86_64")]
+    VmAttributes,
+    #[cfg(guest_arch = "aarch64")]
+    GuestMemfdDefault,
+}
+
+impl KvmGuestMemfdPrivateState {
+    fn uses_vm_attributes(self) -> bool {
+        #[cfg(guest_arch = "x86_64")]
+        {
+            matches!(self, Self::VmAttributes)
+        }
+        #[cfg(guest_arch = "aarch64")]
+        {
+            false
+        }
+    }
+}
+
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Inspect)]
 struct KvmGuestMemfdRange {
     range: MemoryRange,
     file_offset: u64,
 }
 
-#[cfg(guest_arch = "x86_64")]
 #[derive(Debug)]
 enum KvmMemoryBacking<'a> {
     Userspace,
     GuestMemfd {
         file: &'a File,
         file_offset: u64,
-        initial_private: bool,
+        private_state: KvmGuestMemfdPrivateState,
     },
 }
 
-#[cfg(guest_arch = "aarch64")]
-#[derive(Debug)]
-enum KvmMemoryBacking {
-    Userspace,
-}
-
 impl KvmMemoryBackingMode {
-    #[cfg(guest_arch = "x86_64")]
     /// Creates one guestmemfd spanning the supplied RAM ranges.
     ///
     /// Guest ranges are packed contiguously into the file in iteration order.
-    /// `initial_private` controls both the initial memory attributes and which
-    /// backing KVM selects when each slot is first registered.
+    /// `private_state` describes how private state is established.
     pub(crate) fn guest_memfd(
         kvm: &kvm::Partition,
         ram_ranges: impl IntoIterator<Item = MemoryRange>,
-        initial_private: bool,
+        private_state: KvmGuestMemfdPrivateState,
     ) -> Result<Self, MemoryError> {
-        check_private_memory_extensions(kvm)?;
+        check_private_memory_extensions(kvm, private_state)?;
 
         let mut file_size = 0u64;
         let mut ranges = Vec::new();
@@ -148,7 +158,7 @@ impl KvmMemoryBackingMode {
         Ok(Self::GuestMemfd(KvmGuestMemfdBacking {
             file: kvm.create_guest_memfd(file_size)?,
             ranges,
-            initial_private,
+            private_state,
         }))
     }
 }
@@ -193,7 +203,10 @@ impl KvmPartitionInner {
             {
                 return Err(MemoryError::CannotResizeGuestMemfdSlot.into());
             }
-            if existing_range.private_attributes_set {
+            if existing_range
+                .private_state
+                .is_some_and(KvmGuestMemfdPrivateState::uses_vm_attributes)
+            {
                 self.kvm.set_memory_attributes(
                     existing_range.range.start(),
                     existing_range.range.len(),
@@ -206,7 +219,7 @@ impl KvmPartitionInner {
                 state.ranges[slot_to_use] = None;
             }
         }
-        let (guest_memfd_offset, private_attributes_set) = match backing {
+        let (guest_memfd_offset, private_state) = match backing {
             KvmMemoryBacking::Userspace => {
                 // SAFETY: `map_region` requires its caller to keep
                 // `data..data+size` valid until this guest-physical range is
@@ -220,13 +233,12 @@ impl KvmPartitionInner {
                         readonly,
                     )?
                 };
-                (None, false)
+                (None, None)
             }
-            #[cfg(guest_arch = "x86_64")]
             KvmMemoryBacking::GuestMemfd {
                 file,
                 file_offset,
-                initial_private,
+                private_state,
             } => {
                 // SAFETY: `map_region` requires its caller to keep
                 // `data..data+size` valid until this guest-physical range is
@@ -242,7 +254,7 @@ impl KvmPartitionInner {
                         Some((file, file_offset)),
                     )?;
                 };
-                if initial_private {
+                if private_state.uses_vm_attributes() {
                     if let Err(err) = self.kvm.set_memory_attributes(
                         addr,
                         size as u64,
@@ -254,19 +266,18 @@ impl KvmPartitionInner {
                         return Err(err.into());
                     }
                 }
-                (Some(file_offset), initial_private)
+                (Some(file_offset), Some(private_state))
             }
         };
         state.ranges[slot_to_use] = Some(KvmMemoryRange {
             host_addr: data,
             range,
             guest_memfd_offset,
-            private_attributes_set,
+            private_state,
         });
         Ok(())
     }
 
-    #[cfg(guest_arch = "x86_64")]
     fn memory_backing(&self, range: MemoryRange) -> Result<KvmMemoryBacking<'_>, MemoryError> {
         match &self.memory_backing_mode {
             KvmMemoryBackingMode::Userspace => Ok(KvmMemoryBacking::Userspace),
@@ -275,17 +286,12 @@ impl KvmPartitionInner {
                     Some(file_offset) => Ok(KvmMemoryBacking::GuestMemfd {
                         file: &backing.file,
                         file_offset,
-                        initial_private: backing.initial_private,
+                        private_state: backing.private_state,
                     }),
                     None => Ok(KvmMemoryBacking::Userspace),
                 }
             }
         }
-    }
-
-    #[cfg(guest_arch = "aarch64")]
-    fn memory_backing(&self, _range: MemoryRange) -> Result<KvmMemoryBacking, MemoryError> {
-        Ok(KvmMemoryBacking::Userspace)
     }
 
     /// # Safety
@@ -383,7 +389,6 @@ impl KvmPartitionInner {
         Ok(())
     }
 
-    #[cfg(guest_arch = "x86_64")]
     /// Discards data from the backing that is no longer selected by KVM.
     ///
     /// Guestmemfd memory slots have separate shared userspace and private
@@ -391,7 +396,7 @@ impl KvmPartitionInner {
     /// shared mapping with `MADV_DONTNEED`. For a private-to-shared conversion,
     /// punch a hole in guestmemfd so private data cannot become visible after a
     /// later conversion back to private.
-    fn discard_stale_private_memory_backing(
+    pub(crate) fn discard_stale_private_memory_backing(
         &self,
         segments: &[KvmMemoryRangeSegment],
         private: bool,
@@ -448,10 +453,43 @@ impl KvmPartitionInner {
         }
         Ok(())
     }
+
+    #[cfg(guest_arch = "aarch64")]
+    pub(crate) fn handle_cca_ripas_change(
+        &self,
+        gpa: u64,
+        size: u64,
+        flags: u64,
+    ) -> Result<(), KvmError> {
+        let end = gpa
+            .checked_add(size)
+            .ok_or(KvmError::InvalidCcaMemoryFault)?;
+        if !gpa.is_multiple_of(hvdef::HV_PAGE_SIZE)
+            || !size.is_multiple_of(hvdef::HV_PAGE_SIZE)
+            || size == 0
+        {
+            return Err(KvmError::InvalidCcaMemoryFault);
+        }
+
+        let unsupported_flags = flags & !kvm::KVM_MEMORY_EXIT_FLAG_PRIVATE_UAPI;
+        if unsupported_flags != 0 {
+            return Err(KvmError::UnsupportedCcaMemoryFaultFlags(flags));
+        }
+
+        let private = flags & kvm::KVM_MEMORY_EXIT_FLAG_PRIVATE_UAPI != 0;
+        let range = MemoryRange::new(gpa..end);
+        let state = self.memory.lock();
+        let segments =
+            guest_memfd_range_segments(range, &state.ranges).map_err(map_cca_conversion_error)?;
+
+        tracing::debug!(gpa, size, flags, private, "KVM CCA RIPAS change");
+        self.discard_stale_private_memory_backing(&segments, private, "CCA")
+            .map_err(map_cca_conversion_error)?;
+        Ok(())
+    }
 }
 
-#[cfg(guest_arch = "x86_64")]
-fn guest_memfd_range_segments(
+pub(crate) fn guest_memfd_range_segments(
     range: MemoryRange,
     slots: &[Option<KvmMemoryRange>],
 ) -> Result<Vec<KvmMemoryRangeSegment>, MemoryError> {
@@ -488,7 +526,6 @@ fn guest_memfd_range_segments(
     Ok(segments)
 }
 
-#[cfg_attr(guest_arch = "aarch64", expect(dead_code))]
 /// Resolves an imported range to a private guestmemfd slot and source HVA.
 ///
 /// The entire range must be contained in one slot whose private attribute is
@@ -503,7 +540,7 @@ pub(crate) fn private_memory_range_from_slots(
         .find(|slot| slot.range.contains(&range))
         .ok_or(MemoryError::InvalidPrivateMemoryRange)?;
 
-    if slot.guest_memfd_offset.is_none() || !slot.private_attributes_set {
+    if slot.guest_memfd_offset.is_none() || slot.private_state.is_none() {
         return Err(MemoryError::InvalidPrivateMemoryRange);
     }
 
@@ -514,26 +551,31 @@ pub(crate) fn private_memory_range_from_slots(
     })
 }
 
-#[cfg(guest_arch = "x86_64")]
 /// Verifies the KVM capabilities required for guestmemfd private memory.
-fn check_private_memory_extensions(kvm: &kvm::Partition) -> Result<(), MemoryError> {
+pub(crate) fn check_private_memory_extensions(
+    kvm: &kvm::Partition,
+    private_state: KvmGuestMemfdPrivateState,
+) -> Result<(), MemoryError> {
     require_kvm_extension(kvm, kvm::KVM_CAP_USER_MEMORY2, "KVM_CAP_USER_MEMORY2")?;
     require_kvm_extension(kvm, kvm::KVM_CAP_GUEST_MEMFD, "KVM_CAP_GUEST_MEMFD")?;
-    let memory_attributes = require_kvm_extension(
-        kvm,
-        kvm::KVM_CAP_MEMORY_ATTRIBUTES,
-        "KVM_CAP_MEMORY_ATTRIBUTES",
-    )?;
+    let (capability, capability_name) = match private_state {
+        #[cfg(guest_arch = "x86_64")]
+        KvmGuestMemfdPrivateState::VmAttributes => {
+            (kvm::KVM_CAP_MEMORY_ATTRIBUTES, "KVM_CAP_MEMORY_ATTRIBUTES")
+        }
+        #[cfg(guest_arch = "aarch64")]
+        KvmGuestMemfdPrivateState::GuestMemfdDefault => (
+            kvm::KVM_CAP_GUEST_MEMFD_MEMORY_ATTRIBUTES_UAPI,
+            "KVM_CAP_GUEST_MEMFD_MEMORY_ATTRIBUTES",
+        ),
+    };
+    let memory_attributes = require_kvm_extension(kvm, capability, capability_name)?;
     if memory_attributes as u64 & kvm::KVM_MEMORY_ATTRIBUTE_PRIVATE as u64 == 0 {
-        return Err(kvm::Error::MissingCapability(
-            "KVM_CAP_MEMORY_ATTRIBUTES(KVM_MEMORY_ATTRIBUTE_PRIVATE)",
-        )
-        .into());
+        return Err(kvm::Error::MissingCapability(capability_name).into());
     }
     Ok(())
 }
 
-#[cfg(guest_arch = "x86_64")]
 fn require_kvm_extension(
     kvm: &kvm::Partition,
     extension: u32,
@@ -548,7 +590,6 @@ fn require_kvm_extension(
     Ok(value)
 }
 
-#[cfg(guest_arch = "x86_64")]
 fn classify_guest_memfd_backing(
     range: MemoryRange,
     ram_ranges: &[KvmGuestMemfdRange],
@@ -610,7 +651,10 @@ impl virt::PartitionMemoryMap for KvmPartitionInner {
             let Some(kvm_range) = entry else { continue };
             if range.contains(&kvm_range.range) {
                 let guest_memfd_backed = kvm_range.guest_memfd_offset.is_some();
-                if kvm_range.private_attributes_set {
+                if kvm_range
+                    .private_state
+                    .is_some_and(KvmGuestMemfdPrivateState::uses_vm_attributes)
+                {
                     self.kvm.set_memory_attributes(
                         kvm_range.range.start(),
                         kvm_range.range.len(),
@@ -640,7 +684,6 @@ mod tests {
         MemoryRange::new(start..end)
     }
 
-    #[cfg(guest_arch = "x86_64")]
     fn guest_memfd_ranges(ranges: &[MemoryRange]) -> Vec<KvmGuestMemfdRange> {
         let mut file_offset = 0;
         ranges
@@ -653,34 +696,17 @@ mod tests {
             .collect()
     }
 
-    #[derive(Debug, Copy, Clone, Eq, PartialEq)]
-    struct KvmPrivateMemoryRange {
-        gpa: MemoryRange,
-        hva: *mut u8,
-    }
-
-    fn private_memory_range_from_slots(
-        range: MemoryRange,
-        slots: &[Option<KvmMemoryRange>],
-    ) -> Result<KvmPrivateMemoryRange, MemoryError> {
-        let slot = slots
-            .iter()
-            .flatten()
-            .find(|slot| slot.range.contains(&range))
-            .ok_or(MemoryError::InvalidPrivateMemoryRange)?;
-
-        if slot.guest_memfd_offset.is_none() || !slot.private_attributes_set {
-            return Err(MemoryError::InvalidPrivateMemoryRange);
+    fn test_private_state() -> KvmGuestMemfdPrivateState {
+        #[cfg(guest_arch = "x86_64")]
+        {
+            KvmGuestMemfdPrivateState::VmAttributes
         }
-
-        let offset = range.start() - slot.range.start();
-        Ok(KvmPrivateMemoryRange {
-            gpa: range,
-            hva: slot.host_addr.wrapping_add(offset as usize),
-        })
+        #[cfg(guest_arch = "aarch64")]
+        {
+            KvmGuestMemfdPrivateState::GuestMemfdDefault
+        }
     }
 
-    #[cfg(guest_arch = "x86_64")]
     #[test]
     fn guest_memfd_classifier_selects_contained_ram() {
         let ram_ranges = guest_memfd_ranges(&[range(0x1000, 0x9000), range(0x1_0000, 0x2_0000)]);
@@ -695,7 +721,6 @@ mod tests {
         );
     }
 
-    #[cfg(guest_arch = "x86_64")]
     #[test]
     fn guest_memfd_classifier_keeps_non_ram_userspace() {
         let ram_ranges = guest_memfd_ranges(&[range(0x1000, 0x9000), range(0x1_0000, 0x2_0000)]);
@@ -706,7 +731,6 @@ mod tests {
         );
     }
 
-    #[cfg(guest_arch = "x86_64")]
     #[test]
     fn guest_memfd_classifier_rejects_partial_ram_overlap() {
         let ram_ranges = guest_memfd_ranges(&[range(0x1000, 0x9000), range(0x1_0000, 0x2_0000)]);
@@ -717,7 +741,6 @@ mod tests {
         ));
     }
 
-    #[cfg(guest_arch = "x86_64")]
     #[test]
     fn guest_memfd_classifier_does_not_merge_adjacent_ram_ranges() {
         let ram_ranges = guest_memfd_ranges(&[range(0x1000, 0x3000), range(0x3000, 0x5000)]);
@@ -728,7 +751,6 @@ mod tests {
         ));
     }
 
-    #[cfg(guest_arch = "x86_64")]
     #[test]
     fn guest_memfd_classifier_rejects_ambiguous_ram_containment() {
         let ram_ranges = guest_memfd_ranges(&[range(0x1000, 0x5000), range(0x2000, 0x4000)]);
@@ -747,7 +769,7 @@ mod tests {
             host_addr,
             range: range(0x1000, 0x5000),
             guest_memfd_offset: Some(0),
-            private_attributes_set: true,
+            private_state: Some(test_private_state()),
         })];
 
         let resolved = private_memory_range_from_slots(range(0x3000, 0x5000), &slots).unwrap();
@@ -764,7 +786,7 @@ mod tests {
             host_addr,
             range: range(0x1000, 0x5000),
             guest_memfd_offset: None,
-            private_attributes_set: true,
+            private_state: Some(test_private_state()),
         })];
         assert!(matches!(
             private_memory_range_from_slots(range(0x1000, 0x2000), &userspace_slots),
@@ -775,7 +797,7 @@ mod tests {
             host_addr,
             range: range(0x1000, 0x5000),
             guest_memfd_offset: Some(0),
-            private_attributes_set: false,
+            private_state: None,
         })];
         assert!(matches!(
             private_memory_range_from_slots(range(0x1000, 0x2000), &shared_slots),
@@ -784,7 +806,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(guest_arch = "x86_64")]
     fn guest_memfd_segments_cover_adjacent_unordered_slots() {
         let mut first_backing = vec![0u8; 0x2000];
         let mut second_backing = vec![0u8; 0x2000];
@@ -795,13 +816,13 @@ mod tests {
                 host_addr: second_host_addr,
                 range: range(0x3000, 0x5000),
                 guest_memfd_offset: Some(0x8000),
-                private_attributes_set: false,
+                private_state: None,
             }),
             Some(KvmMemoryRange {
                 host_addr: first_host_addr,
                 range: range(0x1000, 0x3000),
                 guest_memfd_offset: Some(0x4000),
-                private_attributes_set: true,
+                private_state: Some(test_private_state()),
             }),
         ];
 
@@ -825,7 +846,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(guest_arch = "x86_64")]
     fn guest_memfd_segments_reject_incomplete_coverage() {
         let mut backing = vec![0u8; 0x4000];
         let host_addr = backing.as_mut_ptr();
@@ -834,13 +854,13 @@ mod tests {
                 host_addr,
                 range: range(0x1000, 0x2000),
                 guest_memfd_offset: Some(0),
-                private_attributes_set: true,
+                private_state: Some(test_private_state()),
             }),
             Some(KvmMemoryRange {
                 host_addr: host_addr.wrapping_add(0x2000),
                 range: range(0x3000, 0x4000),
                 guest_memfd_offset: Some(0x2000),
-                private_attributes_set: true,
+                private_state: Some(test_private_state()),
             }),
         ];
         assert!(matches!(
@@ -852,7 +872,7 @@ mod tests {
             host_addr,
             range: range(0x1000, 0x4000),
             guest_memfd_offset: None,
-            private_attributes_set: false,
+            private_state: None,
         })];
         assert!(matches!(
             guest_memfd_range_segments(range(0x1000, 0x4000), &userspace_slot),
@@ -861,7 +881,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(guest_arch = "x86_64")]
     fn guest_memfd_segments_reject_overlapping_slots() {
         let mut backing = vec![0u8; 0x4000];
         let host_addr = backing.as_mut_ptr();
@@ -870,13 +889,13 @@ mod tests {
                 host_addr,
                 range: range(0x1000, 0x3000),
                 guest_memfd_offset: Some(0),
-                private_attributes_set: true,
+                private_state: Some(test_private_state()),
             }),
             Some(KvmMemoryRange {
                 host_addr: host_addr.wrapping_add(0x1000),
                 range: range(0x2000, 0x4000),
                 guest_memfd_offset: Some(0x1000),
-                private_attributes_set: true,
+                private_state: Some(test_private_state()),
             }),
         ];
 

--- a/vmm_core/virt_kvm/src/memory.rs
+++ b/vmm_core/virt_kvm/src/memory.rs
@@ -213,9 +213,35 @@ impl KvmPartitionInner {
                     0,
                 )?;
             }
+            #[cfg(guest_arch = "aarch64")]
+            if existing_range.private_state == Some(KvmGuestMemfdPrivateState::GuestMemfdDefault) {
+                let guest_memfd_offset = existing_range
+                    .guest_memfd_offset
+                    .ok_or(MemoryError::InvalidPrivateMemoryRange)?;
+                if let Err(err) = self.discard_stale_private_memory_backing(
+                    &[KvmMemoryRangeSegment {
+                        range: existing_range.range,
+                        host_addr: existing_range.host_addr,
+                        guest_memfd_offset,
+                    }],
+                    false,
+                    "CCA slot replacement",
+                ) {
+                    self.mark_cca_fatal();
+                    return Err(err.into());
+                }
+            }
             if existing_range.guest_memfd_offset.is_some() {
                 // SAFETY: clearing a slot removes the memory reference.
-                unsafe { self.clear_slot(slot_to_use, true)? };
+                if let Err(err) = unsafe { self.clear_slot(slot_to_use, true) } {
+                    #[cfg(guest_arch = "aarch64")]
+                    if existing_range.private_state
+                        == Some(KvmGuestMemfdPrivateState::GuestMemfdDefault)
+                    {
+                        self.mark_cca_fatal();
+                    }
+                    return Err(err.into());
+                }
                 state.ranges[slot_to_use] = None;
             }
         }
@@ -393,9 +419,10 @@ impl KvmPartitionInner {
     ///
     /// Guestmemfd memory slots have separate shared userspace and private
     /// guestmemfd backings. For a shared-to-private conversion, discard the
-    /// shared mapping with `MADV_DONTNEED`. For a private-to-shared conversion,
-    /// punch a hole in guestmemfd so private data cannot become visible after a
-    /// later conversion back to private.
+    /// shared backing with `MADV_REMOVE` (falling back to `MADV_DONTNEED` for
+    /// anonymous mappings). For a private-to-shared conversion, punch a hole in
+    /// guestmemfd so private data cannot become visible after a later conversion
+    /// back to private.
     pub(crate) fn discard_stale_private_memory_backing(
         &self,
         segments: &[KvmMemoryRangeSegment],
@@ -411,13 +438,24 @@ impl KvmPartitionInner {
                     isolation_name,
                     "discarding shared backing after private conversion"
                 );
-                let ret = unsafe {
+                let mut ret = unsafe {
                     libc::madvise(
                         segment.host_addr.cast(),
                         segment.range.len() as usize,
-                        libc::MADV_DONTNEED,
+                        libc::MADV_REMOVE,
                     )
                 };
+                if ret != 0 && std::io::Error::last_os_error().raw_os_error() == Some(libc::EINVAL)
+                {
+                    // MADV_REMOVE requires a shared file-backed mapping.
+                    ret = unsafe {
+                        libc::madvise(
+                            segment.host_addr.cast(),
+                            segment.range.len() as usize,
+                            libc::MADV_DONTNEED,
+                        )
+                    };
+                }
                 if ret != 0 {
                     return Err(MemoryError::DiscardSharedBacking(
                         std::io::Error::last_os_error(),
@@ -454,6 +492,12 @@ impl KvmPartitionInner {
         Ok(())
     }
 
+    /// Applies a KVM CCA memory-fault/RIPAS state transition.
+    ///
+    /// The kernel supplies a page-aligned range and indicates whether it must
+    /// become private. The range must remain within configured RAM. As with SNP
+    /// conversions, the old backing is discarded after KVM accepts the new
+    /// memory attribute so stale contents cannot reappear on a later transition.
     #[cfg(guest_arch = "aarch64")]
     pub(crate) fn handle_cca_ripas_change(
         &self,
@@ -479,21 +523,60 @@ impl KvmPartitionInner {
         let private = flags & kvm::KVM_MEMORY_EXIT_FLAG_PRIVATE_UAPI != 0;
         let range = MemoryRange::new(gpa..end);
         let state = self.memory.lock();
-        let segments =
-            guest_memfd_range_segments(range, &state.ranges).map_err(map_cca_conversion_error)?;
+        let segments = guest_memfd_range_intersections(range, &state.ranges)
+            .map_err(map_cca_conversion_error)?;
 
         tracing::debug!(gpa, size, flags, private, "KVM CCA RIPAS change");
-        self.discard_stale_private_memory_backing(&segments, private, "CCA")
-            .map_err(map_cca_conversion_error)?;
+        if let Err(err) = self.discard_stale_private_memory_backing(&segments, private, "CCA") {
+            self.mark_cca_fatal();
+            return Err(map_cca_conversion_error(err));
+        }
         Ok(())
     }
+}
+
+#[cfg(any(guest_arch = "aarch64", test))]
+fn guest_memfd_range_intersections(
+    range: MemoryRange,
+    slots: &[Option<KvmMemoryRange>],
+) -> Result<Vec<KvmMemoryRangeSegment>, MemoryError> {
+    let mut segments = guest_memfd_intersections(range, slots);
+    segments.sort_by_key(|segment| segment.range.start());
+    if segments
+        .windows(2)
+        .any(|segments| segments[0].range.end() > segments[1].range.start())
+    {
+        return Err(MemoryError::InvalidMapGpaRange);
+    }
+    Ok(segments)
 }
 
 pub(crate) fn guest_memfd_range_segments(
     range: MemoryRange,
     slots: &[Option<KvmMemoryRange>],
 ) -> Result<Vec<KvmMemoryRangeSegment>, MemoryError> {
-    let mut segments = slots
+    let mut segments = guest_memfd_intersections(range, slots);
+    segments.sort_by_key(|segment| segment.range.start());
+
+    let mut cursor = range.start();
+    for segment in &segments {
+        if segment.range.start() != cursor {
+            return Err(MemoryError::InvalidMapGpaRange);
+        }
+        cursor = segment.range.end();
+    }
+    if cursor != range.end() {
+        return Err(MemoryError::InvalidMapGpaRange);
+    }
+
+    Ok(segments)
+}
+
+fn guest_memfd_intersections(
+    range: MemoryRange,
+    slots: &[Option<KvmMemoryRange>],
+) -> Vec<KvmMemoryRangeSegment> {
+    slots
         .iter()
         .flatten()
         .filter_map(|slot| {
@@ -509,21 +592,7 @@ pub(crate) fn guest_memfd_range_segments(
                 }
             })
         })
-        .collect::<Vec<_>>();
-    segments.sort_by_key(|segment| segment.range.start());
-
-    let mut cursor = range.start();
-    for segment in &segments {
-        if segment.range.start() != cursor {
-            return Err(MemoryError::InvalidMapGpaRange);
-        }
-        cursor = segment.range.end();
-    }
-    if cursor != range.end() {
-        return Err(MemoryError::InvalidMapGpaRange);
-    }
-
-    Ok(segments)
+        .collect()
 }
 
 /// Resolves an imported range to a private guestmemfd slot and source HVA.
@@ -661,9 +730,46 @@ impl virt::PartitionMemoryMap for KvmPartitionInner {
                         0,
                     )?;
                 }
+                #[cfg(guest_arch = "aarch64")]
+                if kvm_range.private_state == Some(KvmGuestMemfdPrivateState::GuestMemfdDefault) {
+                    let guest_memfd_offset = kvm_range
+                        .guest_memfd_offset
+                        .ok_or(MemoryError::InvalidPrivateMemoryRange)?;
+                    if let Err(err) = self.discard_stale_private_memory_backing(
+                        &[KvmMemoryRangeSegment {
+                            range: kvm_range.range,
+                            host_addr: kvm_range.host_addr,
+                            guest_memfd_offset,
+                        }],
+                        false,
+                        "CCA slot unmap",
+                    ) {
+                        self.mark_cca_fatal();
+                        tracing::error!(
+                            error = &err as &dyn std::error::Error,
+                            "failed CCA slot backing cleanup; partition marked fatal"
+                        );
+                    }
+                }
                 // SAFETY: clearing a slot should always be safe since it removes
                 // and does not add memory references.
-                unsafe { self.clear_slot(slot, guest_memfd_backed)? };
+                // TODO: This error propagates to `PartitionMapper::unmap_region`,
+                // which currently panics because partition unmap is treated as
+                // infallible. Any recoverable policy must keep the slot's backing
+                // VA valid until the slot is cleared.
+                if let Err(err) = unsafe { self.clear_slot(slot, guest_memfd_backed) } {
+                    #[cfg(guest_arch = "aarch64")]
+                    if kvm_range.private_state == Some(KvmGuestMemfdPrivateState::GuestMemfdDefault)
+                    {
+                        self.mark_cca_fatal();
+                        tracing::error!(
+                            error = &err as &dyn std::error::Error,
+                            "failed to clear CCA slot; partition marked fatal"
+                        );
+                        return Err(err.into());
+                    }
+                    return Err(err.into());
+                }
                 *entry = None;
             } else {
                 assert!(
@@ -881,6 +987,33 @@ mod tests {
     }
 
     #[test]
+    fn guest_memfd_intersections_allow_unbacked_ranges() {
+        let mut backing = vec![0u8; 0x1000];
+        let host_addr = backing.as_mut_ptr();
+        let slots = [Some(KvmMemoryRange {
+            host_addr,
+            range: range(0x2000, 0x3000),
+            guest_memfd_offset: Some(0x4000),
+            private_state: Some(test_private_state()),
+        })];
+
+        let segments = guest_memfd_range_intersections(range(0x1000, 0x4000), &slots).unwrap();
+        assert_eq!(
+            segments,
+            [KvmMemoryRangeSegment {
+                range: range(0x2000, 0x3000),
+                host_addr,
+                guest_memfd_offset: 0x4000,
+            }]
+        );
+        assert!(
+            guest_memfd_range_intersections(range(0x4000, 0x5000), &slots)
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    #[test]
     fn guest_memfd_segments_reject_overlapping_slots() {
         let mut backing = vec![0u8; 0x4000];
         let host_addr = backing.as_mut_ptr();
@@ -902,6 +1035,10 @@ mod tests {
         assert!(matches!(
             guest_memfd_range_segments(range(0x1000, 0x4000), &slots),
             Err(MemoryError::InvalidMapGpaRange)
+        ));
+        assert!(matches!(
+            guest_memfd_range_intersections(range(0x1000, 0x4000), &slots),
+            Err(KvmError::InvalidMapGpaRange)
         ));
     }
 }

--- a/vmm_core/virt_kvm/src/memory.rs
+++ b/vmm_core/virt_kvm/src/memory.rs
@@ -1038,7 +1038,7 @@ mod tests {
         ));
         assert!(matches!(
             guest_memfd_range_intersections(range(0x1000, 0x4000), &slots),
-            Err(KvmError::InvalidMapGpaRange)
+            Err(MemoryError::InvalidMapGpaRange)
         ));
     }
 }

--- a/vmm_core/virt_mshv/src/aarch64/mod.rs
+++ b/vmm_core/virt_mshv/src/aarch64/mod.rs
@@ -60,6 +60,7 @@ impl virt::Hypervisor for LinuxMshv {
             supports_gic_v3: true,
             supports_its: false,
             device_assignment_msi_iova: virt::DeviceAssignmentMsiIova::Configurable,
+            shared_gpa_bit: None,
         }
     }
 

--- a/vmm_core/virt_whp/src/lib.rs
+++ b/vmm_core/virt_whp/src/lib.rs
@@ -863,6 +863,7 @@ impl virt::Hypervisor for Whp {
                 supports_gic_v3: true,
                 supports_its: false,
                 device_assignment_msi_iova: virt::DeviceAssignmentMsiIova::Unsupported,
+                shared_gpa_bit: None,
             }
         }
     }


### PR DESCRIPTION
Add support for booting a Linux direct CCA guest using KVM with the v15 cca patch series currently in review on LKML. Note that we do not yet support inplace guest_memfd, but it seems like the patch series works just fine without it. This should support a guest with emulated serial, along with virtio devices exposed over PCIe, similar to the SNP support in KVM and mshv. 

Tested via private additional local changes that test VM boot in FVP and QEMU with new incubator definitions and vmm_tests. Support for those will come in future changes, once they're cleaned up and ready for review. 