### PR TITLE
CI: Give heavy tests more cores

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -34,14 +34,14 @@ slow-timeout = { period = "10m", terminate-after = 2 }
 [[profile.default.overrides]]
 filter = 'package(~vmm_tests) and test(very_heavy)'
 # Extra heavy tests have even more VPs. Internal runners fail when 32vp tests
-# are not run one at a time.
+# are not run one at a time. Default "very_heavy" topology is 32 VPs.
 threads-required = 32
 
 [[profile.default.overrides]]
 filter = 'package(~vmm_tests) and test(heavy) and not (test(very_heavy))'
 # Require more threads for heavy tests with more VPs to avoid unreliability
-# due to contention on the physical cores.
-threads-required = 4
+# due to contention on the physical cores. Default "heavy" topology is 16 VPs.
+threads-required = 12
 
 [[profile.default.overrides]]
 # use fuzzy-matching for the package() to allow out-of-tree tests to use the

--- a/vmm_tests/vmm_tests/tests/tests/x86_64/openhcl_linux_direct.rs
+++ b/vmm_tests/vmm_tests/tests/tests/x86_64/openhcl_linux_direct.rs
@@ -81,7 +81,7 @@ async fn mana_nic_shared_pool(
 
 /// Test an OpenHCL Linux direct VM with many NVMe devices assigned to VTL2 and vmbus relay.
 #[openvmm_test(openhcl_linux_direct_x64 [LATEST_LINUX_DIRECT_TEST_X64])]
-async fn many_nvme_devices_servicing_very_heavy(
+async fn many_nvme_devices_servicing_heavy(
     config: PetriVmBuilder<OpenVmmPetriBackend>,
     (igvm_file,): (ResolvedArtifact<impl petri_artifacts_common::tags::IsOpenhclIgvm>,),
 ) -> Result<(), anyhow::Error> {


### PR DESCRIPTION
"Heavy" tests create 16 VPs, but were only configured to have 4 threads by nextest. This could result in a 4x oversub if a lot of heavy tests were running. Give them more threads.

Also rename one test from very heavy to just heavy, since it's only creating 4 vps, but is doing a lot of work.

Hopefully this resolves some ARM vmm test flakiness we've seen recently.