### PR TITLE
CI: don't cancel-in-progress docs publishing

### DIFF
--- a/.github/workflows/openvmm-docs-ci.yaml
+++ b/.github/workflows/openvmm-docs-ci.yaml
@@ -521,7 +521,7 @@ jobs:
     name: publish openvmm.dev
     concurrency:
       group: publish-openvmm.dev
-      cancel-in-progress: true
+      cancel-in-progress: false
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/flowey/flowey_hvlite/src/pipelines/build_docs.rs
+++ b/flowey/flowey_hvlite/src/pipelines/build_docs.rs
@@ -179,7 +179,7 @@ impl IntoPipeline for BuildDocsCli {
                 .gh_set_pool(crate::pipelines_shared::gh_pools::linux_x64_gh())
                 .gh_set_concurrency_group(GhConcurrencyGroup {
                     name: "publish-openvmm.dev".into(),
-                    cancel_in_progress: true,
+                    cancel_in_progress: false,
                 })
                 .dep_on(
                     |ctx| flowey_lib_hvlite::_jobs::consolidate_and_publish_gh_pages::Params {


### PR DESCRIPTION
When github cancels a CI step due to cancel-in-progress it results in that CI run getting an ugly red X. As someone who's trying to get our CI to consistently have pretty green checkmarks, this annoys me. To fix it, disable cancel-in-progress. This will result in a tiny bit more CI usage, as we may end up running redundant publishing jobs on occasion, but this should be very minor. Having CI consistently and obviously green without needing investigation is, in my opinion, worth that trade.