### PR TITLE
Deps: pin symcrypt by commit (#4352)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7903,7 +7903,7 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 [[package]]
 name = "symcrypt"
 version = "0.6.0"
-source = "git+https://github.com/microsoft/rust-symcrypt.git?branch=release%2F0.6.0#2d83888206139cb8cc522ea3617a1870674ac8a0"
+source = "git+https://github.com/microsoft/rust-symcrypt.git?rev=2d83888206139cb8cc522ea3617a1870674ac8a0#2d83888206139cb8cc522ea3617a1870674ac8a0"
 dependencies = [
  "libc",
  "symcrypt-sys",
@@ -7912,7 +7912,7 @@ dependencies = [
 [[package]]
 name = "symcrypt-sys"
 version = "0.4.0"
-source = "git+https://github.com/microsoft/rust-symcrypt.git?branch=release%2F0.6.0#2d83888206139cb8cc522ea3617a1870674ac8a0"
+source = "git+https://github.com/microsoft/rust-symcrypt.git?rev=2d83888206139cb8cc522ea3617a1870674ac8a0#2d83888206139cb8cc522ea3617a1870674ac8a0"
 dependencies = [
  "libc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -537,7 +537,7 @@ rsa = { version = "0.10.0-rc.18", default-features = false }
 sha1 = { version = "0.11.0", default-features = false }
 sha2 = { version = "0.11.0", default-features = false }
 signature = { version = "3.0.0", default-features = false }
-symcrypt = { version = "0.6.0", git = "https://github.com/microsoft/rust-symcrypt.git", branch = "release/0.6.0" }
+symcrypt = { version = "0.6.0", git = "https://github.com/microsoft/rust-symcrypt.git", rev = "2d83888206139cb8cc522ea3617a1870674ac8a0" }
 x509-cert = { version = "0.3.0-rc.4", default-features = false }
 
 # --- Data structures / collections ---


### PR DESCRIPTION
The symcrypt repo is undergoing some restructuring. Pin our dependency by commit instead of by branch to be safe.

Clean cherry-pick of #4352.

This has no behavior changes, it is merely a build system tweak for futureproofing.