### PR TITLE
docs: update standalone OpenVMM guidance

### DIFF
--- a/Guide/src/index.md
+++ b/Guide/src/index.md
@@ -3,8 +3,8 @@
 OpenVMM is a modular, cross-platform Virtual Machine Monitor (VMM), written in
 Rust.
 
-Although it can function as a traditional VMM, OpenVMM's development is
-currently focused on its role in the [OpenHCL paravisor][paravisor].
+OpenVMM can run as a traditional VMM and also serves as the VMM within the
+[OpenHCL paravisor][paravisor].
 
 The project is open-source, MIT Licensed, and developed publicly at
 [microsoft/openvmm](https://github.com/microsoft/openvmm) on GitHub.
@@ -50,16 +50,9 @@ enabling several important Azure scenarios:
 ## Standalone VMM
 
 OpenVMM can also run as a general-purpose VMM on a Windows, Linux, or macOS
-host. At the moment, this is primarily a development vehicle: most of the same
-code runs in OpenVMM on a host and OpenVMM in a paravisor, and it is often
-easier to test it on a host.
-
-We will continue to build and test OpenVMM in this configuration, but currently
-we are not focused on the goal of supporting this for production workloads. It
-is missing many of the features and interface stability that are required for
-general-purpose use. We recommend you consider other Rust-based VMMs such as
-[Cloud Hypervisor](https://github.com/cloud-hypervisor/cloud-hypervisor) for
-such use cases.
+host. This configuration shares most of its code with OpenVMM running in a
+paravisor and provides a convenient environment for running and testing virtual
+machines directly on a host.
 
 ## Relationship to other Rust-based VMMs
 

--- a/Guide/src/reference/architecture/openvmm.md
+++ b/Guide/src/reference/architecture/openvmm.md
@@ -1,3 +1,13 @@
 # OpenVMM Architecture
 
-> This page is under construction
+This section describes the architecture of OpenVMM when it runs as a hosted
+VMM.
+
+- [Memory Layout](./openvmm/memory-layout.md) describes the guest physical
+  address space.
+- [Memory Backing](./openvmm/memory-backing.md) explains how guest RAM is
+  allocated and shared.
+- [NUMA Topology](./openvmm/numa.md) covers guest NUMA configuration and host
+  memory placement.
+- [mesh](./openvmm/mesh.md) describes OpenVMM's inter-process communication
+  framework.

--- a/Guide/src/reference/openvmm/management.md
+++ b/Guide/src/reference/openvmm/management.md
@@ -1,16 +1,13 @@
 # Configuration and Management
 
-```admonish warning title="DISCLAIMER"
-OpenVMM's configuration and management interfaces are currently unstable,
-incomplete, lightly documented, and broadly speaking - not particularly
-"polished".
+OpenVMM exposes three configuration and management interfaces. The CLI and
+interactive console support direct VM configuration and lifecycle operations,
+while gRPC and ttrpc provide programmatic control.
 
-These interfaces are **strictly for dev use only**.
-
-Refer to the [OpenVMM disclaimer] for more context.
+```admonish note title="Interface compatibility"
+These interfaces continue to evolve and may change between releases. Consult
+the documentation for your OpenVMM version, especially when upgrading.
 ```
-
-At the moment, OpenVMM exposes 3 distinct configuration and management interfaces.
 
 - **CLI**: Used to configure and launch a single VM
   - This allows configuring static VM resource assignments, such as the
@@ -21,13 +18,12 @@ At the moment, OpenVMM exposes 3 distinct configuration and management interface
   - This interface allows users to perform core VM operations such as stop,
     restart, save, restore, pause, resume, etc.. as well as things like storage
     hot-add, VTL2 servicing, running Inspect queries, etc..
-- **gRPC / ttrpc**: A _very_ WIP set of APIs for configuring and interacting
-  with VMs
+- **gRPC / ttrpc**: Programmatic APIs for configuring and interacting with VMs.
+  API compatibility and implementation coverage continue to evolve.
 
-## Missing Functionality (non-exhaustive)
+## Management Capabilities
 
-The following is a non-exhaustive list of notable management features that
-OpenVMM is currently missing.
+The following table summarizes the status of selected management features.
 
 <!-- NOTE: this is an HTML table, rather than a markdown table, as certain cells
 contain long blocks of text, which aren't easy to write using standard markdown
@@ -72,8 +68,5 @@ tables. -->
 </table>
 </div>
 
-If a feature is missing from this list, please check if the feature is being
-tracked via a Issue on the OpenVMM GitHub, and/or submit a PR adding it to this
-list.
-
-[OpenVMM disclaimer]: ../../user_guide/openvmm.md#admonition-disclaimer
+For additional feature requests and status information, search the
+[OpenVMM GitHub issues](https://github.com/microsoft/openvmm/issues).

--- a/Guide/src/reference/openvmm/management/cli.md
+++ b/Guide/src/reference/openvmm/management/cli.md
@@ -1,10 +1,11 @@
 # CLI
 
-```admonish danger title="Disclaimer"
-The following list is not exhaustive, and may be out of date.
-
-The most up to date reference is always the [code itself](https://openvmm.dev/rustdoc/linux/openvmm_entry/struct.Options.html),
-as well as the generated CLI help (via `cargo run -- --help`).
+```admonish note title="CLI compatibility and reference"
+The CLI is not a stable compatibility interface and may change between
+releases. This page summarizes OpenVMM's command-line options. The generated
+`openvmm --help` output is authoritative for the binary being run, and the
+[`Options` rustdoc](https://openvmm.dev/rustdoc/linux/openvmm_entry/struct.Options.html)
+describes the source definitions.
 ```
 
 * `--version`, `-V`: Print the OpenVMM build identity and exit. `-V` prints

--- a/Guide/src/reference/openvmm/management/grpc.md
+++ b/Guide/src/reference/openvmm/management/grpc.md
@@ -21,13 +21,11 @@ For example, to accept ttrpc clients only:
 
 Here is a list of supported RPCs:
 
-```admonish danger title="Disclaimer"
-The following list is not exhaustive, and may be out of date. The most up to
-date reference is the [`vmservice.proto`] file.
-
-Moreover, many APIs defined in the `.proto` file may not be fully wired up yet.
-
-In other words: This API is _very_ WIP, and user discretion is advised.
+```admonish note title="API reference"
+The API continues to evolve, and compatibility between releases is not
+guaranteed. The [`vmservice.proto`] file is the authoritative API definition.
+The list below summarizes the available RPCs; some definitions may be added
+before their implementation is connected end to end.
 ```
 
 * CreateVM

--- a/Guide/src/reference/openvmm/management/interactive_console.md
+++ b/Guide/src/reference/openvmm/management/interactive_console.md
@@ -7,11 +7,9 @@ To enter OpenVMM's interactive command mode, launch OpenVMM, and type `ctrl-q`.
 
 You can then type the following commands (followed by return):
 
-```admonish danger title="Disclaimer"
-The following list is not exhaustive and may be out of date.
-
-The most up to date reference is always the code itself. For a full list of
-commands, please invoke the `help` command.
+```admonish note title="Command reference"
+This page summarizes the interactive commands. Enter `help` in the interactive
+console for the commands supported by the running binary.
 ```
 
 * `q` / `quit`: quit the program.

--- a/Guide/src/user_guide/openhcl/run/openvmm.md
+++ b/Guide/src/user_guide/openhcl/run/openvmm.md
@@ -1,29 +1,25 @@
 # Windows - OpenVMM
 
-OpenVMM currently has basic support for running with OpenHCL when run on Windows
-with WHP, with some caveats:
+OpenVMM can run OpenHCL on Windows using WHP. Compared with running OpenHCL on
+Hyper-V, this environment has the following differences:
 
-1. Performance is not great due to the extra overhead of OpenVMM modeling VTLs,
-   not the hypervisor.
-2. Not all hypercalls are implemented, only the set used by OpenHCL.
-3. Not all OpenHCL configuration and runtime management APIs are exposed / wired-up.
+1. Modeling VTLs in OpenVMM adds overhead compared with hypervisor-provided
+   VTLs.
+2. The WHP path implements the hypercalls used by OpenHCL rather than the full
+   Hyper-V hypercall surface.
+3. Some OpenHCL configuration and runtime management APIs are not exposed
+   through this path.
 
-These are all caveats that can (and will) be overcome with additional
-investments into OpenVMM.
-
-That said: running OpenHCL on OpenVMM is currently considered to be a **dev-only
-workflow**, not suitable for production use.
-
-To get a more complete and accurate experience of what OpenHCL's production
-runtime characteristics and user ergonomics are like, we currently suggest
-[running OpenHCL on Hyper-V](./hyperv.md).
+This configuration is intended primarily for developing and validating
+OpenHCL. It does not reproduce every runtime or performance characteristic of
+Hyper-V. To evaluate behavior in a Hyper-V environment, see
+[Running OpenHCL on Hyper-V](./hyperv.md).
 
 ## Examples
 
 ```admonish warning
-These examples assume basic familiarity with the OpenVMM command line, and a
-willingness to deal with OpenVMM's various "rough edges" (as described in
-[Getting Started: OpenVMM](../../openvmm.md#disclaimer)).
+These examples assume basic familiarity with the OpenVMM command line. See
+[Running OpenVMM](../../openvmm/run.md) for an introduction.
 ```
 
 ```admonish tip

--- a/Guide/src/user_guide/openvmm.md
+++ b/Guide/src/user_guide/openvmm.md
@@ -64,7 +64,7 @@ devices, and scenarios OpenVMM currently supports.
   - Serial (term, socket, tcp)
   - Storage (raw img, VHD/VHDx, Linux blockdev, HTTP)
   - Networking (various)
-- Management APIs (unstable)
+- Management interfaces (evolving)
   - CLI
   - Interactive console
   - gRPC
@@ -73,32 +73,10 @@ devices, and scenarios OpenVMM currently supports.
 For more information on any / all of these features, see their corresponding
 pages under the **Reference** section of the OpenVMM Guide.
 
-...though, as you may be able to tell by looking at the sidebar, that section of
-the Guide is currently under construction, and not all items have corresponding
-pages at this time.
-
-* * *
-
-Before heading on to [Running OpenVMM](./openvmm/run.md), please take a moment
-to read and understand the following important disclaimer:
-
-```admonish warning title="DISCLAIMER"
-In recent years, development efforts in the OpenVMM project have primarily
-focused on [OpenHCL](./openhcl.md) (AKA: OpenVMM as a paravisor).
-
-As a result, not a lot of "polish" has gone into making the experience of
-running OpenVMM in traditional host contexts particularly "pleasant".
-This lack of polish manifests in several ways, including but not limited to:
-
-- Unorganized and minimally documented management interfaces (e.g: CLI, ttrpc/grpc)
-- Unoptimized device backend performance (e.g: for storage, networking, graphics)
-- Unexpectedly missing device features (e.g: legacy IDE drive, PS/2 mouse features)
-- **No API or feature-set stability guarantees whatsoever.**
-
-At this time, OpenVMM _on the host_ is not yet ready to run end-user
-workloads, and should should be treated more akin to a development platform
-for implementing new OpenVMM features, rather than a ready-to-deploy
-application.
+```admonish note title="Management interface compatibility"
+OpenVMM's management interfaces continue to evolve and may change between
+releases. Consult the documentation for your OpenVMM version, especially when
+upgrading.
 ```
 
 [^dlls]: though, depending on the platform and compiled-in feature-set, some

--- a/Guide/src/user_guide/openvmm/run.md
+++ b/Guide/src/user_guide/openvmm/run.md
@@ -4,8 +4,7 @@
 This page offers a high-level overview of different ways to launch and interact
 with OpenVMM.
 
-These examples are by no means "exhaustive", and should be treated as a useful
-jumping-off point for subsequent self-guided experimentation with OpenVMM.
+These examples provide a starting point for launching and configuring OpenVMM.
 
 ## Obtaining a copy of OpenVMM
 


### PR DESCRIPTION
## Summary
- remove blanket language that describes standalone OpenVMM as unsuitable for production
- retain focused compatibility guidance for evolving management interfaces
- replace outdated disclaimers and placeholders with specific technical context

## Validation
- `cargo xtask fmt --fix`
- `mdbook test .`
- `mdbook build .`