### PR TITLE
netvsp - Extending VTL0 timeout to address blackout gaps (#4309)

### DIFF
--- a/openhcl/underhill_core/src/emuplat/netvsp.rs
+++ b/openhcl/underhill_core/src/emuplat/netvsp.rs
@@ -54,8 +54,9 @@ use vpci::bus_control::VpciBusControl;
 use vpci::bus_control::VpciBusEvent;
 
 /// Default timeout for actions communicating with other components where an action
-/// is expected to take time, but still complete in a reasonable window.
-const MAX_WAIT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+/// is expected to take time, but still complete in a reasonable window. Live Migration
+/// expects a 60s timeout.
+const MAX_WAIT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(60);
 
 #[derive(Debug)]
 enum HclNetworkVfManagerMessage {


### PR DESCRIPTION
Apparently 10s is not long enough, and is creating a noticeable issue with migrations. Extending to 60s to match host timeouts & avoid a noticeable blackout.

Backport of #4309 to address a live incident, no modifications required.