### PR TITLE
hcl: Flush register page to appropriate vtl

### DIFF
--- a/openhcl/hcl/src/ioctl/aarch64.rs
+++ b/openhcl/hcl/src/ioctl/aarch64.rs
@@ -325,7 +325,8 @@ impl<'a> super::BackingPrivate<'a> for MshvArm64<'a> {
         reg_page.dirty = 0.into();
 
         // Set the registers now that the register page is marked invalid.
-        if let Err(err) = runner.set_vp_registers(GuestVtl::Vtl0, regs.as_slice()) {
+        let vtl = reg_page.vtl.try_into().unwrap();
+        if let Err(err) = runner.set_vp_registers(vtl, regs.as_slice()) {
             panic!(
                 "Failed to flush register page: {}",
                 &err as &dyn std::error::Error

--- a/openhcl/hcl/src/ioctl/x64.rs
+++ b/openhcl/hcl/src/ioctl/x64.rs
@@ -439,7 +439,8 @@ impl<'a> BackingPrivate<'a> for MshvX64<'a> {
         reg_page.dirty = 0.into();
 
         // Set the registers now that the register page is marked invalid.
-        if let Err(err) = runner.set_vp_registers(GuestVtl::Vtl0, regs.as_slice()) {
+        let vtl = reg_page.vtl.try_into().unwrap();
+        if let Err(err) = runner.set_vp_registers(vtl, regs.as_slice()) {
             panic!(
                 "Failed to flush register page: {}",
                 &err as &dyn std::error::Error


### PR DESCRIPTION
This shouldn't actually have any effect today, as we don't set up a register page for VTL 1, but it's strictly more correct and futureproof to do it this way.