### PR TITLE
chipset: Actually enable the PM timer assist on the Hyper-V PM device

### DIFF
--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -2516,8 +2516,11 @@ async fn new_underhill_vm(
         } else {
             anyhow::bail!("unsupported guest architecture")
         },
-    )
-    .with_platform_pm_timer_assist();
+    );
+
+    if !isolation.is_hardware_isolated() {
+        chipset = chipset.with_platform_pm_timer_assist();
+    }
 
     if with_serial {
         chipset = chipset.with_serial(serial_inputs);

--- a/vm/devices/chipset/src/pm/mod.rs
+++ b/vm/devices/chipset/src/pm/mod.rs
@@ -434,7 +434,7 @@ impl PowerManagementDevice {
 
     fn enable_acpi_mode(&mut self, default_pio_dynamic: u16) {
         tracing::debug!("ACPI mode enabled");
-        self.rt.pio_dynamic.map(default_pio_dynamic);
+        self.update_dynamic_pio_mappings(Some(default_pio_dynamic));
         self.state.control = CONTROL_SCI_ENABLE_MASK;
     }
 
@@ -458,8 +458,6 @@ impl PowerManagementDevice {
         self.rt.acpi_interrupt.set_level(level)
     }
 
-    /// (used by the PIIX4 wrapper device)
-    ///
     /// Remap dynamic registers based on config in the PCI config space
     #[inline(always)]
     pub fn update_dynamic_pio_mappings(&mut self, pio_dynamic_addr: Option<u16>) {
@@ -507,7 +505,7 @@ impl ChangeDeviceState for PowerManagementDevice {
     async fn stop(&mut self) {}
 
     async fn reset(&mut self) {
-        self.rt.pio_dynamic.unmap();
+        self.update_dynamic_pio_mappings(None);
         self.rt.acpi_interrupt.set_level(false);
         self.state = PmState::new();
         if let Some(acpi_mode) = self.enable_acpi_mode {


### PR DESCRIPTION
We accidentally were only enabling the PM timer assist on the PIIX4 PCAT-only path, not the generic power management UEFI path. Unify them.