### PR TITLE
xtask: Fix the workspaced lint running with --only-diffed

### DIFF
--- a/xtask/src/tasks/fmt/lints/workspaced.rs
+++ b/xtask/src/tasks/fmt/lints/workspaced.rs
@@ -171,7 +171,7 @@ impl Lint for WorkspacedManifest {
     }
 
     fn exit_workspace(&mut self, content: &mut Lintable<DocumentMut>) {
-        // Any members or dependencies that we expected to see but didn't are errors,
+        // Any workspace members that we expected to see but didn't are errors,
         // unless we're only checking diffs, in which case we know we'll miss crates.
         if !self.only_diffed {
             for member in self.members.iter() {

--- a/xtask/src/tasks/fmt/lints/workspaced.rs
+++ b/xtask/src/tasks/fmt/lints/workspaced.rs
@@ -29,14 +29,18 @@ pub struct WorkspacedManifest {
     members: Vec<PathBuf>,
     excluded: Vec<PathBuf>,
     dependencies: Vec<PathBuf>,
+
+    only_diffed: bool,
 }
 
 impl Lint for WorkspacedManifest {
-    fn new(_ctx: &LintCtx) -> Self {
+    fn new(ctx: &LintCtx) -> Self {
         WorkspacedManifest {
             members: Vec::new(),
             excluded: Vec::new(),
             dependencies: Vec::new(),
+
+            only_diffed: ctx.only_diffed,
         }
     }
 
@@ -167,12 +171,15 @@ impl Lint for WorkspacedManifest {
     }
 
     fn exit_workspace(&mut self, content: &mut Lintable<DocumentMut>) {
-        // Any members or dependencies that we expected to see but didn't are errors
-        for member in self.members.iter() {
-            content.unfixable(&format!(
-                "workspace member {} does not exist",
-                member.display()
-            ));
+        // Any members or dependencies that we expected to see but didn't are errors,
+        // unless we're only checking diffs, in which case we know we'll miss crates.
+        if !self.only_diffed {
+            for member in self.members.iter() {
+                content.unfixable(&format!(
+                    "workspace member {} does not exist",
+                    member.display()
+                ));
+            }
         }
         // Dependencies that we didn't see may be from other workspaces, as is done in the internal repo, so they're allowed
         // Exclusions that we didn't see may be nested workspaces, which don't get visited, so they're allowed


### PR DESCRIPTION
We know that when running with --only-diffed we will not process every crate in the workspace, so don't assume we are.