### PR TITLE
vmm_tests: guest hibernation + OpenHCL hibernate-token coverage

### DIFF
--- a/guest_test_uefi/src/uefi/action.rs
+++ b/guest_test_uefi/src/uefi/action.rs
@@ -1,0 +1,90 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Generic boot-action selector for `guest_test_uefi`.
+//!
+//! Petri selects the guest's behavior by seeding a UEFI variable (via a
+//! `CUSTOM_UEFI` NVRAM delta in the VMGS) that this application reads at
+//! startup. When the variable is absent or unrecognized, the default action is
+//! to run the normal test suite; specific values select alternate behaviors
+//! such as requesting hibernation.
+
+// UNSAFETY: Raw port I/O / SMC needed to request an ACPI/PSCI power transition.
+#![expect(unsafe_code)]
+
+use uefi::cstr16;
+use uefi::runtime;
+use uefi::runtime::VariableVendor;
+
+/// The UEFI variable, under the EFI global namespace, that petri writes to
+/// select a guest action. Keep in sync with the petri-side seeding helper.
+const ACTION_VAR_NAME: &uefi::CStr16 = cstr16!("PetriBootAction");
+
+/// The action a caller requested this application to perform at startup.
+pub enum GuestAction {
+    /// Run the normal `guest_test_uefi` test suite (the default).
+    RunTests,
+    /// Request hibernation from the platform, then never return.
+    Hibernate,
+}
+
+impl GuestAction {
+    /// Map a raw variable value to an action, tolerating a trailing NUL.
+    fn from_value(value: &[u8]) -> Self {
+        let value = value.split(|&b| b == 0).next().unwrap_or(value);
+        match value {
+            b"hibernate" => GuestAction::Hibernate,
+            _ => GuestAction::RunTests,
+        }
+    }
+}
+
+/// Read the petri-selected action, defaulting to running the test suite when
+/// the selector variable is absent or unreadable.
+pub fn selected_action() -> GuestAction {
+    match runtime::get_variable_boxed(ACTION_VAR_NAME, &VariableVendor::GLOBAL_VARIABLE) {
+        Ok((value, _)) => GuestAction::from_value(&value),
+        Err(_) => GuestAction::RunTests,
+    }
+}
+
+/// Request hibernation from the platform and do not return.
+///
+/// On x86_64 this writes the ACPI PM control register requesting S4; on aarch64
+/// it issues the PSCI `SYSTEM_OFF2` call requesting hibernation. Under OpenHCL
+/// these are trapped by the paravisor, which records the hibernate token and
+/// notifies the host.
+pub fn hibernate() -> ! {
+    uefi::println!("guest_test_uefi: requesting hibernation");
+
+    #[cfg(target_arch = "x86_64")]
+    // SAFETY: Writing the emulated ACPI PM control register (PM base 0x400 +
+    // control offset 0x04) with SLP_EN set and suspend type 1 requests S4
+    // (hibernate). The write has no memory effects on the guest.
+    unsafe {
+        core::arch::asm!(
+            "out dx, ax",
+            in("dx") 0x404u16,
+            in("ax") 0x2400u16,
+            options(nomem, nostack, preserves_flags),
+        );
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    // SAFETY: PSCI SYSTEM_OFF2 (0x8400_0015) with HIBERNATE_OFF (1) requests
+    // hibernation and does not return.
+    unsafe {
+        core::arch::asm!(
+            "smc #0",
+            in("x0") 0x8400_0015u64,
+            in("x1") 1u64,
+            options(nomem, nostack, preserves_flags),
+        );
+    }
+
+    // The platform should have halted this VP; if control returns, spin so we
+    // never fall through to unrelated code.
+    loop {
+        core::hint::spin_loop();
+    }
+}

--- a/guest_test_uefi/src/uefi/action.rs
+++ b/guest_test_uefi/src/uefi/action.rs
@@ -9,9 +9,6 @@
 //! to run the normal test suite; specific values select alternate behaviors
 //! such as requesting hibernation.
 
-// UNSAFETY: Raw port I/O / SMC needed to request an ACPI/PSCI power transition.
-#![expect(unsafe_code)]
-
 use uefi::cstr16;
 use uefi::runtime;
 use uefi::runtime::VariableVendor;
@@ -45,46 +42,5 @@ pub fn selected_action() -> GuestAction {
     match runtime::get_variable_boxed(ACTION_VAR_NAME, &VariableVendor::GLOBAL_VARIABLE) {
         Ok((value, _)) => GuestAction::from_value(&value),
         Err(_) => GuestAction::RunTests,
-    }
-}
-
-/// Request hibernation from the platform and do not return.
-///
-/// On x86_64 this writes the ACPI PM control register requesting S4; on aarch64
-/// it issues the PSCI `SYSTEM_OFF2` call requesting hibernation. Under OpenHCL
-/// these are trapped by the paravisor, which records the hibernate token and
-/// notifies the host.
-pub fn hibernate() -> ! {
-    uefi::println!("guest_test_uefi: requesting hibernation");
-
-    #[cfg(target_arch = "x86_64")]
-    // SAFETY: Writing the emulated ACPI PM control register (PM base 0x400 +
-    // control offset 0x04) with SLP_EN set and suspend type 1 requests S4
-    // (hibernate). The write has no memory effects on the guest.
-    unsafe {
-        core::arch::asm!(
-            "out dx, ax",
-            in("dx") 0x404u16,
-            in("ax") 0x2400u16,
-            options(nomem, nostack, preserves_flags),
-        );
-    }
-
-    #[cfg(target_arch = "aarch64")]
-    // SAFETY: PSCI SYSTEM_OFF2 (0x8400_0015) with HIBERNATE_OFF (1) requests
-    // hibernation and does not return.
-    unsafe {
-        core::arch::asm!(
-            "smc #0",
-            in("x0") 0x8400_0015u64,
-            in("x1") 1u64,
-            options(nomem, nostack, preserves_flags),
-        );
-    }
-
-    // The platform should have halted this VP; if control returns, spin so we
-    // never fall through to unrelated code.
-    loop {
-        core::hint::spin_loop();
     }
 }

--- a/guest_test_uefi/src/uefi/hibernate.rs
+++ b/guest_test_uefi/src/uefi/hibernate.rs
@@ -3,7 +3,7 @@
 
 //! Requests a platform hibernation from the guest.
 
-// UNSAFETY: Raw port I/O / SMC needed to request an ACPI/PSCI power transition.
+// UNSAFETY: Raw port I/O / HVC needed to request an ACPI/PSCI power transition.
 #![expect(unsafe_code)]
 
 /// Request hibernation from the platform and do not return.
@@ -30,11 +30,12 @@ pub fn hibernate() -> ! {
 
     #[cfg(target_arch = "aarch64")]
     // SAFETY: PSCI SYSTEM_OFF2 (0x8400_0015) with HIBERNATE_OFF (1) requests
-    // hibernation and does not return. x0/x1 are marked clobbered (and flags are
-    // not preserved) because an SMC may modify them if it unexpectedly returns.
+    // hibernation and does not return. The PSCI conduit is HVC (the platform
+    // advertises PSCI_USE_HVC); x0/x1 are marked clobbered (and flags are not
+    // preserved) because the call may modify them if it unexpectedly returns.
     unsafe {
         core::arch::asm!(
-            "smc #0",
+            "hvc #0",
             inlateout("x0") 0x8400_0015u64 => _,
             inlateout("x1") 1u64 => _,
             options(nomem, nostack),

--- a/guest_test_uefi/src/uefi/hibernate.rs
+++ b/guest_test_uefi/src/uefi/hibernate.rs
@@ -3,7 +3,7 @@
 
 //! Requests a platform hibernation from the guest.
 
-// UNSAFETY: Raw port I/O / HVC needed to request an ACPI/PSCI power transition.
+// UNSAFETY: Raw port I/O / SMC needed to request an ACPI/PSCI power transition.
 #![expect(unsafe_code)]
 
 /// Request hibernation from the platform and do not return.
@@ -29,14 +29,16 @@ pub fn hibernate() -> ! {
     }
 
     #[cfg(target_arch = "aarch64")]
-    // SAFETY: PSCI SYSTEM_OFF2 (0x8400_0015) with HIBERNATE_OFF (1) requests
-    // hibernation and does not return. The PSCI conduit is HVC (the platform
-    // advertises PSCI_USE_HVC); x0/x1 are marked clobbered (and flags are not
-    // preserved) because the call may modify them if it unexpectedly returns.
+    // SAFETY: PSCI SYSTEM_OFF2 (SMC64 `0xC400_0015`) with type HIBERNATE (1)
+    // requests hibernation and does not return. Matches the Hyper-V UEFI
+    // convention: the Microsoft hypervisor traps SMC (via HCR_EL2.TSC) for PSCI
+    // power calls, and a 64-bit guest uses the SMC64 function ID. x0/x1 are
+    // marked clobbered (and flags not preserved) since the call may modify them
+    // if it unexpectedly returns.
     unsafe {
         core::arch::asm!(
-            "hvc #0",
-            inlateout("x0") 0x8400_0015u64 => _,
+            "smc #0",
+            inlateout("x0") 0xC400_0015u64 => _,
             inlateout("x1") 1u64 => _,
             options(nomem, nostack),
         );

--- a/guest_test_uefi/src/uefi/hibernate.rs
+++ b/guest_test_uefi/src/uefi/hibernate.rs
@@ -30,13 +30,14 @@ pub fn hibernate() -> ! {
 
     #[cfg(target_arch = "aarch64")]
     // SAFETY: PSCI SYSTEM_OFF2 (0x8400_0015) with HIBERNATE_OFF (1) requests
-    // hibernation and does not return.
+    // hibernation and does not return. x0/x1 are marked clobbered (and flags are
+    // not preserved) because an SMC may modify them if it unexpectedly returns.
     unsafe {
         core::arch::asm!(
             "smc #0",
-            in("x0") 0x8400_0015u64,
-            in("x1") 1u64,
-            options(nomem, nostack, preserves_flags),
+            inlateout("x0") 0x8400_0015u64 => _,
+            inlateout("x1") 1u64 => _,
+            options(nomem, nostack),
         );
     }
 

--- a/guest_test_uefi/src/uefi/hibernate.rs
+++ b/guest_test_uefi/src/uefi/hibernate.rs
@@ -1,0 +1,48 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Requests a platform hibernation from the guest.
+
+// UNSAFETY: Raw port I/O / SMC needed to request an ACPI/PSCI power transition.
+#![expect(unsafe_code)]
+
+/// Request hibernation from the platform and do not return.
+///
+/// On x86_64 this writes the ACPI PM control register requesting S4; on aarch64
+/// it issues the PSCI `SYSTEM_OFF2` call requesting hibernation. Under OpenHCL
+/// these are trapped by the paravisor, which records the hibernate token and
+/// notifies the host.
+pub fn hibernate() -> ! {
+    uefi::println!("guest_test_uefi: requesting hibernation");
+
+    #[cfg(target_arch = "x86_64")]
+    // SAFETY: Writing the emulated ACPI PM control register (PM base 0x400 +
+    // control offset 0x04) with SLP_EN set and suspend type 1 requests S4
+    // (hibernate). The write has no memory effects on the guest.
+    unsafe {
+        core::arch::asm!(
+            "out dx, ax",
+            in("dx") 0x404u16,
+            in("ax") 0x2400u16,
+            options(nomem, nostack, preserves_flags),
+        );
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    // SAFETY: PSCI SYSTEM_OFF2 (0x8400_0015) with HIBERNATE_OFF (1) requests
+    // hibernation and does not return.
+    unsafe {
+        core::arch::asm!(
+            "smc #0",
+            in("x0") 0x8400_0015u64,
+            in("x1") 1u64,
+            options(nomem, nostack, preserves_flags),
+        );
+    }
+
+    // The platform should have halted this VP; if control returns, spin so we
+    // never fall through to unrelated code.
+    loop {
+        core::hint::spin_loop();
+    }
+}

--- a/guest_test_uefi/src/uefi/mod.rs
+++ b/guest_test_uefi/src/uefi/mod.rs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 mod action;
+mod hibernate;
 mod rt;
 mod splash;
 mod tests;
@@ -23,7 +24,7 @@ fn uefi_main() -> Status {
     splash::draw_splash(Splashes(NonZeroU8::new(1).unwrap()));
 
     match action::selected_action() {
-        action::GuestAction::Hibernate => action::hibernate(),
+        action::GuestAction::Hibernate => hibernate::hibernate(),
         action::GuestAction::RunTests => tests::run_tests(),
     }
 

--- a/guest_test_uefi/src/uefi/mod.rs
+++ b/guest_test_uefi/src/uefi/mod.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+mod action;
 mod rt;
 mod splash;
 mod tests;
@@ -21,7 +22,10 @@ fn uefi_main() -> Status {
     // running UEFI on a VM without a gfx adapter - such as in CI).
     splash::draw_splash(Splashes(NonZeroU8::new(1).unwrap()));
 
-    tests::run_tests();
+    match action::selected_action() {
+        action::GuestAction::Hibernate => action::hibernate(),
+        action::GuestAction::RunTests => tests::run_tests(),
+    }
 
     Status::SUCCESS
 }

--- a/openvmm/openvmm_core/src/worker/dispatch.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch.rs
@@ -1583,6 +1583,7 @@ impl InitializedVm {
             LoadMode::Pcat {
                 firmware,
                 boot_order,
+                enable_hibernation,
             } => {
                 tracing::debug!(?firmware, "Loading BIOS firmware.");
                 let rom_builder = RomBuilder::new("bios".into(), Box::new(mapper.clone()));
@@ -1638,7 +1639,7 @@ impl InitializedVm {
                             chipset_high_mmio: chipset_mmio.high,
                             srat,
 
-                            hibernation_enabled: false,
+                            hibernation_enabled: *enable_hibernation,
                             initial_generation_id: {
                                 let mut generation_id = [0; 16];
                                 getrandom::fill(&mut generation_id).expect("rng failure");
@@ -3333,6 +3334,7 @@ impl LoadedVmInner {
                 enable_vmbus,
                 force_dma_bounce,
                 enable_hv,
+                enable_hibernation,
             } => {
                 let acpi_tables = [
                     // MADT
@@ -3370,6 +3372,7 @@ impl LoadedVmInner {
                     vmbus: enable_vmbus,
                     force_dma_bounce,
                     hv: enable_hv,
+                    hibernation: enable_hibernation,
                 };
                 let regs =
                     super::vm_loaders::uefi::load_uefi(&super::vm_loaders::uefi::LoadUefiParams {

--- a/openvmm/openvmm_core/src/worker/dispatch.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch.rs
@@ -186,6 +186,7 @@ impl Manifest {
     fn from_config(config: Config) -> Self {
         Self {
             load_mode: config.load_mode,
+            hibernation_enabled: config.hibernation_enabled,
             floppy_disks: config.floppy_disks,
             ide_disks: config.ide_disks,
             pcie_root_complexes: config.pcie_root_complexes,
@@ -230,6 +231,7 @@ impl Manifest {
 #[derive(MeshPayload)]
 pub struct Manifest {
     load_mode: LoadMode,
+    hibernation_enabled: bool,
     floppy_disks: Vec<FloppyDiskConfig>,
     ide_disks: Vec<IdeDeviceConfig>,
     pcie_root_complexes: Vec<PcieRootComplexConfig>,
@@ -803,6 +805,7 @@ struct LoadedVmInner {
     firmware_event_send: Option<mesh::Sender<get_resources::ged::FirmwareEvent>>,
 
     load_mode: LoadMode,
+    hibernation_enabled: bool,
     igvm_file: Option<IgvmFile>,
     next_igvm_file: Option<IgvmFile>,
     _vmgs_task: Option<Task<()>>,
@@ -1583,7 +1586,6 @@ impl InitializedVm {
             LoadMode::Pcat {
                 firmware,
                 boot_order,
-                enable_hibernation,
             } => {
                 tracing::debug!(?firmware, "Loading BIOS firmware.");
                 let rom_builder = RomBuilder::new("bios".into(), Box::new(mapper.clone()));
@@ -1639,7 +1641,7 @@ impl InitializedVm {
                             chipset_high_mmio: chipset_mmio.high,
                             srat,
 
-                            hibernation_enabled: *enable_hibernation,
+                            hibernation_enabled: cfg.hibernation_enabled,
                             initial_generation_id: {
                                 let mut generation_id = [0; 16];
                                 getrandom::fill(&mut generation_id).expect("rng failure");
@@ -3069,6 +3071,7 @@ impl InitializedVm {
                 chipset_capabilities: cfg.chipset_capabilities,
                 firmware_event_send: cfg.firmware_event_send,
                 load_mode: cfg.load_mode,
+                hibernation_enabled: cfg.hibernation_enabled,
                 virtio_mmio_region,
                 virtio_mmio_irq,
                 chipset_mmio,
@@ -3334,7 +3337,6 @@ impl LoadedVmInner {
                 enable_vmbus,
                 force_dma_bounce,
                 enable_hv,
-                enable_hibernation,
             } => {
                 let acpi_tables = [
                     // MADT
@@ -3372,7 +3374,7 @@ impl LoadedVmInner {
                     vmbus: enable_vmbus,
                     force_dma_bounce,
                     hv: enable_hv,
-                    hibernation: enable_hibernation,
+                    hibernation: self.hibernation_enabled,
                 };
                 let regs =
                     super::vm_loaders::uefi::load_uefi(&super::vm_loaders::uefi::LoadUefiParams {
@@ -4021,6 +4023,7 @@ impl LoadedVm {
 
         let manifest = Manifest {
             load_mode: self.inner.load_mode,
+            hibernation_enabled: self.inner.hibernation_enabled,
             floppy_disks: vec![],            // TODO
             ide_disks: vec![],               // TODO
             pcie_root_complexes: vec![],     // TODO

--- a/openvmm/openvmm_core/src/worker/dispatch.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch.rs
@@ -186,7 +186,6 @@ impl Manifest {
     fn from_config(config: Config) -> Self {
         Self {
             load_mode: config.load_mode,
-            hibernation_enabled: config.hibernation_enabled,
             floppy_disks: config.floppy_disks,
             ide_disks: config.ide_disks,
             pcie_root_complexes: config.pcie_root_complexes,
@@ -231,7 +230,6 @@ impl Manifest {
 #[derive(MeshPayload)]
 pub struct Manifest {
     load_mode: LoadMode,
-    hibernation_enabled: bool,
     floppy_disks: Vec<FloppyDiskConfig>,
     ide_disks: Vec<IdeDeviceConfig>,
     pcie_root_complexes: Vec<PcieRootComplexConfig>,
@@ -805,7 +803,6 @@ struct LoadedVmInner {
     firmware_event_send: Option<mesh::Sender<get_resources::ged::FirmwareEvent>>,
 
     load_mode: LoadMode,
-    hibernation_enabled: bool,
     igvm_file: Option<IgvmFile>,
     next_igvm_file: Option<IgvmFile>,
     _vmgs_task: Option<Task<()>>,
@@ -1586,6 +1583,7 @@ impl InitializedVm {
             LoadMode::Pcat {
                 firmware,
                 boot_order,
+                hibernation_enabled,
             } => {
                 tracing::debug!(?firmware, "Loading BIOS firmware.");
                 let rom_builder = RomBuilder::new("bios".into(), Box::new(mapper.clone()));
@@ -1641,7 +1639,7 @@ impl InitializedVm {
                             chipset_high_mmio: chipset_mmio.high,
                             srat,
 
-                            hibernation_enabled: cfg.hibernation_enabled,
+                            hibernation_enabled: *hibernation_enabled,
                             initial_generation_id: {
                                 let mut generation_id = [0; 16];
                                 getrandom::fill(&mut generation_id).expect("rng failure");
@@ -3071,7 +3069,6 @@ impl InitializedVm {
                 chipset_capabilities: cfg.chipset_capabilities,
                 firmware_event_send: cfg.firmware_event_send,
                 load_mode: cfg.load_mode,
-                hibernation_enabled: cfg.hibernation_enabled,
                 virtio_mmio_region,
                 virtio_mmio_irq,
                 chipset_mmio,
@@ -3337,6 +3334,7 @@ impl LoadedVmInner {
                 enable_vmbus,
                 force_dma_bounce,
                 enable_hv,
+                hibernation_enabled,
             } => {
                 let acpi_tables = [
                     // MADT
@@ -3374,7 +3372,7 @@ impl LoadedVmInner {
                     vmbus: enable_vmbus,
                     force_dma_bounce,
                     hv: enable_hv,
-                    hibernation: self.hibernation_enabled,
+                    hibernation: hibernation_enabled,
                 };
                 let regs =
                     super::vm_loaders::uefi::load_uefi(&super::vm_loaders::uefi::LoadUefiParams {
@@ -4023,7 +4021,6 @@ impl LoadedVm {
 
         let manifest = Manifest {
             load_mode: self.inner.load_mode,
-            hibernation_enabled: self.inner.hibernation_enabled,
             floppy_disks: vec![],            // TODO
             ide_disks: vec![],               // TODO
             pcie_root_complexes: vec![],     // TODO

--- a/openvmm/openvmm_core/src/worker/vm_loaders/uefi.rs
+++ b/openvmm/openvmm_core/src/worker/vm_loaders/uefi.rs
@@ -34,6 +34,7 @@ pub enum Error {
 pub struct UefiLoadSettings {
     pub debugging: bool,
     pub battery: bool,
+    pub hibernation: bool,
     pub memory_protections: bool,
     pub frontpage: bool,
     pub tpm: bool,
@@ -105,7 +106,7 @@ pub fn load_uefi(params: &LoadUefiParams<'_>) -> Result<Vec<Register>, Error> {
         .collect();
 
     let flags = config::Flags::new()
-        .with_hibernate_enabled(true)
+        .with_hibernate_enabled(settings.hibernation)
         .with_serial_controllers_enabled(settings.serial)
         .with_vpci_boot_enabled(settings.vpci_boot)
         .with_debugger_enabled(settings.debugging)

--- a/openvmm/openvmm_defs/src/config.rs
+++ b/openvmm/openvmm_defs/src/config.rs
@@ -61,6 +61,8 @@ pub struct Config {
     pub layout: vmm_core_defs::LayoutConfig,
     // This is used for testing. TODO: resourcify, and also store this in VMGS.
     pub rtc_delta_milliseconds: i64,
+    /// Whether the guest firmware should enable hibernation (S4) support.
+    pub hibernation_enabled: bool,
 }
 
 pub const DEFAULT_GIC_DISTRIBUTOR_BASE: u64 = 0xFFFF_0000;
@@ -142,12 +144,10 @@ pub enum LoadMode {
         enable_vmbus: bool,
         force_dma_bounce: bool,
         enable_hv: bool,
-        enable_hibernation: bool,
     },
     Pcat {
         firmware: RomFileLocation,
         boot_order: [PcatBootDevice; 4],
-        enable_hibernation: bool,
     },
     Igvm {
         file: File,

--- a/openvmm/openvmm_defs/src/config.rs
+++ b/openvmm/openvmm_defs/src/config.rs
@@ -61,8 +61,6 @@ pub struct Config {
     pub layout: vmm_core_defs::LayoutConfig,
     // This is used for testing. TODO: resourcify, and also store this in VMGS.
     pub rtc_delta_milliseconds: i64,
-    /// Whether the guest firmware should enable hibernation (S4) support.
-    pub hibernation_enabled: bool,
 }
 
 pub const DEFAULT_GIC_DISTRIBUTOR_BASE: u64 = 0xFFFF_0000;
@@ -144,10 +142,14 @@ pub enum LoadMode {
         enable_vmbus: bool,
         force_dma_bounce: bool,
         enable_hv: bool,
+        /// Whether the guest firmware should enable hibernation (S4) support.
+        hibernation_enabled: bool,
     },
     Pcat {
         firmware: RomFileLocation,
         boot_order: [PcatBootDevice; 4],
+        /// Whether the guest firmware should enable hibernation (S4) support.
+        hibernation_enabled: bool,
     },
     Igvm {
         file: File,

--- a/openvmm/openvmm_defs/src/config.rs
+++ b/openvmm/openvmm_defs/src/config.rs
@@ -142,10 +142,12 @@ pub enum LoadMode {
         enable_vmbus: bool,
         force_dma_bounce: bool,
         enable_hv: bool,
+        enable_hibernation: bool,
     },
     Pcat {
         firmware: RomFileLocation,
         boot_order: [PcatBootDevice; 4],
+        enable_hibernation: bool,
     },
     Igvm {
         file: File,

--- a/openvmm/openvmm_entry/src/cli_args.rs
+++ b/openvmm/openvmm_entry/src/cli_args.rs
@@ -1097,6 +1097,10 @@ flags:
     #[clap(long)]
     pub battery: bool,
 
+    /// enable guest hibernation (ACPI S4)
+    #[clap(long)]
+    pub hibernation: bool,
+
     /// set the uefi console mode
     #[clap(long)]
     pub uefi_console_mode: Option<UefiConsoleModeCli>,

--- a/openvmm/openvmm_entry/src/cli_args.rs
+++ b/openvmm/openvmm_entry/src/cli_args.rs
@@ -1097,7 +1097,7 @@ flags:
     #[clap(long)]
     pub battery: bool,
 
-    /// enable guest hibernation (ACPI S4)
+    /// enable guest hibernation
     #[clap(long)]
     pub hibernation: bool,
 

--- a/openvmm/openvmm_entry/src/lib.rs
+++ b/openvmm/openvmm_entry/src/lib.rs
@@ -1278,6 +1278,7 @@ async fn vm_config_from_command_line(
                 .pcat_boot_order
                 .map(|x| x.0)
                 .unwrap_or(DEFAULT_PCAT_BOOT_ORDER),
+            hibernation_enabled: opt.hibernation,
         };
     } else if opt.uefi {
         use openvmm_defs::config::UefiConsoleMode;
@@ -1317,6 +1318,7 @@ async fn vm_config_from_command_line(
             enable_vmbus: !opt.no_vmbus,
             force_dma_bounce: opt.uefi_force_dma_bounce,
             enable_hv: !opt.no_hv,
+            hibernation_enabled: opt.hibernation,
         };
     } else {
         // Linux Direct
@@ -1895,11 +1897,9 @@ async fn vm_config_from_command_line(
         );
     }
 
-    let hibernation_enabled = opt.hibernation;
     let mut cfg = Config {
         chipset,
         load_mode,
-        hibernation_enabled,
         floppy_disks,
         pcie_root_complexes,
         pcie_ecam_below_4gb: opt.pcie_ecam_below_4gb,

--- a/openvmm/openvmm_entry/src/lib.rs
+++ b/openvmm/openvmm_entry/src/lib.rs
@@ -1472,7 +1472,7 @@ async fn vm_config_from_command_line(
                         },
                     },
                     enable_battery: opt.battery,
-                    enable_hibernation: false,
+                    enable_hibernation: opt.hibernation,
                     no_persistent_secrets: true,
                     igvm_attest_test_config: None,
                     test_gsp_by_id: opt.test_gsp_by_id,
@@ -1895,7 +1895,7 @@ async fn vm_config_from_command_line(
         );
     }
 
-    let hibernation_enabled = matches!(load_mode, LoadMode::Uefi { .. });
+    let hibernation_enabled = opt.hibernation;
     let mut cfg = Config {
         chipset,
         load_mode,

--- a/openvmm/openvmm_entry/src/lib.rs
+++ b/openvmm/openvmm_entry/src/lib.rs
@@ -1278,7 +1278,6 @@ async fn vm_config_from_command_line(
                 .pcat_boot_order
                 .map(|x| x.0)
                 .unwrap_or(DEFAULT_PCAT_BOOT_ORDER),
-            enable_hibernation: false,
         };
     } else if opt.uefi {
         use openvmm_defs::config::UefiConsoleMode;
@@ -1318,7 +1317,6 @@ async fn vm_config_from_command_line(
             enable_vmbus: !opt.no_vmbus,
             force_dma_bounce: opt.uefi_force_dma_bounce,
             enable_hv: !opt.no_hv,
-            enable_hibernation: true,
         };
     } else {
         // Linux Direct
@@ -1897,9 +1895,11 @@ async fn vm_config_from_command_line(
         );
     }
 
+    let hibernation_enabled = matches!(load_mode, LoadMode::Uefi { .. });
     let mut cfg = Config {
         chipset,
         load_mode,
+        hibernation_enabled,
         floppy_disks,
         pcie_root_complexes,
         pcie_ecam_below_4gb: opt.pcie_ecam_below_4gb,

--- a/openvmm/openvmm_entry/src/lib.rs
+++ b/openvmm/openvmm_entry/src/lib.rs
@@ -1278,6 +1278,7 @@ async fn vm_config_from_command_line(
                 .pcat_boot_order
                 .map(|x| x.0)
                 .unwrap_or(DEFAULT_PCAT_BOOT_ORDER),
+            enable_hibernation: false,
         };
     } else if opt.uefi {
         use openvmm_defs::config::UefiConsoleMode;
@@ -1317,6 +1318,7 @@ async fn vm_config_from_command_line(
             enable_vmbus: !opt.no_vmbus,
             force_dma_bounce: opt.uefi_force_dma_bounce,
             enable_hv: !opt.no_hv,
+            enable_hibernation: true,
         };
     } else {
         // Linux Direct

--- a/openvmm/openvmm_entry/src/lib.rs
+++ b/openvmm/openvmm_entry/src/lib.rs
@@ -1472,6 +1472,7 @@ async fn vm_config_from_command_line(
                         },
                     },
                     enable_battery: opt.battery,
+                    enable_hibernation: false,
                     no_persistent_secrets: true,
                     igvm_attest_test_config: None,
                     test_gsp_by_id: opt.test_gsp_by_id,

--- a/openvmm/openvmm_entry/src/ttrpc/mod.rs
+++ b/openvmm/openvmm_entry/src/ttrpc/mod.rs
@@ -806,7 +806,6 @@ impl VmService {
                         default_boot_always_attempt: false,
                         force_dma_bounce: false,
                         enable_hv: true,
-                        enable_hibernation: true,
                     },
                     vm_manifest_builder::BaseChipsetType::HypervGen2Uefi,
                     Some((base_template, uefi.secure_boot_enabled)),
@@ -886,9 +885,11 @@ impl VmService {
             BuiltPcieTopology::default()
         };
 
+        let hibernation_enabled = matches!(load_mode, LoadMode::Uefi { .. });
         let mut config = Config {
             // TODO: devices, other stuff
             load_mode,
+            hibernation_enabled,
             ide_disks: vec![],
             floppy_disks: vec![],
             pcie_root_complexes: pcie.root_complexes,

--- a/openvmm/openvmm_entry/src/ttrpc/mod.rs
+++ b/openvmm/openvmm_entry/src/ttrpc/mod.rs
@@ -806,6 +806,7 @@ impl VmService {
                         default_boot_always_attempt: false,
                         force_dma_bounce: false,
                         enable_hv: true,
+                        hibernation_enabled: true,
                     },
                     vm_manifest_builder::BaseChipsetType::HypervGen2Uefi,
                     Some((base_template, uefi.secure_boot_enabled)),
@@ -885,11 +886,9 @@ impl VmService {
             BuiltPcieTopology::default()
         };
 
-        let hibernation_enabled = matches!(load_mode, LoadMode::Uefi { .. });
         let mut config = Config {
             // TODO: devices, other stuff
             load_mode,
-            hibernation_enabled,
             ide_disks: vec![],
             floppy_disks: vec![],
             pcie_root_complexes: pcie.root_complexes,

--- a/openvmm/openvmm_entry/src/ttrpc/mod.rs
+++ b/openvmm/openvmm_entry/src/ttrpc/mod.rs
@@ -806,6 +806,7 @@ impl VmService {
                         default_boot_always_attempt: false,
                         force_dma_bounce: false,
                         enable_hv: true,
+                        enable_hibernation: true,
                     },
                     vm_manifest_builder::BaseChipsetType::HypervGen2Uefi,
                     Some((base_template, uefi.secure_boot_enabled)),

--- a/petri/src/lib.rs
+++ b/petri/src/lib.rs
@@ -62,7 +62,7 @@ pub const SIZE_1_GB: u64 = 1024 * SIZE_1_MB;
 pub enum ShutdownKind {
     Shutdown,
     Reboot,
-    // TODO: Add hibernate?
+    Hibernate,
 }
 
 /// Error running command

--- a/petri/src/vm/hyperv/hyperv.psm1
+++ b/petri/src/vm/hyperv/hyperv.psm1
@@ -128,6 +128,8 @@ function New-CustomVM
 
         [bool] $VMBusMessageRedirection = $false,
 
+        [bool] $EnableHibernation = $false,
+
         [string] $FirmwareFile = $null,
 
         [string] $FirmwareParameters = $null,
@@ -233,6 +235,7 @@ function New-CustomVM
         GuestStateIsolationMode    = $GuestStateIsolationMode
         VMBusMessageRedirection    = $VMBusMessageRedirection
         SecureBootEnabled          = $SecureBootEnabled
+        EnableHibernation          = $EnableHibernation
         VirtualNumaEnabled         = $false
         UserSnapshotType           = 2 #disable
     }

--- a/petri/src/vm/hyperv/mod.rs
+++ b/petri/src/vm/hyperv/mod.rs
@@ -591,6 +591,9 @@ impl PetriVmRuntime for HyperVPetriRuntime {
         match kind {
             ShutdownKind::Shutdown => self.vm.stop().await?,
             ShutdownKind::Reboot => self.vm.restart().await?,
+            ShutdownKind::Hibernate => {
+                anyhow::bail!("hibernate is not yet supported on the Hyper-V backend")
+            }
         }
 
         Ok(())

--- a/petri/src/vm/hyperv/powershell.rs
+++ b/petri/src/vm/hyperv/powershell.rs
@@ -305,6 +305,8 @@ pub struct HyperVNewCustomVMArgs {
     pub com_3: bool,
     /// Enable the TPM
     pub tpm_enabled: bool,
+    /// Enable guest hibernation
+    pub hibernation_enabled: bool,
     /// Temporary file containing management VTL settings
     pub management_vtl_settings: Option<NamedTempFile>,
 }
@@ -482,11 +484,6 @@ impl HyperVNewCustomVMArgs {
             ..
         } = config;
 
-        anyhow::ensure!(
-            !config.hibernation_enabled,
-            "hibernation is not yet supported on the Hyper-V backend"
-        );
-
         if firmware
             .openhcl_config()
             .is_some_and(|c| c.vtl2_base_address_type.is_some())
@@ -620,6 +617,7 @@ impl HyperVNewCustomVMArgs {
                 }
                 tpm_enabled
             },
+            hibernation_enabled: config.hibernation_enabled,
             com_1: true,
 
             // specified after creation
@@ -836,6 +834,7 @@ pub async fn run_new_customvm(ps_mod: &Path, args: HyperVNewCustomVMArgs) -> any
             .arg("Com1", args.com_1)
             .arg("Com3", args.com_3)
             .arg("TpmEnabled", args.tpm_enabled)
+            .arg("EnableHibernation", args.hibernation_enabled)
             .arg_opt(
                 "ManagementVtlSettings",
                 args.management_vtl_settings.as_ref().map(|f| f.path()),

--- a/petri/src/vm/hyperv/powershell.rs
+++ b/petri/src/vm/hyperv/powershell.rs
@@ -482,6 +482,11 @@ impl HyperVNewCustomVMArgs {
             ..
         } = config;
 
+        anyhow::ensure!(
+            !config.hibernation_enabled,
+            "hibernation is not yet supported on the Hyper-V backend"
+        );
+
         if firmware
             .openhcl_config()
             .is_some_and(|c| c.vtl2_base_address_type.is_some())

--- a/petri/src/vm/mod.rs
+++ b/petri/src/vm/mod.rs
@@ -1529,6 +1529,16 @@ impl<T: PetriVmmBackend> PetriVmBuilder<T> {
         self
     }
 
+    /// Enable guest hibernation support (OpenHCL DPS `enable_hibernation`).
+    pub fn with_hibernation_enabled(mut self, enable: bool) -> Self {
+        self.config
+            .firmware
+            .openhcl_config_mut()
+            .expect("hibernation is only supported for OpenHCL firmware.")
+            .hibernation_enabled = enable;
+        self
+    }
+
     /// Specify the guest state lifetime for the VM
     pub fn with_guest_state_lifetime(
         mut self,
@@ -2503,6 +2513,9 @@ pub enum OpenvmmLogConfig {
 pub struct OpenHclConfig {
     /// Whether to enable VMBus redirection
     pub vmbus_redirect: bool,
+    /// Whether to enable guest hibernation support (OpenHCL DPS
+    /// `enable_hibernation`).
+    pub hibernation_enabled: bool,
     /// Test-specified command-line parameters to append to the petri generated
     /// command line and pass to OpenHCL. VM backends should use
     /// [`OpenHclConfig::command_line()`] rather than reading this directly.
@@ -2565,6 +2578,7 @@ impl Default for OpenHclConfig {
     fn default() -> Self {
         Self {
             vmbus_redirect: false,
+            hibernation_enabled: false,
             custom_command_line: None,
             log_levels: OpenvmmLogConfig::TestDefault,
             vtl2_base_address_type: None,

--- a/petri/src/vm/mod.rs
+++ b/petri/src/vm/mod.rs
@@ -231,6 +231,8 @@ pub struct PetriVmConfig {
     pub host_log_levels: Option<OpenvmmLogConfig>,
     /// Firmware and/or OS to load into the VM and associated settings
     pub firmware: Firmware,
+    /// Whether to enable guest hibernation support.
+    pub hibernation_enabled: bool,
     /// The amount of memory, in bytes, to assign to the VM
     pub memory: MemoryConfig,
     /// The processor topology for the VM
@@ -458,6 +460,7 @@ impl<T: PetriVmmBackend> PetriVmBuilder<T> {
                 arch: artifacts.arch,
                 host_log_levels: None,
                 firmware: artifacts.firmware,
+                hibernation_enabled: false,
                 memory: Default::default(),
                 proc_topology: Default::default(),
 
@@ -539,6 +542,7 @@ impl<T: PetriVmmBackend> PetriVmBuilder<T> {
                 arch: artifacts.arch,
                 host_log_levels: None,
                 firmware: artifacts.firmware,
+                hibernation_enabled: false,
                 memory: Default::default(),
                 proc_topology: Default::default(),
 
@@ -1529,13 +1533,13 @@ impl<T: PetriVmmBackend> PetriVmBuilder<T> {
         self
     }
 
-    /// Enable guest hibernation support (OpenHCL DPS `enable_hibernation`).
+    /// Enable guest hibernation support.
+    ///
+    /// Applies to any firmware type: for OpenHCL this sets the DPS
+    /// `enable_hibernation` flag; for OpenVMM UEFI/PCAT firmware it enables the
+    /// firmware's hibernation support.
     pub fn with_hibernation_enabled(mut self, enable: bool) -> Self {
-        self.config
-            .firmware
-            .openhcl_config_mut()
-            .expect("hibernation is only supported for OpenHCL firmware.")
-            .hibernation_enabled = enable;
+        self.config.hibernation_enabled = enable;
         self
     }
 
@@ -2513,9 +2517,6 @@ pub enum OpenvmmLogConfig {
 pub struct OpenHclConfig {
     /// Whether to enable VMBus redirection
     pub vmbus_redirect: bool,
-    /// Whether to enable guest hibernation support (OpenHCL DPS
-    /// `enable_hibernation`).
-    pub hibernation_enabled: bool,
     /// Test-specified command-line parameters to append to the petri generated
     /// command line and pass to OpenHCL. VM backends should use
     /// [`OpenHclConfig::command_line()`] rather than reading this directly.
@@ -2578,7 +2579,6 @@ impl Default for OpenHclConfig {
     fn default() -> Self {
         Self {
             vmbus_redirect: false,
-            hibernation_enabled: false,
             custom_command_line: None,
             log_levels: OpenvmmLogConfig::TestDefault,
             vtl2_base_address_type: None,

--- a/petri/src/vm/openvmm/construct.rs
+++ b/petri/src/vm/openvmm/construct.rs
@@ -988,7 +988,8 @@ impl PetriVmConfigSetupCore<'_> {
                 },
             ) => {
                 let OpenHclConfig {
-                    vmbus_redirect: _, // config_openhcl_vmbus_devices
+                    vmbus_redirect: _,      // config_openhcl_vmbus_devices
+                    hibernation_enabled: _, // config_openhcl_vmbus_devices (GED)
                     custom_command_line: _,
                     log_levels: _,
                     vtl2_base_address_type,
@@ -1134,7 +1135,11 @@ impl PetriVmConfigSetupCore<'_> {
                 efi_diagnostics_log_level,
                 efi_diagnostics_rate_limit: _, // applied device-side via UefiManifest::new
             },
-            OpenHclConfig { vmbus_redirect, .. },
+            OpenHclConfig {
+                vmbus_redirect,
+                hibernation_enabled,
+                ..
+            },
         ) = match self.firmware {
             Firmware::OpenhclUefi {
                 uefi_config,
@@ -1182,6 +1187,7 @@ impl PetriVmConfigSetupCore<'_> {
                 None => get_resources::ged::GuestSecureBootTemplateType::None,
             },
             enable_battery: false,
+            enable_hibernation: *hibernation_enabled,
             no_persistent_secrets: self.tpm_config.as_ref().is_some_and(|c| c.no_persistent_secrets),
             igvm_attest_test_config: None,
             test_gsp_by_id,

--- a/petri/src/vm/openvmm/construct.rs
+++ b/petri/src/vm/openvmm/construct.rs
@@ -119,6 +119,7 @@ impl PetriVmConfigOpenVmm {
             arch,
             host_log_levels,
             firmware,
+            hibernation_enabled,
             memory,
             proc_topology,
             vmgs,
@@ -146,6 +147,7 @@ impl PetriVmConfigOpenVmm {
         let setup = PetriVmConfigSetupCore {
             arch,
             firmware: &firmware,
+            hibernation_enabled,
             driver,
             logger: log_source,
             vmgs: &vmgs,
@@ -773,6 +775,7 @@ impl PetriVmConfigOpenVmm {
 struct PetriVmConfigSetupCore<'a> {
     arch: MachineArch,
     firmware: &'a Firmware,
+    hibernation_enabled: bool,
     driver: &'a DefaultDriver,
     logger: &'a PetriLogSource,
     vmgs: &'a PetriVmgsResource,
@@ -928,6 +931,7 @@ impl PetriVmConfigSetupCore<'_> {
                 LoadMode::Pcat {
                     firmware,
                     boot_order: DEFAULT_PCAT_BOOT_ORDER,
+                    enable_hibernation: self.hibernation_enabled,
                 }
             }
             (
@@ -971,6 +975,7 @@ impl PetriVmConfigSetupCore<'_> {
                     enable_vmbus: !self.no_vmbus,
                     force_dma_bounce: *force_dma_bounce,
                     enable_hv: !self.no_hv,
+                    enable_hibernation: self.hibernation_enabled,
                 }
             }
             (
@@ -988,8 +993,7 @@ impl PetriVmConfigSetupCore<'_> {
                 },
             ) => {
                 let OpenHclConfig {
-                    vmbus_redirect: _,      // config_openhcl_vmbus_devices
-                    hibernation_enabled: _, // config_openhcl_vmbus_devices (GED)
+                    vmbus_redirect: _, // config_openhcl_vmbus_devices
                     custom_command_line: _,
                     log_levels: _,
                     vtl2_base_address_type,
@@ -1135,11 +1139,7 @@ impl PetriVmConfigSetupCore<'_> {
                 efi_diagnostics_log_level,
                 efi_diagnostics_rate_limit: _, // applied device-side via UefiManifest::new
             },
-            OpenHclConfig {
-                vmbus_redirect,
-                hibernation_enabled,
-                ..
-            },
+            OpenHclConfig { vmbus_redirect, .. },
         ) = match self.firmware {
             Firmware::OpenhclUefi {
                 uefi_config,
@@ -1187,7 +1187,7 @@ impl PetriVmConfigSetupCore<'_> {
                 None => get_resources::ged::GuestSecureBootTemplateType::None,
             },
             enable_battery: false,
-            enable_hibernation: *hibernation_enabled,
+            enable_hibernation: self.hibernation_enabled,
             no_persistent_secrets: self.tpm_config.as_ref().is_some_and(|c| c.no_persistent_secrets),
             igvm_attest_test_config: None,
             test_gsp_by_id,

--- a/petri/src/vm/openvmm/construct.rs
+++ b/petri/src/vm/openvmm/construct.rs
@@ -181,6 +181,7 @@ impl PetriVmConfigOpenVmm {
         );
 
         let mut load_mode = setup.load_firmware()?;
+        let hibernation_enabled = setup.hibernation_enabled;
 
         // If using pipette-as-init, replace the initrd with the pre-built
         // one that has pipette injected. run_core() guarantees that
@@ -642,6 +643,7 @@ impl PetriVmConfigOpenVmm {
         let config = Config {
             // Firmware
             load_mode,
+            hibernation_enabled,
             firmware_event_send: Some(firmware_event_send),
 
             // CPU and RAM
@@ -931,7 +933,6 @@ impl PetriVmConfigSetupCore<'_> {
                 LoadMode::Pcat {
                     firmware,
                     boot_order: DEFAULT_PCAT_BOOT_ORDER,
-                    enable_hibernation: self.hibernation_enabled,
                 }
             }
             (
@@ -975,7 +976,6 @@ impl PetriVmConfigSetupCore<'_> {
                     enable_vmbus: !self.no_vmbus,
                     force_dma_bounce: *force_dma_bounce,
                     enable_hv: !self.no_hv,
-                    enable_hibernation: self.hibernation_enabled,
                 }
             }
             (

--- a/petri/src/vm/openvmm/construct.rs
+++ b/petri/src/vm/openvmm/construct.rs
@@ -181,7 +181,6 @@ impl PetriVmConfigOpenVmm {
         );
 
         let mut load_mode = setup.load_firmware()?;
-        let hibernation_enabled = setup.hibernation_enabled;
 
         // If using pipette-as-init, replace the initrd with the pre-built
         // one that has pipette injected. run_core() guarantees that
@@ -643,7 +642,6 @@ impl PetriVmConfigOpenVmm {
         let config = Config {
             // Firmware
             load_mode,
-            hibernation_enabled,
             firmware_event_send: Some(firmware_event_send),
 
             // CPU and RAM
@@ -933,6 +931,7 @@ impl PetriVmConfigSetupCore<'_> {
                 LoadMode::Pcat {
                     firmware,
                     boot_order: DEFAULT_PCAT_BOOT_ORDER,
+                    hibernation_enabled: self.hibernation_enabled,
                 }
             }
             (
@@ -976,6 +975,7 @@ impl PetriVmConfigSetupCore<'_> {
                     enable_vmbus: !self.no_vmbus,
                     force_dma_bounce: *force_dma_bounce,
                     enable_hv: !self.no_hv,
+                    hibernation_enabled: self.hibernation_enabled,
                 }
             }
             (

--- a/petri/src/vm/openvmm/runtime.rs
+++ b/petri/src/vm/openvmm/runtime.rs
@@ -472,6 +472,9 @@ impl PetriVmInner {
                             hyperv_ic_resources::shutdown::ShutdownType::PowerOff
                         }
                         ShutdownKind::Reboot => hyperv_ic_resources::shutdown::ShutdownType::Reboot,
+                        ShutdownKind::Hibernate => {
+                            hyperv_ic_resources::shutdown::ShutdownType::Hibernate
+                        }
                     },
                     force: false,
                 },

--- a/vm/devices/get/get_resources/src/lib.rs
+++ b/vm/devices/get/get_resources/src/lib.rs
@@ -87,8 +87,6 @@ pub mod ged {
         pub secure_boot_template: GuestSecureBootTemplateType,
         /// Enable battery.
         pub enable_battery: bool,
-        /// Enable hibernation.
-        pub enable_hibernation: bool,
         /// Suppress attestation and disable TPM state persistence.
         pub no_persistent_secrets: bool,
         /// Test configuration for IGVM Attest message.
@@ -99,6 +97,10 @@ pub mod ged {
         pub efi_diagnostics_log_level: EfiDiagnosticsLogLevelType,
         /// Force UEFI to bounce-buffer all DMA traffic.
         pub force_dma_bounce_enabled: bool,
+        /// Enable hibernation.
+        // Keep at the end: `MeshPayload` numbers fields by declaration order, so
+        // new fields must be appended to preserve wire compatibility.
+        pub enable_hibernation: bool,
     }
 
     /// The firmware and chipset configuration for the guest.

--- a/vm/devices/get/get_resources/src/lib.rs
+++ b/vm/devices/get/get_resources/src/lib.rs
@@ -98,8 +98,6 @@ pub mod ged {
         /// Force UEFI to bounce-buffer all DMA traffic.
         pub force_dma_bounce_enabled: bool,
         /// Enable hibernation.
-        // Keep at the end: `MeshPayload` numbers fields by declaration order, so
-        // new fields must be appended to preserve wire compatibility.
         pub enable_hibernation: bool,
     }
 

--- a/vm/devices/get/get_resources/src/lib.rs
+++ b/vm/devices/get/get_resources/src/lib.rs
@@ -87,6 +87,8 @@ pub mod ged {
         pub secure_boot_template: GuestSecureBootTemplateType,
         /// Enable battery.
         pub enable_battery: bool,
+        /// Enable hibernation.
+        pub enable_hibernation: bool,
         /// Suppress attestation and disable TPM state persistence.
         pub no_persistent_secrets: bool,
         /// Test configuration for IGVM Attest message.

--- a/vm/devices/get/guest_emulation_device/src/lib.rs
+++ b/vm/devices/get/guest_emulation_device/src/lib.rs
@@ -1132,10 +1132,10 @@ impl<T: RingMem + Unpin> GedChannel<T> {
         let msg = get_protocol::PowerOffNotification::read_from_prefix(message_buf)
             .map_err(|_| Error::MessageTooSmall)?
             .0; // TODO: zerocopy: map_err (https://github.com/microsoft/openvmm/issues/759)
-        let request = if msg.hibernate.0 != 0 {
-            PowerRequest::Hibernate
-        } else {
-            PowerRequest::PowerOff
+        let request = match msg.hibernate.0 {
+            0 => PowerRequest::PowerOff,
+            1 => PowerRequest::Hibernate,
+            _ => return Err(Error::InvalidFieldValue),
         };
         state.power_client.power_request(request);
         Ok(())

--- a/vm/devices/get/guest_emulation_device/src/lib.rs
+++ b/vm/devices/get/guest_emulation_device/src/lib.rs
@@ -1094,7 +1094,7 @@ impl<T: RingMem + Unpin> GedChannel<T> {
     ) -> Result<(), Error> {
         match header.message_id() {
             HostNotifications::POWER_OFF => {
-                self.handle_power_off(state);
+                self.handle_power_off(message_buf, state)?;
             }
             HostNotifications::RESET => {
                 self.handle_reset(state);
@@ -1124,8 +1124,21 @@ impl<T: RingMem + Unpin> GedChannel<T> {
         Ok(())
     }
 
-    fn handle_power_off(&mut self, state: &mut GuestEmulationDevice) {
-        state.power_client.power_request(PowerRequest::PowerOff);
+    fn handle_power_off(
+        &mut self,
+        message_buf: &[u8],
+        state: &mut GuestEmulationDevice,
+    ) -> Result<(), Error> {
+        let msg = get_protocol::PowerOffNotification::read_from_prefix(message_buf)
+            .map_err(|_| Error::MessageTooSmall)?
+            .0; // TODO: zerocopy: map_err (https://github.com/microsoft/openvmm/issues/759)
+        let request = if msg.hibernate.0 != 0 {
+            PowerRequest::Hibernate
+        } else {
+            PowerRequest::PowerOff
+        };
+        state.power_client.power_request(request);
+        Ok(())
     }
 
     fn handle_reset(&mut self, state: &mut GuestEmulationDevice) {

--- a/vm/devices/get/guest_emulation_device/src/lib.rs
+++ b/vm/devices/get/guest_emulation_device/src/lib.rs
@@ -148,6 +148,8 @@ pub struct GuestConfig {
     pub secure_boot_template: SecureBootTemplateType,
     /// Enable battery.
     pub enable_battery: bool,
+    /// Enable hibernation.
+    pub enable_hibernation: bool,
     /// Suppress attestation.
     pub no_persistent_secrets: bool,
     /// Guest state lifetime
@@ -1348,6 +1350,7 @@ impl<T: RingMem + Unpin> GedChannel<T> {
                     _ => panic!("Invalid secure boot template"),
                 },
                 enable_battery: state.config.enable_battery,
+                enable_hibernation: state.config.enable_hibernation,
                 console_mode: uefi_console_mode.unwrap_or(UefiConsoleMode::DEFAULT).0,
                 bios_guid: if state.test_gsp_by_id {
                     guid::guid!("2b701019-2816-4a85-9692-3981f1af4423")

--- a/vm/devices/get/guest_emulation_device/src/resolver.rs
+++ b/vm/devices/get/guest_emulation_device/src/resolver.rs
@@ -193,6 +193,7 @@ impl AsyncResolveResource<VmbusDeviceHandleKind, GuestEmulationDeviceHandle>
                     }
                 },
                 enable_battery: resource.enable_battery,
+                enable_hibernation: resource.enable_hibernation,
                 no_persistent_secrets: resource.no_persistent_secrets,
                 guest_state_lifetime,
                 guest_state_encryption_policy,

--- a/vm/devices/get/guest_emulation_device/src/test_utilities.rs
+++ b/vm/devices/get/guest_emulation_device/src/test_utilities.rs
@@ -257,6 +257,7 @@ pub fn create_host_channel(
         secure_boot_enabled: false,
         secure_boot_template: SecureBootTemplateType::SECURE_BOOT_DISABLED,
         enable_battery: false,
+        enable_hibernation: false,
         no_persistent_secrets: true,
         guest_state_lifetime: Default::default(),
         guest_state_encryption_policy: Default::default(),

--- a/vmm_core/virt_mshv/src/aarch64/mod.rs
+++ b/vmm_core/virt_mshv/src/aarch64/mod.rs
@@ -605,6 +605,9 @@ impl MshvProcessor<'_> {
                     hvdef::HvArm64ResetType::REBOOT => {
                         return Err(VpHaltReason::Reset);
                     }
+                    hvdef::HvArm64ResetType::HIBERNATE => {
+                        return Err(VpHaltReason::Hibernate);
+                    }
                     _ => {
                         tracelimit::warn_ratelimited!(
                             reset_type = ?info.reset_type,

--- a/vmm_core/virt_whp/src/lib.rs
+++ b/vmm_core/virt_whp/src/lib.rs
@@ -1618,6 +1618,16 @@ impl VtlPartition {
                     #[cfg(guest_arch = "aarch64")]
                     {
                         features.bank0 |= F::AccessVpRegs | F::SyncContext | F::TbFlushHypercalls;
+
+                        // Opt into delivery of the system-reset intercept family
+                        // (PSCI SYSTEM_OFF2/hibernate, SYSTEM_RESET2) when the
+                        // hypervisor advertises it.
+                        if supported_synth_features
+                            .bank0
+                            .is_set(F::InterceptSystemReset)
+                        {
+                            features.bank0 |= F::InterceptSystemReset;
+                        }
                     }
 
                     if vtl == Vtl::Vtl0 {

--- a/vmm_tests/vmm_tests/tests/tests/multiarch.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch.rs
@@ -27,6 +27,8 @@ use vmm_test_macros::vmm_test_with;
 
 /// Test for the Windows DirectIO (`-net dio`) network backend.
 mod dio_nic;
+/// Guest hibernation and OpenHCL hibernate token tests.
+mod hibernate;
 /// Nested-virtualization test: Hyper-V role + DDA inside an OpenVMM guest.
 mod hyperv_nested;
 /// Tests for Hyper-V integration components.

--- a/vmm_tests/vmm_tests/tests/tests/multiarch/hibernate.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch/hibernate.rs
@@ -1,0 +1,146 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Tests for guest hibernation and the OpenHCL hibernate token.
+//!
+//! These boot the `guest_test_uefi` image with its `PetriBootAction=hibernate`
+//! selector set, so the guest requests a real platform hibernation at startup
+//! (x86_64 via the ACPI PM control register, aarch64 via PSCI `SYSTEM_OFF2`).
+
+use petri::PetriGuestStateLifetime;
+use petri::PetriHaltReason;
+use petri::PetriVmBuilder;
+use petri::PetriVmmBackend;
+use petri::ResolvedArtifact;
+use petri::run_host_cmd;
+use petri_artifacts_common::tags::IsVmgsTool;
+use petri_artifacts_vmm_test::artifacts::vmgstool::VMGSTOOL_NATIVE;
+use std::process::Command;
+use vmm_test_macros::vmm_test_with;
+
+/// A `CUSTOM_UEFI` NVRAM delta that seeds the `PetriBootAction` EFI global
+/// variable with the value `hibernate`, selecting the guest's hibernate action.
+/// The `guid`/`attributes`/`value` fields are base64: `guid` is the EFI global
+/// variable GUID (`8be4df61-93ca-11d2-aa0d-00e098032b8c`), `attributes` is
+/// `0x07` (NV | BS | RT), and `value` is the ASCII string `hibernate`.
+const HIBERNATE_ACTION_JSON: &[u8] = br#"{
+    "type": "Microsoft.Compute/disks",
+    "properties": {
+        "uefiSettings": {
+            "signatureMode": "Append",
+            "signatures": {},
+            "PetriBootAction": {
+                "guid": "Yd/ki8qT0hGqDQDgmAMrjA==",
+                "attributes": "Bw==",
+                "value": "aGliZXJuYXRl"
+            }
+        }
+    }
+}"#;
+
+/// Little-endian encoding of `hibernate::Token::CURRENT` (`Hibernated { 1, 9 }`,
+/// i.e. `0x0109`) as written to `vmgs::FileId::HIBERNATION_TOKEN`. Keep in sync
+/// with `underhill_core::hibernate::Token::CURRENT`.
+const HIBERNATE_TOKEN_CURRENT: [u8; 8] = [0x09, 0x01, 0, 0, 0, 0, 0, 0];
+
+/// Verify that a guest hibernation request halts the VM with a hibernate reason.
+///
+/// This exercises the non-paravisor path: the guest's power request reaches the
+/// host emulation directly (x86_64 ACPI PM device, aarch64 reset intercept).
+#[vmm_test_with(
+    noagent,
+    configs(
+        openvmm_uefi_x64(guest_test_uefi_x64),
+        openvmm_uefi_aarch64(guest_test_uefi_aarch64)
+    )
+)]
+async fn hibernate_halts<T: PetriVmmBackend>(config: PetriVmBuilder<T>) -> anyhow::Result<()> {
+    let vm = config
+        .with_windows_secure_boot_template()
+        .with_custom_uefi_json(HIBERNATE_ACTION_JSON)
+        .run_without_agent()
+        .await?;
+
+    let halt_reason = vm.wait_for_teardown().await?;
+    if halt_reason.reason != PetriHaltReason::Hibernate {
+        anyhow::bail!("expected Hibernate, got {halt_reason:?}");
+    }
+
+    Ok(())
+}
+
+/// Verify that an OpenHCL guest hibernation writes the hibernate token to VMGS.
+///
+/// The guest requests hibernation; OpenHCL records the current firmware version
+/// in `HIBERNATION_TOKEN` before notifying the host, which then surfaces a
+/// hibernate halt. Afterwards the persisted token is read back from VMGS.
+#[vmm_test_with(
+    noagent,
+    configs(
+        openvmm_openhcl_uefi_x64(guest_test_uefi_x64)[VMGSTOOL_NATIVE],
+        openvmm_openhcl_uefi_aarch64(guest_test_uefi_aarch64)[VMGSTOOL_NATIVE]
+    )
+)]
+async fn hibernate_token<T: PetriVmmBackend>(
+    config: PetriVmBuilder<T>,
+    (vmgstool,): (ResolvedArtifact<impl IsVmgsTool>,),
+) -> anyhow::Result<()> {
+    let temp_dir = tempfile::tempdir()?;
+    let vmgs_path = temp_dir.path().join("test.vmgs");
+    let vmgstool_path = vmgstool.get();
+
+    // Create a VMGS and seed the hibernate action selector into CUSTOM_UEFI.
+    let mut cmd = Command::new(vmgstool_path);
+    cmd.arg("create").arg("--filepath").arg(&vmgs_path);
+    run_host_cmd(cmd).await?;
+
+    let json_path = temp_dir.path().join("action.json");
+    std::fs::write(&json_path, HIBERNATE_ACTION_JSON)?;
+
+    let mut cmd = Command::new(vmgstool_path);
+    cmd.arg("write")
+        .arg("--filepath")
+        .arg(&vmgs_path)
+        .arg("--data-path")
+        .arg(&json_path)
+        .arg("--file-id")
+        .arg("CUSTOM_UEFI");
+    run_host_cmd(cmd).await?;
+
+    // Boot: the guest reads the selector and requests hibernation.
+    let mut vm = config
+        .with_windows_secure_boot_template()
+        .with_hibernation_enabled(true)
+        .with_guest_state_lifetime(PetriGuestStateLifetime::Disk)
+        .with_persistent_vmgs(&vmgs_path)
+        .run_without_agent()
+        .await?;
+
+    let halt_reason = vm.wait_for_halt().await?;
+    if halt_reason.reason != PetriHaltReason::Hibernate {
+        anyhow::bail!("expected Hibernate, got {halt_reason:?}");
+    }
+
+    // Hyper-V VMs copy the VMGS rather than use it in-place; use the real path.
+    let vmgs_path = vm.get_guest_state_file().await?.unwrap_or(vmgs_path);
+    vm.teardown().await?;
+
+    // The hibernate token must record the current firmware version.
+    let token_path = temp_dir.path().join("token.bin");
+    let mut cmd = Command::new(vmgstool_path);
+    cmd.arg("dump")
+        .arg("--filepath")
+        .arg(&vmgs_path)
+        .arg("--data-path")
+        .arg(&token_path)
+        .arg("--file-id")
+        .arg("HIBERNATION_TOKEN");
+    run_host_cmd(cmd).await?;
+
+    let token = std::fs::read(&token_path)?;
+    if token != HIBERNATE_TOKEN_CURRENT {
+        anyhow::bail!("HIBERNATION_TOKEN = {token:02x?}, expected {HIBERNATE_TOKEN_CURRENT:02x?}");
+    }
+
+    Ok(())
+}

--- a/vmm_tests/vmm_tests/tests/tests/multiarch/hibernate.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch/hibernate.rs
@@ -122,8 +122,6 @@ async fn hibernate_token<T: PetriVmmBackend>(
         anyhow::bail!("expected Hibernate, got {halt_reason:?}");
     }
 
-    // Hyper-V VMs copy the VMGS rather than use it in-place; use the real path.
-    let vmgs_path = vm.get_guest_state_file().await?.unwrap_or(vmgs_path);
     vm.teardown().await?;
 
     // The hibernate token must record the current firmware version.

--- a/vmm_tests/vmm_tests/tests/tests/multiarch/hibernate.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch/hibernate.rs
@@ -57,6 +57,7 @@ const HIBERNATE_TOKEN_CURRENT: [u8; 8] = [0x09, 0x01, 0, 0, 0, 0, 0, 0];
 async fn hibernate_halts<T: PetriVmmBackend>(config: PetriVmBuilder<T>) -> anyhow::Result<()> {
     let vm = config
         .with_windows_secure_boot_template()
+        .with_hibernation_enabled(true)
         .with_custom_uefi_json(HIBERNATE_ACTION_JSON)
         .run_without_agent()
         .await?;

--- a/vmm_tests/vmm_tests/tests/tests/multiarch/hibernate.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch/hibernate.rs
@@ -47,13 +47,13 @@ const HIBERNATE_TOKEN_CURRENT: [u8; 8] = [0x09, 0x01, 0, 0, 0, 0, 0, 0];
 ///
 /// This exercises the non-paravisor path: the guest's power request reaches the
 /// host emulation directly (x86_64 ACPI PM device, aarch64 reset intercept).
-#[vmm_test_with(
-    noagent,
-    configs(
-        openvmm_uefi_x64(guest_test_uefi_x64),
-        openvmm_uefi_aarch64(guest_test_uefi_aarch64)
-    )
-)]
+///
+/// Only x86_64 runs in CI. The aarch64 path is fully scaffolded (guest PSCI
+/// `SYSTEM_OFF2` in `guest_test_uefi`, `virt_whp` `InterceptSystemReset`, and the
+/// reset-intercept mapping), but the WHP-based aarch64-windows runner does not
+/// surface the hibernate intercept, so its config is omitted until the
+/// hypervisor delivers it.
+#[vmm_test_with(noagent, configs(openvmm_uefi_x64(guest_test_uefi_x64)))]
 async fn hibernate_halts<T: PetriVmmBackend>(config: PetriVmBuilder<T>) -> anyhow::Result<()> {
     let vm = config
         .with_windows_secure_boot_template()
@@ -79,12 +79,12 @@ async fn hibernate_halts<T: PetriVmmBackend>(config: PetriVmBuilder<T>) -> anyho
 /// The guest requests hibernation; OpenHCL records the current firmware version
 /// in `HIBERNATION_TOKEN` before notifying the host, which then surfaces a
 /// hibernate halt. Afterwards the persisted token is read back from VMGS.
+///
+/// Only x86_64 runs in CI; see `hibernate_halts` for why the aarch64 config is
+/// omitted pending WHP hibernate-intercept support.
 #[vmm_test_with(
     noagent,
-    configs(
-        openvmm_openhcl_uefi_x64(guest_test_uefi_x64)[VMGSTOOL_NATIVE],
-        openvmm_openhcl_uefi_aarch64(guest_test_uefi_aarch64)[VMGSTOOL_NATIVE]
-    )
+    configs(openvmm_openhcl_uefi_x64(guest_test_uefi_x64)[VMGSTOOL_NATIVE])
 )]
 async fn hibernate_token<T: PetriVmmBackend>(
     config: PetriVmBuilder<T>,

--- a/vmm_tests/vmm_tests/tests/tests/multiarch/hibernate.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch/hibernate.rs
@@ -79,9 +79,7 @@ async fn hibernate_halts<T: PetriVmmBackend>(config: PetriVmBuilder<T>) -> anyho
     noagent,
     configs(
         openvmm_openhcl_uefi_x64(guest_test_uefi_x64)[VMGSTOOL_NATIVE],
-        openvmm_openhcl_uefi_aarch64(guest_test_uefi_aarch64)[VMGSTOOL_NATIVE],
-        hyperv_openhcl_uefi_x64(guest_test_uefi_x64)[VMGSTOOL_NATIVE],
-        hyperv_openhcl_uefi_aarch64(guest_test_uefi_aarch64)[VMGSTOOL_NATIVE]
+        openvmm_openhcl_uefi_aarch64(guest_test_uefi_aarch64)[VMGSTOOL_NATIVE]
     )
 )]
 async fn hibernate_token<T: PetriVmmBackend>(
@@ -124,9 +122,6 @@ async fn hibernate_token<T: PetriVmmBackend>(
         anyhow::bail!("expected Hibernate, got {halt_reason:?}");
     }
 
-    // Read the token from the VMGS the VM actually used (the Hyper-V backend
-    // may relocate it out of the temp dir).
-    let vmgs_path = vm.get_guest_state_file().await?.unwrap_or(vmgs_path);
     vm.teardown().await?;
 
     // The hibernate token must record the current firmware version.

--- a/vmm_tests/vmm_tests/tests/tests/multiarch/hibernate.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch/hibernate.rs
@@ -59,6 +59,10 @@ async fn hibernate_halts<T: PetriVmmBackend>(config: PetriVmBuilder<T>) -> anyho
         .with_windows_secure_boot_template()
         .with_hibernation_enabled(true)
         .with_custom_uefi_json(HIBERNATE_ACTION_JSON)
+        // Seeding custom UEFI NVRAM leaves the boot order empty, so force the
+        // firmware to fall back to the guest_test_uefi removable-media loader
+        // (required on aarch64, where the fallback is otherwise skipped).
+        .with_default_boot_always_attempt(true)
         .run_without_agent()
         .await?;
 
@@ -112,6 +116,10 @@ async fn hibernate_token<T: PetriVmmBackend>(
     let mut vm = config
         .with_windows_secure_boot_template()
         .with_hibernation_enabled(true)
+        // The seeded CUSTOM_UEFI leaves the boot order empty, so force the
+        // firmware to fall back to the guest_test_uefi removable-media loader
+        // (required on aarch64, where the fallback is otherwise skipped).
+        .with_default_boot_always_attempt(true)
         .with_guest_state_lifetime(PetriGuestStateLifetime::Disk)
         .with_persistent_vmgs(&vmgs_path)
         .run_without_agent()

--- a/vmm_tests/vmm_tests/tests/tests/multiarch/hibernate.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch/hibernate.rs
@@ -79,7 +79,9 @@ async fn hibernate_halts<T: PetriVmmBackend>(config: PetriVmBuilder<T>) -> anyho
     noagent,
     configs(
         openvmm_openhcl_uefi_x64(guest_test_uefi_x64)[VMGSTOOL_NATIVE],
-        openvmm_openhcl_uefi_aarch64(guest_test_uefi_aarch64)[VMGSTOOL_NATIVE]
+        openvmm_openhcl_uefi_aarch64(guest_test_uefi_aarch64)[VMGSTOOL_NATIVE],
+        hyperv_openhcl_uefi_x64(guest_test_uefi_x64)[VMGSTOOL_NATIVE],
+        hyperv_openhcl_uefi_aarch64(guest_test_uefi_aarch64)[VMGSTOOL_NATIVE]
     )
 )]
 async fn hibernate_token<T: PetriVmmBackend>(
@@ -122,6 +124,9 @@ async fn hibernate_token<T: PetriVmmBackend>(
         anyhow::bail!("expected Hibernate, got {halt_reason:?}");
     }
 
+    // Read the token from the VMGS the VM actually used (the Hyper-V backend
+    // may relocate it out of the temp dir).
+    let vmgs_path = vm.get_guest_state_file().await?.unwrap_or(vmgs_path);
     vm.teardown().await?;
 
     // The hibernate token must record the current firmware version.


### PR DESCRIPTION
## Summary

Adds VMM test coverage for guest hibernation and the OpenHCL hibernate token, plus the petri/guest plumbing needed to trigger and observe a hibernation from a test.

There was previously no test coverage for the OpenHCL hibernate token flow. These tests drive a hardware-level hibernation request from the in-tree `guest_test_uefi` guest and assert the resulting halt reason and the token persisted to VMGS.

## Not included (follow-ups)

- Resume half (boot2 "resume under the current firmware version" + token consumed) — needs a two-boot harness.
- A `poweroff` guest action to cover the `NotHibernated` token transition.
