### PR TITLE
TDX: Fix a needless kernel warning

### DIFF
--- a/openhcl/openhcl_boot/src/dt.rs
+++ b/openhcl/openhcl_boot/src/dt.rs
@@ -254,17 +254,23 @@ pub fn write_dt(
 
     #[cfg(target_arch = "x86_64")]
     if isolation_type == IsolationType::Tdx {
+        // Linux ignores the whole `/reserved-memory` subtree unless its cell
+        // counts match the root node's, so these must stay in sync with the
+        // root node above.
         let mut mailbox_builder = root_builder
             .start_node("reserved-memory")?
             .add_u32(p_address_cells, 2)?
-            .add_u32(p_size_cells, 1)?
+            .add_u32(p_size_cells, 2)?
             .add_null(p_ranges)?;
 
         let name = format_fixed!(32, "wakeup_table@{:x}", RESET_VECTOR_PAGE);
         let mailbox_addr_builder = mailbox_builder
             .start_node(name.as_ref())?
             .add_str(p_compatible, "intel,wakeup-mailbox")?
-            .add_u32_array(p_reg, &[0x0, RESET_VECTOR_PAGE.try_into().unwrap(), 0x1000])?;
+            .add_u32_array(
+                p_reg,
+                &[0x0, RESET_VECTOR_PAGE.try_into().unwrap(), 0x0, 0x1000],
+            )?;
 
         mailbox_builder = mailbox_addr_builder.end_node()?;
 


### PR DESCRIPTION
The /reserved-memory node OpenHCL's bootshim emits for TDX declared cell counts that don't match the DT root node, so Linux rejects the whole subtree and emits a warning during boot ("OF: reserved mem: Reserved memory: unsupported node format, ignoring"). Fix this by making the counts match.