### PR TITLE
pipette: Run in a loop in winsvc too

### DIFF
--- a/petri/pipette/src/winsvc.rs
+++ b/petri/pipette/src/winsvc.rs
@@ -90,8 +90,16 @@ async fn service_main_inner(
     set_status(service::ServiceState::Running)?;
 
     let run = async {
-        let agent = Agent::new(driver, transport).await?;
-        agent.run().await
+        loop {
+            let agent = Agent::new(driver.clone(), transport).await?;
+            match agent.run().await {
+                Ok(_) => eprintln!("Pipette disconnected, reconnecting..."),
+                Err(err) => {
+                    eprintln!("Pipette agent failed: {:#}", err);
+                    break Err(err);
+                }
+            }
+        }
     };
 
     let stop = async {


### PR DESCRIPTION
We've seen some vmm tests fail due to connection issues with the winservice version of pipette. Have its connect attempt run in a loop, very similarly to how main.rs works.