### PR TITLE
attestation: Report provenance signer in uppercase

### DIFF
--- a/openhcl/underhill_attestation/src/lib.rs
+++ b/openhcl/underhill_attestation/src/lib.rs
@@ -1799,7 +1799,7 @@ pub fn get_provenance_claims(prov_file: &[u8]) -> Result<VmgsProvisioner, Error>
     );
     let signer = format!(
         "did:x509:0:sha256:{}:subject:{}",
-        hex::encode(digest).to_uppercase(),
+        hex::encode_upper(digest),
         sn
     );
     let vmgsid = jwt.jwt.body.vmgsid;

--- a/openhcl/underhill_attestation/src/lib.rs
+++ b/openhcl/underhill_attestation/src/lib.rs
@@ -1797,7 +1797,11 @@ pub fn get_provenance_claims(prov_file: &[u8]) -> Result<VmgsProvisioner, Error>
             .map_err(ProvenanceError::X509Error)
             .map_err(AttestationErrorInner::Provenance)?),
     );
-    let signer = format!("did:x509:0:sha256:{}:subject:{}", hex::encode(digest), sn);
+    let signer = format!(
+        "did:x509:0:sha256:{}:subject:{}",
+        hex::encode(digest).to_uppercase(),
+        sn
+    );
     let vmgsid = jwt.jwt.body.vmgsid;
 
     Ok(VmgsProvisioner {
@@ -3609,7 +3613,7 @@ mod tests {
         );
         assert_eq!(
             claims.signer,
-            "did:x509:0:sha256:ea76599d86897382aa519ff2bc0fa6b9c15d60da2ebe53e72139cd317b0797ed:subject:fican.cvmprovisioningservice.core.azure-test.net"
+            "did:x509:0:sha256:EA76599D86897382AA519FF2BC0FA6B9C15D60DA2EBE53E72139CD317B0797ED:subject:fican.cvmprovisioningservice.core.azure-test.net"
         );
     }
 


### PR DESCRIPTION
Legacy HCL reports the provenance root cert hash in uppercase. For compatibility, OpenHCL should do the same.

Fixes #4324.