### PR TITLE
kernel upgrade: Update OpenHCL to use v6.18.37.5

### DIFF
--- a/flowey/flowey_lib_hvlite/src/_jobs/cfg_versions.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/cfg_versions.rs
@@ -29,7 +29,7 @@ pub const NEXTEST: &str = "0.9.133";
 pub const NODEJS: &str = "24.x";
 // None disables hcl-dev builds and tests; Some(version) enables them.
 pub const OPENHCL_KERNEL_DEV_VERSION: Option<&str> = None;
-pub const OPENHCL_KERNEL_STABLE_VERSION: &str = "6.18.37.4";
+pub const OPENHCL_KERNEL_STABLE_VERSION: &str = "6.18.37.5";
 pub const OPENVMM_DEPS: &str = "0.3.0-116";
 pub const PROTOC: &str = "27.1";
 

--- a/nix/openhcl_kernel.nix
+++ b/nix/openhcl_kernel.nix
@@ -1,7 +1,7 @@
 { system, stdenv, fetchzip, targetArch ? null, is_dev ? false, is_cvm ? false }:
 
 let
-  version = if is_dev then "deprecated" else "6.18.37.4";
+  version = if is_dev then "deprecated" else "6.18.37.5";
   # Allow explicit override of architecture, otherwise derive from host system
   # Note: targetArch uses "x86_64"/"aarch64", but URLs use "x64"/"arm64"
   arch = if targetArch == "x86_64" then "x64"
@@ -18,11 +18,11 @@ let
   hashes = {
     hcl-main = {
       std = {
-        x64 = "sha256-SlYEQxn56WvMWd+85ph4EAKZNQ6pS+FLGBlEYspmZYA=";
-        arm64 = "sha256-ftKWHixNquT5NATXKWzLOuUh36uUyzslYHh8qvP93FQ=";
+        x64 = "sha256-4kzxC2Y5Mgu5IUOpSd5P0oRCJ3mAWyBeSPMy+oDpX3A=";
+        arm64 = "sha256-Ye31oycicbZQe4VsHnfrIqdDYLIencmfLSKCB71O3lQ=";
       };
       cvm = {
-        x64 = "sha256-iMgViANcMOowzi3nyriDI7M9bv/69AN9inCweWmcups=";
+        x64 = "sha256-X/0m+DofK1twISaAqLCS/Rp9QMjld5MIVIHEBdJmdmo=";
         arm64 = throw "openhcl-kernel: cvm arm64 variant not available";
       };
     };


### PR DESCRIPTION
Upgrade kernel used in OpenHCL to 6.18.37.5 release tag. Regenerate all variant hashes (hcl-main, std/cvm, x64/arm64) in openhcl_kernel.nix.
This includes fix for page table memory regression in VTL2.

Kernel PR: https://github.com/microsoft/OHCL-Linux-Kernel/pull/159