### PR TITLE
Misc: Reduce some log noise

### DIFF
--- a/vm/aarch64/aarch64emu/src/opcodes.rs
+++ b/vm/aarch64/aarch64emu/src/opcodes.rs
@@ -390,7 +390,7 @@ impl LoadStoreRegister {
         };
         let size = self.data_size()?;
         let register_index = self.rt();
-        tracing::info!(
+        tracing::trace!(
             ?op_group,
             op,
             start_address,

--- a/vm/devices/vmbus/vmbus_client/src/lib.rs
+++ b/vm/devices/vmbus/vmbus_client/src/lib.rs
@@ -1603,6 +1603,12 @@ impl ClientTaskInner {
             self.messages.send(&protocol::CloseChannel { channel_id });
             channel.state = ChannelState::Offered;
             channel.connection_id.store(0, Ordering::Release);
+        } else if matches!(channel.state, ChannelState::Revoked) {
+            tracing::debug!(
+                channel_id = channel_id.0,
+                key = %OfferKey::from(&channel.offer),
+                "close for channel already revoked by the server"
+            );
         } else {
             tracing::warn!(
                 channel_id = channel_id.0,

--- a/vmm_core/virt_whp/src/hypercalls.rs
+++ b/vmm_core/virt_whp/src/hypercalls.rs
@@ -1659,6 +1659,41 @@ mod x86 {
 
                     tracing::trace!(?vsm_config, "set VsmPartitionConfig");
                 }
+                HvX64RegisterName::GuestVsmPartitionConfig => {
+                    if self.state.active_vtl != Vtl::Vtl2 || vtl != Vtl::Vtl2 {
+                        tracelimit::error_ratelimited!(active_vtl = ?self.state.active_vtl, "invalid guest vsm partition config set register");
+                        return Err(HvError::AccessDenied);
+                    }
+
+                    // Since guest VSM is unsupported, the only configuration
+                    // that can be applied is the one `get_vp_register` already
+                    // reports. VTL2 writes this to revoke guest VSM, which is
+                    // already the case, so accept that and reject anything that
+                    // would grant the guest a VTL.
+                    if hvdef::HvRegisterGuestVsmPartitionConfig::from(value.as_u64()).maximum_vtl()
+                        != 0
+                    {
+                        return Err(HvError::InvalidParameter);
+                    }
+                }
+                HvX64RegisterName::PmTimerAssist => {
+                    if self.state.active_vtl != Vtl::Vtl2 || vtl != Vtl::Vtl2 {
+                        tracelimit::error_ratelimited!(active_vtl = ?self.state.active_vtl, "invalid pm timer assist set register");
+                        return Err(HvError::AccessDenied);
+                    }
+
+                    // TODO: the assist is not implemented.
+                    return Err(HvError::InvalidParameter);
+                }
+                HvX64RegisterName::RegisterPage => {
+                    if self.state.active_vtl != Vtl::Vtl2 || vtl != Vtl::Vtl2 {
+                        tracelimit::error_ratelimited!(active_vtl = ?self.state.active_vtl, "invalid register page set register");
+                        return Err(HvError::AccessDenied);
+                    }
+
+                    // TODO: the VTL2 register page is not implemented.
+                    return Err(HvError::InvalidParameter);
+                }
                 HvX64RegisterName::DeliverabilityNotifications => {
                     if self.state.active_vtl != Vtl::Vtl2 || vtl != Vtl::Vtl0 {
                         tracelimit::error_ratelimited!(active_vtl = ?self.state.active_vtl, "invalid set deliverability notification register");

--- a/vmm_core/virt_whp/src/hypercalls.rs
+++ b/vmm_core/virt_whp/src/hypercalls.rs
@@ -1669,10 +1669,8 @@ mod x86 {
                     // that can be applied is the one `get_vp_register` already
                     // reports. VTL2 writes this to revoke guest VSM, which is
                     // already the case, so accept that and reject anything that
-                    // would grant the guest a VTL.
-                    if hvdef::HvRegisterGuestVsmPartitionConfig::from(value.as_u64()).maximum_vtl()
-                        != 0
-                    {
+                    // would grant the guest a VTL, or do anything else.
+                    if value.as_u64() != 0 {
                         return Err(HvError::InvalidParameter);
                     }
                 }


### PR DESCRIPTION
aarch64emu: Lower the tracing level of each emulated instruction from info to trace.
vmbus_client: Lower the tracing level when we receive a channel close for a channel that's already revoked, it's not warning worthy.
virt_whp: Implement stubs for registers OpenHCL tries to access unconditionally so they stop emitting 'unknown register' warnings.