### PR TITLE
x86emu: Inject GP on non-emulatable instructions (#4287)

### DIFF
--- a/vmm_core/virt_support_x86emu/src/emulate.rs
+++ b/vmm_core/virt_support_x86emu/src/emulate.rs
@@ -493,13 +493,9 @@ async fn emulate_core<T: EmulatorSupport>(
                     error = &err as &dyn std::error::Error,
                     ?instruction_bytes,
                     physical_address = cpu.support.physical_address(),
-                    "given an instruction that we shouldn't have been asked to emulate - likely a bug in the caller"
+                    "given an instruction that we shouldn't have been asked to emulate"
                 );
-
-                return Err(EmulationError::Emulator {
-                    bytes: instruction_bytes.to_vec(),
-                    error: err,
-                });
+                cpu.support.inject_pending_event(gpf_event());
             }
             x86emu::Error::InstructionException(exception, error_code, cause) => {
                 tracing::trace!(


### PR DESCRIPTION
One of the first things our instruction emulator does before emulating an instruction is check if that instruction actually touches memory or ports. If it doesn't, it will refuse to emulate the instruction, even if it knows how. This is because such cases are indicative of some sort of bug; instructions that don't touch memory or ports shouldn't cause an exit during normal operation. Historically these bugs have been ours, so such a case triggered a panic so we could investigate. However we're now seeing a case that appears to be due to a guest bug. Change this panic behavior to inject a GP instead to fail the guest without crashing ourselves. This matches the behavior of Hyper-V's instruction emulator.

Clean cherry-pick of #4287 