### PR TITLE
aarch64: advertise host SSID/ATS for accelerated SMMU

### DIFF
--- a/openvmm/openvmm_core/src/worker/dispatch.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch.rs
@@ -3156,6 +3156,11 @@ impl LoadedVmInner {
     }
 
     async fn load_firmware(&mut self, vtl2_only: bool) -> anyhow::Result<()> {
+        #[cfg(guest_arch = "aarch64")]
+        if let IommuDevices::Smmu(devices) = &mut self.iommu_devices {
+            devices.refresh_acpi_capabilities();
+        }
+
         let cache_topology = if cfg!(guest_arch = "aarch64") {
             Some(
                 cache_topology::CacheTopology::from_host()

--- a/openvmm/openvmm_core/src/worker/dispatch/smmu_wiring.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch/smmu_wiring.rs
@@ -84,6 +84,18 @@ pub(super) struct SmmuDevicesResult {
     pub shared_states: Vec<Option<Arc<smmu::SmmuSharedState>>>,
     /// ACPI IORT configuration for each SMMU instance.
     pub configs: Vec<vmm_core::acpi_builder::AcpiSmmuConfig>,
+    /// Shared states corresponding one-to-one with `configs`.
+    config_states: Vec<Arc<smmu::SmmuSharedState>>,
+}
+
+impl SmmuDevicesResult {
+    /// Refreshes host-derived ACPI capabilities after cold-plug devices bind.
+    pub fn refresh_acpi_capabilities(&mut self) {
+        assert_eq!(self.configs.len(), self.config_states.len());
+        for (config, state) in self.configs.iter_mut().zip(&self.config_states) {
+            config.ats_supported = state.ats_supported();
+        }
+    }
 }
 
 fn reserved_iova_ranges(
@@ -119,6 +131,7 @@ pub(super) fn setup_smmu(
     let mut shared_states: Vec<Option<Arc<smmu::SmmuSharedState>>> =
         vec![None; pcie_host_bridges.len()];
     let mut configs = Vec::new();
+    let mut config_states = Vec::new();
 
     // Iterate RCs with SMMU enabled, zipping with resolved MMIO+SPI resources.
     let smmu_rcs = root_complexes
@@ -183,7 +196,8 @@ pub(super) fn setup_smmu(
                     )
                 })?;
 
-        shared_states[rc_pos] = Some(smmu_device.lock().shared_state().clone());
+        let shared_state = smmu_device.lock().shared_state().clone();
+        shared_states[rc_pos] = Some(shared_state.clone());
         let reserved_iova_ranges =
             reserved_iova_ranges(accel, resolved.device_assignment_msi_iova_range)
                 .with_context(|| format!("SMMU on root complex {}", rc.name))?;
@@ -201,13 +215,16 @@ pub(super) fn setup_smmu(
             base: smmu.base,
             event_gsiv: smmu.evtq_intid,
             gerr_gsiv: smmu.gerr_intid,
+            ats_supported: false,
             reserved_iova_ranges,
         });
+        config_states.push(shared_state);
     }
 
     Ok(SmmuDevicesResult {
         shared_states,
         configs,
+        config_states,
     })
 }
 

--- a/vm/acpi_spec/src/iort.rs
+++ b/vm/acpi_spec/src/iort.rs
@@ -122,7 +122,12 @@ impl IortPciRootComplex {
     /// Create a PCI Root Complex node. The `length` field in the header
     /// includes space for `mapping_count` trailing `IortIdMapping` entries,
     /// which must be appended separately after serializing this struct.
-    pub fn new(identifier: u32, pci_segment_number: u16, mapping_count: u32) -> Self {
+    pub fn new(
+        identifier: u32,
+        pci_segment_number: u16,
+        mapping_count: u32,
+        ats_supported: bool,
+    ) -> Self {
         let mut header = IortNodeHeader::new::<Self>(
             IORT_NODE_TYPE_PCI_ROOT_COMPLEX,
             IORT_PCI_ROOT_COMPLEX_REVISION,
@@ -136,7 +141,7 @@ impl IortPciRootComplex {
         Self {
             header,
             memory_properties: IortMemoryAccessProperties::coherent(),
-            ats_attribute: 0.into(),
+            ats_attribute: u32::from(ats_supported).into(),
             pci_segment_number: u32::from(pci_segment_number).into(),
             memory_address_limit: 64,
             reserved: [0; 3],

--- a/vm/devices/iommu/smmu/src/emulator.rs
+++ b/vm/devices/iommu/smmu/src/emulator.rs
@@ -73,6 +73,10 @@ pub struct HostSmmuCaps {
     pub(crate) ttendian: registers::Idr0TtEndian,
     /// Host 4KB translation granule support (IDR5.GRAN4K).
     pub(crate) gran4k: bool,
+    /// Host SMMU PASID/SSID width (IDR1.SSIDSIZE).
+    pub(crate) ssid_bits: u8,
+    /// Host SMMU ATS support (IDR0.ATS).
+    pub(crate) ats: bool,
 }
 
 impl HostSmmuCaps {
@@ -86,6 +90,7 @@ impl HostSmmuCaps {
     /// [`SmmuSharedState::bind_accel_viommu`].
     pub fn from_idr(idr: [u32; 6]) -> Self {
         let idr0 = registers::Idr0::from(idr[0]);
+        let idr1 = registers::Idr1::from(idr[1]);
         let idr5 = registers::Idr5::from(idr[5]);
 
         Self {
@@ -93,7 +98,19 @@ impl HostSmmuCaps {
             ttf: registers::Idr0Ttf::from(idr0.ttf()),
             ttendian: registers::Idr0TtEndian(idr0.ttendian()),
             gran4k: idr5.gran4k(),
+            ssid_bits: idr1.ssidsize(),
+            ats: idr0.ats(),
         }
+    }
+
+    /// Maximum PASID width exposed to the guest endpoint and vSMMU.
+    pub fn ssid_bits(self) -> u8 {
+        self.ssid_bits
+    }
+
+    /// Whether ATS may be exposed to the guest.
+    pub fn ats(self) -> bool {
+        self.ats
     }
 }
 
@@ -202,12 +219,13 @@ pub struct SmmuDevice {
 }
 
 impl SmmuDevice {
-    fn sanitize_cr0(value: u32) -> registers::Cr0 {
+    fn sanitize_cr0(value: u32, ats_supported: bool) -> registers::Cr0 {
         let requested = registers::Cr0::from(value);
         registers::Cr0::new()
             .with_smmuen(requested.smmuen())
             .with_eventqen(requested.eventqen())
             .with_cmdqen(requested.cmdqen())
+            .with_atschk(requested.atschk() && ats_supported)
     }
 
     fn sanitize_gbpa(value: u32) -> registers::Gbpa {
@@ -248,9 +266,7 @@ impl SmmuDevice {
 
         let idr1 = registers::Idr1::new()
             .with_sidsize(config.sidsize)
-            // TODO: support substreams (SSID/PASID). When SSIDSIZE > 0, the
-            // accel path must validate the host SMMU's SSIDSIZE >= the
-            // advertised value in resolve_host_caps.
+            // Resolved from the host before VM start for accelerated devices.
             .with_ssidsize(0)
             .with_cmdqs(8) // 256 entries max
             .with_eventqs(8) // 256 entries max
@@ -356,11 +372,19 @@ impl SmmuDevice {
         &self.shared_state
     }
 
+    fn effective_idr0(&self) -> registers::Idr0 {
+        self.idr0.with_ats(self.shared_state.ats_supported())
+    }
+
+    fn effective_idr1(&self) -> registers::Idr1 {
+        self.idr1.with_ssidsize(self.shared_state.ssid_bits())
+    }
+
     /// Handles a 32-bit MMIO read at the given offset from the device base.
     fn read_reg32(&self, offset: u32) -> u32 {
         match offset as u16 {
-            registers::IDR0 => self.idr0.into(),
-            registers::IDR1 => self.idr1.into(),
+            registers::IDR0 => self.effective_idr0().into(),
+            registers::IDR1 => self.effective_idr1().into(),
             registers::IDR2 => self.idr2,
             registers::IDR3 => self.idr3,
             registers::IDR4 => self.idr4,
@@ -441,7 +465,7 @@ impl SmmuDevice {
             | registers::IRQ_CTRLACK => {}
 
             registers::CR0 => {
-                let requested = Self::sanitize_cr0(value);
+                let requested = Self::sanitize_cr0(value, self.shared_state.ats_supported());
                 let previous = self.cr0;
                 self.cr0 = requested;
 
@@ -759,7 +783,8 @@ impl SmmuDevice {
                     | CmdOpcode::TLBI_NSNH_ALL
                     | CmdOpcode::CFGI_CD
                     | CmdOpcode::CFGI_CD_ALL
-            ) || (opcode == CmdOpcode::ATC_INV && self.idr0.ats());
+            ) || (opcode == CmdOpcode::ATC_INV
+                && self.shared_state.ats_supported());
 
             if forwardable {
                 // SID-based invalidations (CFGI_CD/CFGI_CD_ALL, and ATC_INV
@@ -1051,13 +1076,20 @@ impl ChangeDeviceState for SmmuDevice {
         let reset_gbpa = registers::Gbpa::new().with_abort(false);
         let reset_strtab_base = 0;
         let reset_strtab_base_cfg = registers::StrtabBaseCfg::new();
-        let TranslationPolicy { oas_mask, .. } = shared_state.translation_policy();
+        let TranslationPolicy {
+            oas_mask,
+            ssid_bits,
+            ats,
+            ..
+        } = shared_state.translation_policy();
         let reset_policy = TranslationPolicy {
             enabled: reset_cr0.smmuen(),
             gbpa_abort: reset_gbpa.abort(),
             strtab_base: registers::StrtabBase::from(reset_strtab_base).addr(),
             strtab_log2size: reset_strtab_base_cfg.log2size(),
             oas_mask,
+            ssid_bits,
+            ats,
         };
         shared_state.transition_translation_policy(reset_policy, "SMMU reset");
 
@@ -1191,7 +1223,7 @@ impl SaveRestore for SmmuDevice {
             gerrorn,
         } = saved;
 
-        let restored_cr0 = Self::sanitize_cr0(cr0);
+        let restored_cr0 = Self::sanitize_cr0(cr0, self.shared_state.ats_supported());
         let restored_cr1 = registers::Cr1::from(cr1);
         let restored_cr2 = registers::Cr2::from(cr2);
         let restored_gbpa = Self::sanitize_gbpa(gbpa);
@@ -2320,7 +2352,35 @@ mod tests {
             ttf: Idr0Ttf::new().with_aarch64(true),
             ttendian: Idr0TtEndian::LE,
             gran4k: true,
+            ssid_bits: 14,
+            ats: true,
         }
+    }
+
+    #[test]
+    fn test_accel_host_caps_are_advertised() {
+        let gm = GuestMemory::allocate(0x1000);
+        let mut dev = SmmuDevice::new(
+            TEST_MMIO_BASE,
+            gm,
+            &SmmuConfig {
+                sidsize: 16,
+                oas_policy: SmmuOasPolicy::Fixed(48),
+                accel: true,
+            },
+            None,
+            None,
+        );
+
+        dev.shared_state
+            .bind_accel_viommu(test_host_caps(), &MockViommu::new())
+            .unwrap();
+
+        assert!(Idr0::from(read32(&mut dev, IDR0)).ats());
+        assert_eq!(Idr1::from(read32(&mut dev, IDR1)).ssidsize(), 14);
+
+        write32(&mut dev, CR0, Cr0::new().with_atschk(true).into());
+        assert!(Cr0::from(read32(&mut dev, CR0ACK)).atschk());
     }
 
     #[test]
@@ -3363,8 +3423,18 @@ mod tests {
     /// `CERROR_ILL` instead of being forwarded.
     #[test]
     fn test_cmdq_atc_inv_illegal_when_ats_disabled() {
-        let (mut dev, sink) = make_accel_cmdq_test_device();
-        assert!(!dev.idr0.ats());
+        let mut dev = make_cmdq_test_device();
+        let sink = MockViommu::new();
+        dev.shared_state
+            .bind_accel_viommu(
+                HostSmmuCaps {
+                    ats: false,
+                    ..test_host_caps()
+                },
+                &sink,
+            )
+            .expect("bind ATS-disabled host SMMU");
+        assert!(!Idr0::from(read32(&mut dev, IDR0)).ats());
 
         write_cmdq_entry(
             &dev,

--- a/vm/devices/iommu/smmu/src/shared.rs
+++ b/vm/devices/iommu/smmu/src/shared.rs
@@ -152,6 +152,8 @@ pub(crate) struct TranslationPolicy {
     pub(crate) strtab_base: u64,
     pub(crate) strtab_log2size: u8,
     pub(crate) oas_mask: u64,
+    pub(crate) ssid_bits: u8,
+    pub(crate) ats: bool,
 }
 
 /// Reduce a guest stage-1 STE to the double-words that are architecturally
@@ -171,10 +173,10 @@ pub(crate) struct TranslationPolicy {
 /// - `IDR1.ATTR_TYPES_OVR == 0` → MTCFG, MemAttr, SHCFG, ALLOCCFG are RES0;
 /// - `IDR1.ATTR_PERMS_OVR == 0` → NSCFG, PRIVCFG, INSTCFG are RES0;
 /// - `IDR0.HYP == 0` → STRW is fixed to NS-EL1 (0);
-/// - `IDR0.ATS == 0` → EATS is IGNORED;
-/// - `IDR1.SSIDSIZE == 0` → S1CDMax is IGNORED, and S1Fmt and S1DSS are in turn
-///   IGNORED ("substreams unsupported"), leaving `S1ContextPtr` addressing
-///   exactly one CD;
+/// - when `IDR0.ATS == 0`, EATS is IGNORED;
+/// - when `IDR1.SSIDSIZE == 0`, S1CDMax is IGNORED, and S1Fmt and S1DSS are in
+///   turn IGNORED ("substreams unsupported"), leaving `S1ContextPtr`
+///   addressing exactly one CD;
 /// - unadvertised optional features (S1PIE, S1MPAM, CONT, DCP, DRE, PPAR, MEV)
 ///   are RES0/IGNORED; the SW bits have no hardware effect.
 ///
@@ -182,27 +184,42 @@ pub(crate) struct TranslationPolicy {
 /// fetch address to the OAS (§3.4), so the pointer it acts on never contains
 /// bits above the advertised output address size.
 ///
-/// Retained — DW0: V, Config, S1ContextPtr; DW1: S1CIR, S1COR, S1CSH, S1STALLD.
-/// Rebuilding the words through the typed field setters keeps the selection
-/// tied to the spec definitions.
+/// Retained unconditionally — DW0: V, Config, S1ContextPtr; DW1: S1CIR, S1COR,
+/// S1CSH, S1STALLD. S1Fmt, S1CDMax, and S1DSS are additionally retained when
+/// SSID support is advertised; EATS is retained when ATS is advertised.
 ///
 /// NOTE: if this emulator ever advertises one of the above features, the
 /// retained set must grow to match (and attach-time capability resolution must
 /// gate the new field against the host SMMU).
-fn canonical_s1_ste_dwords(ste: &crate::spec::ste::Ste, oas_mask: u64) -> [u64; 2] {
+fn canonical_s1_ste_dwords(
+    ste: &crate::spec::ste::Ste,
+    oas_mask: u64,
+    ssid_bits: u8,
+    ats: bool,
+) -> [u64; 2] {
     use crate::spec::ste::SteDw0;
     use crate::spec::ste::SteDw1;
 
-    let dw0 = SteDw0::new()
+    let mut dw0 = SteDw0::new()
         .with_v(ste.qw0.v())
         .with_config(ste.qw0.config())
         .with_s1_context_ptr((ste.s1_context_ptr() & oas_mask) >> 6);
 
-    let dw1 = SteDw1::new()
+    let mut dw1 = SteDw1::new()
         .with_s1_cir(ste.qw1.s1_cir())
         .with_s1_cor(ste.qw1.s1_cor())
         .with_s1_csh(ste.qw1.s1_csh())
         .with_s1stalld(ste.qw1.s1stalld());
+
+    if ssid_bits != 0 {
+        dw0 = dw0
+            .with_s1_fmt(ste.qw0.s1_fmt())
+            .with_s1_cd_max(ste.qw0.s1_cd_max());
+        dw1 = dw1.with_s1_dss(ste.qw1.s1_dss());
+    }
+    if ats {
+        dw1 = dw1.with_eats(ste.qw1.eats());
+    }
 
     [dw0.into(), dw1.into()]
 }
@@ -373,6 +390,10 @@ struct SharedStateInner {
     /// Advertised output address size in bits. Reflected in IDR5.OAS and
     /// used to derive `oas_mask`.
     oas_bits: u8,
+    /// Advertised PASID/SSID width, resolved from the host before start.
+    ssid_bits: u8,
+    /// Whether ATS is advertised, resolved from the host before start.
+    ats: bool,
     /// Host SMMU capabilities, once an accelerated VFIO device has bound and
     /// [`SmmuSharedState::resolve_host_caps`] has resolved or validated the
     /// host-derived parameters. `None` until then (and always `None` for
@@ -466,6 +487,8 @@ impl SmmuSharedState {
                 strtab_base: 0,
                 strtab_log2size: 0,
                 oas_bits,
+                ssid_bits: 0,
+                ats: false,
                 resolved_host_caps: None,
                 oas_mask,
             }),
@@ -497,6 +520,16 @@ impl SmmuSharedState {
     /// Returns the currently advertised output address size in bits.
     pub(crate) fn oas_bits(&self) -> u8 {
         self.inner.read().oas_bits
+    }
+
+    /// Returns the currently advertised PASID/SSID width.
+    pub(crate) fn ssid_bits(&self) -> u8 {
+        self.inner.read().ssid_bits
+    }
+
+    /// Returns whether ATS is currently advertised.
+    pub fn ats_supported(&self) -> bool {
+        self.inner.read().ats
     }
 
     /// Freezes guest-visible capabilities before the VM can observe them.
@@ -605,6 +638,29 @@ impl SmmuSharedState {
             anyhow::bail!("host SMMU does not support the 4KB translation granule (IDR5.GRAN4K=0)");
         }
 
+        if caps.ssid_bits > 20 {
+            anyhow::bail!(
+                "host reported PASID width {} above the PCIe maximum of 20",
+                caps.ssid_bits
+            );
+        }
+
+        if !inner.capabilities_frozen {
+            inner.ssid_bits = caps.ssid_bits;
+            inner.ats = caps.ats;
+        } else {
+            if inner.ssid_bits > caps.ssid_bits {
+                anyhow::bail!(
+                    "advertised SMMU SSID width {} exceeds host PASID width {}",
+                    inner.ssid_bits,
+                    caps.ssid_bits
+                );
+            }
+            if inner.ats && !caps.ats {
+                anyhow::bail!("advertised SMMU ATS is not supported by the host device");
+            }
+        }
+
         // OAS: decode the host's IDR5.OAS encoding (may be a reserved value).
         // Before the device starts, `auto` adopts the host value. Once
         // capabilities are guest-visible, both policies only validate the
@@ -661,6 +717,8 @@ impl SmmuSharedState {
             strtab_base: inner.strtab_base,
             strtab_log2size: inner.strtab_log2size,
             oas_mask: inner.oas_mask,
+            ssid_bits: inner.ssid_bits,
+            ats: inner.ats,
         }
     }
 
@@ -1014,7 +1072,12 @@ impl SmmuSharedState {
         match translate::ste_config_action(&ste) {
             translate::SteAction::Bypass => StreamConfig::Bypass,
             translate::SteAction::S1Translate => StreamConfig::Translate {
-                ste_dwords: canonical_s1_ste_dwords(&ste, policy.oas_mask),
+                ste_dwords: canonical_s1_ste_dwords(
+                    &ste,
+                    policy.oas_mask,
+                    policy.ssid_bits,
+                    policy.ats,
+                ),
             },
             // Config[2]==0 (0b000 / reserved) aborts with no event; an illegal
             // config (0b110/0b111 on this stage-1-only SMMU) also aborts here —
@@ -1668,7 +1731,7 @@ mod tests {
             _qw2_7: [0; 6],
         };
 
-        let [out0, out1] = canonical_s1_ste_dwords(&ste, TEST_OAS_MASK);
+        let [out0, out1] = canonical_s1_ste_dwords(&ste, TEST_OAS_MASK, 0, false);
         // Retained fields survive untouched.
         assert_eq!(out0, u64::from(qw0));
         assert_eq!(out1, u64::from(qw1));
@@ -1682,7 +1745,7 @@ mod tests {
             qw1: SteDw1::from(u64::MAX),
             _qw2_7: [u64::MAX; 6],
         };
-        let [out0, out1] = canonical_s1_ste_dwords(&ste, TEST_OAS_MASK);
+        let [out0, out1] = canonical_s1_ste_dwords(&ste, TEST_OAS_MASK, 0, false);
 
         // DW0 retains V[0] | Config[3:1] | S1ContextPtr[55:6], the pointer
         // truncated to the 48-bit OAS. S1Fmt[5:4] and S1CDMax[63:59] are
@@ -1693,6 +1756,28 @@ mod tests {
         // IDR0.ATS == 0; everything else (STRW, SHCFG, NSCFG, PRIVCFG,
         // stage-2/override fields, ...) is RES0/IGNORED.
         assert_eq!(out1, 0x0800_00fc);
+    }
+
+    #[test]
+    fn test_canonical_s1_ste_dwords_preserves_pasid_and_ats_fields() {
+        let ste = Ste {
+            qw0: SteDw0::new()
+                .with_v(true)
+                .with_config(SteConfig::S1_TRANS.0)
+                .with_s1_fmt(2)
+                .with_s1_context_ptr(0x1234)
+                .with_s1_cd_max(14),
+            qw1: SteDw1::new().with_s1_dss(2).with_eats(1),
+            _qw2_7: [0; 6],
+        };
+
+        let [out0, out1] = canonical_s1_ste_dwords(&ste, TEST_OAS_MASK, 14, true);
+        let out0 = SteDw0::from(out0);
+        let out1 = SteDw1::from(out1);
+        assert_eq!(out0.s1_fmt(), 2);
+        assert_eq!(out0.s1_cd_max(), 14);
+        assert_eq!(out1.s1_dss(), 2);
+        assert_eq!(out1.eats(), 1);
     }
 
     /// A mock SignalMsi that records calls.
@@ -2354,6 +2439,8 @@ mod tests {
             ttf: registers::Idr0Ttf::new().with_aarch64(true),
             ttendian: registers::Idr0TtEndian::LE,
             gran4k: true,
+            ssid_bits: 14,
+            ats: true,
         }
     }
 
@@ -2371,6 +2458,22 @@ mod tests {
     fn resolve_host_caps_accepts_compatible_host() {
         let state = make_accel_state(crate::SmmuOasPolicy::Fixed(40));
         state.resolve_host_caps(compatible_host_caps()).unwrap();
+    }
+
+    #[test]
+    fn resolve_host_caps_updates_ats_support() {
+        let supported = make_accel_state(crate::SmmuOasPolicy::Fixed(40));
+        supported.resolve_host_caps(compatible_host_caps()).unwrap();
+        assert!(supported.ats_supported());
+
+        let unsupported = make_accel_state(crate::SmmuOasPolicy::Fixed(40));
+        unsupported
+            .resolve_host_caps(crate::HostSmmuCaps {
+                ats: false,
+                ..compatible_host_caps()
+            })
+            .unwrap();
+        assert!(!unsupported.ats_supported());
     }
 
     #[test]

--- a/vmm_core/src/acpi_builder.rs
+++ b/vmm_core/src/acpi_builder.rs
@@ -42,6 +42,8 @@ pub struct AcpiSmmuConfig {
     pub event_gsiv: u32,
     /// GIC SPI INTID for the global error interrupt.
     pub gerr_gsiv: u32,
+    /// Whether the PCI root complex may use ATS through this SMMU.
+    pub ats_supported: bool,
     /// IOVA ranges reserved by the host IOMMU (e.g., MSI windows). When
     /// non-empty, an IORT RMR node (or DT `reserved-memory` entry) is
     /// generated so the guest identity-maps these ranges in its S1 page
@@ -681,10 +683,10 @@ impl<T: AcpiTopology> AcpiTablesBuilder<'_, T> {
 
         // SMMUv3 nodes come after ITS Group (if present).
         // Build a map from RC index → SMMU node offset for RC routing.
-        let mut smmu_rc_offsets: Vec<(u32, u32)> = Vec::new();
+        let mut smmu_rc_offsets: Vec<(u32, u32, bool)> = Vec::new();
         for cfg in smmu_configs {
             let smmu_node_offset = iort::IORT_NODE_OFFSET + iort_extra.len() as u32;
-            smmu_rc_offsets.push((cfg.rc_index, smmu_node_offset));
+            smmu_rc_offsets.push((cfg.rc_index, smmu_node_offset, cfg.ats_supported));
 
             if has_its {
                 // The SMMUv3 node needs two ID mappings when ITS is present:
@@ -753,18 +755,24 @@ impl<T: AcpiTopology> AcpiTablesBuilder<'_, T> {
             // - Otherwise, no mapping (mapping_count = 0).
             let smmu_offset = smmu_rc_offsets
                 .iter()
-                .find(|(idx, _)| *idx == bridge.index)
-                .map(|(_, off)| *off);
+                .find(|(idx, _, _)| *idx == bridge.index)
+                .map(|(_, off, ats_supported)| (*off, *ats_supported));
 
-            let (rc_mapping_count, rc_target_offset, rc_has_smmu) = if let Some(off) = smmu_offset {
-                (1, off, true)
-            } else if has_its {
-                (1, its_group_offset, false)
-            } else {
-                (0, 0, false)
-            };
+            let (rc_mapping_count, rc_target_offset, rc_has_smmu, ats_supported) =
+                if let Some((off, ats_supported)) = smmu_offset {
+                    (1, off, true, ats_supported)
+                } else if has_its {
+                    (1, its_group_offset, false, false)
+                } else {
+                    (0, 0, false, false)
+                };
 
-            let rc = iort::IortPciRootComplex::new(bridge.index, bridge.segment, rc_mapping_count);
+            let rc = iort::IortPciRootComplex::new(
+                bridge.index,
+                bridge.segment,
+                rc_mapping_count,
+                ats_supported,
+            );
             iort_extra.extend_from_slice(rc.as_bytes());
 
             if rc_mapping_count > 0 {
@@ -801,8 +809,8 @@ impl<T: AcpiTopology> AcpiTablesBuilder<'_, T> {
             }
             let smmu_offset = smmu_rc_offsets
                 .iter()
-                .find(|(idx, _)| *idx == cfg.rc_index)
-                .map(|(_, off)| *off)
+                .find(|(idx, _, _)| *idx == cfg.rc_index)
+                .map(|(_, off, _)| *off)
                 .expect("RMR config references a valid SMMU");
 
             let rmr_count = cfg.reserved_iova_ranges.len() as u32;
@@ -1830,6 +1838,7 @@ mod test {
                     base: smmu_base,
                     event_gsiv: 35,
                     gerr_gsiv: 36,
+                    ats_supported: false,
                     reserved_iova_ranges: Vec::new(),
                 }],
             },


### PR DESCRIPTION
## Summary

Advertise physical SMMUv3 PASID/SSID width and ATS support through an accelerated ARM vSMMU, and report the same ATS capability in ACPI IORT.

## Changes

- Decode physical SMMU `IDR1.SSIDSIZE` and `IDR0.ATS` from `IOMMU_GET_HW_INFO`.
- Resolve and freeze host-derived SSID/ATS capabilities before the guest can observe the vSMMU.
- Advertise the resolved values through vSMMU `IDR0` and `IDR1`.
- Acknowledge `CR0.ATSCHK` and forward `ATC_INV` only when the physical SMMU supports ATS.
- Preserve `S1Fmt`, `S1CDMax`, and `S1DSS` in nested STEs when SSID support is advertised, and preserve `EATS` when ATS is advertised.
- Derive each IORT root-complex ATS attribute from the resolved physical `IDR0.ATS` capability before firmware construction.

## Split PRs

- #4375 contains the independent per-endpoint PASID discovery and synthetic PCI capability previously included here.
- #4372 contains the ARM64 UEFI low-memory layout previously included here.
- #4373 contains the independently discovered MPIDR fix.
- #4374 contains configurable GICv2m SPI capacity.

## Validation

- `cargo +1.95.0 test -p smmu --lib` (172 passed)
- `cargo +1.95.0 test -p openvmm_core --lib` (56 passed)
- `OPENVMM_GUEST_TARGET=aarch64 RUSTFLAGS='-D warnings' cargo +1.95.0 clippy -p smmu -p openvmm_core --all-targets --all-features`
- `cargo xtask fmt --only-diffed`
- The combined vSMMU and endpoint behavior was validated with four GB200 GPUs in an Ubuntu 24.04 UEFI guest: CUDA initialization, 189471 MiB per GPU, and NVLink fabric all succeeded.
