### PR TITLE
ci: cache vhds on self-hosted runners

### DIFF
--- a/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
+++ b/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
@@ -30,7 +30,6 @@ use flowey_lib_hvlite::install_vmm_tests_external_deps::VmmTestsExternalDepsLinu
 use flowey_lib_hvlite::install_vmm_tests_external_deps::VmmTestsExternalDepsWindows;
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
-use std::path::PathBuf;
 use target_lexicon::Triple;
 use vmm_test_images::KnownTestArtifacts;
 
@@ -61,10 +60,6 @@ pub struct CheckinGatesCli {
 
     #[clap(flatten)]
     local_run_args: Option<crate::pipelines_shared::cfg_common_params::LocalRunArgs>,
-
-    /// Set custom path to search for / download VMM tests disk-images
-    #[clap(long)]
-    vmm_tests_disk_cache_dir: Option<PathBuf>,
 }
 
 impl IntoPipeline for CheckinGatesCli {
@@ -72,7 +67,6 @@ impl IntoPipeline for CheckinGatesCli {
         let Self {
             config,
             local_run_args,
-            vmm_tests_disk_cache_dir,
         } = self;
 
         let release = match config {
@@ -1751,15 +1745,6 @@ impl IntoPipeline for CheckinGatesCli {
                     done: ctx.new_done_handle(),
                 }
             });
-
-            if let Some(vmm_tests_disk_cache_dir) = vmm_tests_disk_cache_dir.clone() {
-                vmm_tests_run_job = vmm_tests_run_job.config(
-                    flowey_lib_hvlite::download_openvmm_vmm_tests_artifacts::Config {
-                        custom_cache_dir: Some(vmm_tests_disk_cache_dir),
-                        ..Default::default()
-                    },
-                );
-            }
 
             let vmm_tests_run_job = vmm_tests_run_job.finish();
             if !label.contains("snp") {

--- a/flowey/flowey_lib_hvlite/src/_jobs/local_build_and_run_nextest_vmm_tests.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/local_build_and_run_nextest_vmm_tests.rs
@@ -847,7 +847,6 @@ pub(crate) fn init_artifacts_dir(
     skip_vhd_prompt: bool,
 ) -> anyhow::Result<()> {
     let vmm_test_artifacts_dir = test_content_dir.join("images");
-    fs_err::create_dir_all(&vmm_test_artifacts_dir)?;
     ctx.config(crate::download_openvmm_vmm_tests_artifacts::Config {
         custom_cache_dir: Some(vmm_test_artifacts_dir.clone()),
         skip_prompt: Some(skip_vhd_prompt),

--- a/flowey/flowey_lib_hvlite/src/download_openvmm_vmm_tests_artifacts.rs
+++ b/flowey/flowey_lib_hvlite/src/download_openvmm_vmm_tests_artifacts.rs
@@ -80,7 +80,15 @@ impl FlowNodeWithConfig for Node {
             }
             true
         };
-        let custom_disk_policy = config.custom_disk_policy;
+        let custom_disk_policy = match ctx.backend() {
+            FlowBackend::Local => config.custom_disk_policy,
+            // default to strict policy in CI
+            _ => Some(
+                config
+                    .custom_disk_policy
+                    .unwrap_or(CustomDiskPolicy::Strict),
+            ),
+        };
         let custom_cache_dir = config.custom_cache_dir;
 
         let persistent_dir = ctx.persistent_dir();
@@ -98,11 +106,17 @@ impl FlowNodeWithConfig for Node {
             move |rt| {
                 let output_folder = if let Some(dir) = custom_cache_dir {
                     dir
+                } else if let Some(dir) = std::env::var_os("VMM_TEST_IMAGES") {
+                    PathBuf::from(dir)
                 } else if let Some(dir) = persistent_dir {
                     rt.read(dir)
                 } else {
                     std::env::current_dir()?
                 };
+
+                if !output_folder.exists() {
+                    fs_err::create_dir_all(&output_folder)?;
+                }
 
                 rt.write(write_output_folder, &output_folder.absolute()?);
 

--- a/flowey/flowey_lib_hvlite/src/download_openvmm_vmm_tests_artifacts.rs
+++ b/flowey/flowey_lib_hvlite/src/download_openvmm_vmm_tests_artifacts.rs
@@ -106,13 +106,19 @@ impl FlowNodeWithConfig for Node {
             move |rt| {
                 let output_folder = if let Some(dir) = custom_cache_dir {
                     dir
-                } else if let Some(dir) = std::env::var_os("VMM_TEST_IMAGES") {
+                } else if let Some(dir) =
+                    std::env::var_os("VMM_TEST_IMAGES").and_then(|v| (!v.is_empty()).then_some(v))
+                {
                     PathBuf::from(dir)
                 } else if let Some(dir) = persistent_dir {
                     rt.read(dir)
                 } else {
                     std::env::current_dir()?
                 };
+
+                if output_folder.is_file() {
+                    anyhow::bail!("output dir is a file");
+                }
 
                 if !output_folder.exists() {
                     fs_err::create_dir_all(&output_folder)?;

--- a/flowey/flowey_lib_hvlite/src/download_openvmm_vmm_tests_artifacts.rs
+++ b/flowey/flowey_lib_hvlite/src/download_openvmm_vmm_tests_artifacts.rs
@@ -116,13 +116,14 @@ impl FlowNodeWithConfig for Node {
                     std::env::current_dir()?
                 };
 
-                if output_folder.is_file() {
-                    anyhow::bail!("output dir is a file");
+                if output_folder.exists() && !output_folder.is_dir() {
+                    anyhow::bail!(
+                        "output dir path exists but is not a directory: {}",
+                        output_folder.display()
+                    );
                 }
 
-                if !output_folder.exists() {
-                    fs_err::create_dir_all(&output_folder)?;
-                }
+                fs_err::create_dir_all(&output_folder)?;
 
                 rt.write(write_output_folder, &output_folder.absolute()?);
 


### PR DESCRIPTION
Our ARM, TDX, and SNP runners are not wiped between runs, so we can speed up tests by caching VHDs. These machines have been configured with a system environment variable specifying where to store the VHDs.