### PR TITLE
deps: update mu_msvm with v26.0.22 release (#4201)

### DIFF
--- a/flowey/flowey_lib_hvlite/src/_jobs/cfg_versions.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/cfg_versions.rs
@@ -24,7 +24,7 @@ pub const GH_CLI: &str = "2.52.0";
 pub const MDBOOK: &str = "0.4.40";
 pub const MDBOOK_ADMONISH: &str = "1.18.0";
 pub const MDBOOK_MERMAID: &str = "0.14.0";
-pub const MU_MSVM: &str = "26.0.19";
+pub const MU_MSVM: &str = "26.0.22";
 pub const NEXTEST: &str = "0.9.133";
 pub const NODEJS: &str = "24.x";
 // None disables hcl-dev builds and tests; Some(version) enables them.

--- a/nix/uefi_mu_msvm.nix
+++ b/nix/uefi_mu_msvm.nix
@@ -8,13 +8,13 @@ let
          else if system == "aarch64-linux" then "AARCH64-CLANGPDB"
          else "X64-VS2022";
   hash = {
-    "AARCH64-CLANGPDB" = "sha256-3UjCLzbldssvanro50hZoTQ4zrs+RzHKfnwdJMTcgQk=";
-    "X64-VS2022" = "sha256-7g0tD6S1911TpnLs5Annj6XMJavGDx0/qJhD2978ODE=";
+    "AARCH64-CLANGPDB" = "sha256-fblviUh4wCh5s+/2N4fSFl6oSuCF69IqjdIqOgudtnc=";
+    "X64-VS2022" = "sha256-fHvCIgZgoJBp79MeZglBe/vJU7vj6ZLeFLlCJk1ptRs=";
   }.${archToolchain};
 
 in stdenv.mkDerivation rec {
   pname = "uefi-mu-msvm-${archToolchain}";
-  version = "26.0.19";
+  version = "26.0.22";
 
   src = fetchzip {
     url =


### PR DESCRIPTION
Clean cherry pick of PR #4201

changelog: from previous ingestion: https://github.com/microsoft/mu_msvm/compare/v26.0.13...v26.0.22
