### PR TITLE
virtiofs: preserve initial handle value when clearing HandleMap

### DIFF
--- a/vm/devices/virtio/virtiofs/src/lib.rs
+++ b/vm/devices/virtio/virtiofs/src/lib.rs
@@ -667,6 +667,7 @@ impl VirtioFs {
 /// A key/value map where the keys are automatically incremented identifiers.
 struct HandleMap<T> {
     values: HashMap<u64, T>,
+    initial_handle: u64,
     next_handle: u64,
 }
 
@@ -680,6 +681,7 @@ impl<T> HandleMap<T> {
     pub fn starting_at(next_handle: u64) -> Self {
         Self {
             values: HashMap::new(),
+            initial_handle: next_handle,
             next_handle,
         }
     }
@@ -714,7 +716,7 @@ impl<T> HandleMap<T> {
     /// Clears the map and resets the handle values.
     pub fn clear(&mut self) {
         self.values.clear();
-        self.next_handle = 1;
+        self.next_handle = self.initial_handle;
     }
 }
 
@@ -806,7 +808,6 @@ impl InodeMap {
             // Node 1 is synthetic and not stored here; drop everything and resume
             // allocating node IDs after the reserved root id.
             self.inodes_by_node_id.clear();
-            self.inodes_by_node_id.next_handle = FUSE_ROOT_ID + 1;
             self.inodes_by_key.clear();
             return;
         }


### PR DESCRIPTION
Fixes #4274.

`HandleMap::clear()` previously reset `next_handle` to `1`, regardless of the value supplied to `HandleMap::starting_at()`. For `SectionFs`, which starts allocation at `2` because node ID `1` is reserved for the synthetic FUSE root, this caused the first node allocated after `FUSE_DESTROY` to incorrectly use `FUSE_ROOT_ID`.

Linux rejects that node ID, causing the first file creation in a remounted session to fail with `EIO`. 

This change makes `HandleMap` retain its initial handle and restore it when cleared. It also removes the now-redundant manual reset from `InodeMap::clear()`.