### PR TITLE
snp: support IGVM launch on MSHV

### DIFF
--- a/Guide/src/reference/openvmm/management/cli.md
+++ b/Guide/src/reference/openvmm/management/cli.md
@@ -93,11 +93,23 @@ describes the source definitions.
   `snp`.
 
   SNP support is currently limited to Linux direct boot and is intended for
-  bring-up. MSHV SNP can expose Hyper-V enlightenments with `--hv --no-vmbus`;
-  VMBus devices remain unsupported. SNP does not support UEFI, VTL2, or
-  hugetlb-backed memory. In addition to the minimal emulated chipset and serial
-  console, optional devices are limited to virtio devices attached through
-  PCIe.
+  bring-up. It supports either loader-based kernel/initrd boot or an SNP IGVM
+  selected with `--igvm-personality linux-direct`. MSHV SNP can expose Hyper-V
+  enlightenments with `--hv --no-vmbus`; VMBus devices remain unsupported.
+  The IGVM must use VTL0, no shared GPA boundary, and no relocation metadata.
+
+  SNP does not support UEFI, VTL2, or hugetlb-backed memory. In addition to
+  the minimal emulated chipset and serial console, optional devices are
+  limited to virtio devices attached through PCIe.
+
+  A minimal MSHV IGVM invocation is:
+
+  ```bash
+  openvmm --hypervisor mshv --isolation snp \
+    --igvm path/to/snp-linux-direct.bin \
+    --igvm-personality linux-direct --com1 console \
+    --no-vmbus -m 160MB -p 1
+  ```
 * `--snp-restricted-injection`: Enable restricted interrupt injection in the
   loader-generated SNP VMSA. This bring-up option has no default and requires
   `--hypervisor mshv --isolation snp` with Linux direct boot. KVM SNP does not

--- a/vm/loader/igvmfilegen/src/main.rs
+++ b/vm/loader/igvmfilegen/src/main.rs
@@ -669,9 +669,6 @@ fn create_igvm_file<R: IgvmfilegenRegister + GuestArch + 'static>(
                 if shared_gpa_boundary_bits.is_some() {
                     bail!("snp_linux_direct does not support a shared GPA boundary");
                 }
-                if !matches!(injection_type, SnpInjectionType::Normal) {
-                    bail!("snp_linux_direct requires normal interrupt injection");
-                }
                 if !matches!(secure_avic, SecureAvicType::Disabled) {
                     bail!("snp_linux_direct requires secure AVIC to be disabled");
                 }
@@ -682,6 +679,7 @@ fn create_igvm_file<R: IgvmfilegenRegister + GuestArch + 'static>(
                     memory_page_count: *memory_page_count,
                     c_bit_position: *c_bit_position,
                     policy: SnpPolicy::from(*policy).with_debug(*enable_debug as u8),
+                    injection_type,
                     resources: &resources,
                 })?
             }

--- a/vm/loader/igvmfilegen/src/snp_linux_direct.rs
+++ b/vm/loader/igvmfilegen/src/snp_linux_direct.rs
@@ -15,6 +15,7 @@ use igvm_defs::SnpPolicy;
 use igvmfilegen_config::LinuxImage;
 use igvmfilegen_config::ResourceType;
 use igvmfilegen_config::Resources;
+use igvmfilegen_config::SnpInjectionType;
 use loader::importer::BootPageAcceptance;
 use loader::importer::ImageLoad;
 use loader::importer::X86Register;
@@ -58,6 +59,8 @@ pub struct BuildParams<'a> {
     pub c_bit_position: u8,
     /// The SNP guest policy.
     pub policy: SnpPolicy,
+    /// The SNP interrupt-injection mode.
+    pub injection_type: &'a SnpInjectionType,
     /// The kernel, optional initrd, and bootshim resources.
     pub resources: &'a Resources,
 }
@@ -158,13 +161,17 @@ fn new_loader(
     policy: SnpPolicy,
     c_bit_position: u8,
     memory_page_count: u64,
+    injection_type: &SnpInjectionType,
 ) -> IgvmLoader<X86Register> {
     IgvmLoader::new_snp_linux_direct(SnpLinuxDirectConfig {
         policy,
         c_bit_mask: 1u64 << c_bit_position,
         ram_page_count: memory_page_count,
         vmsa_page: Some(KVM_VMSA_GPA / PAGE_SIZE),
-        injection_type: InjectionType::Normal,
+        injection_type: match injection_type {
+            SnpInjectionType::Normal => InjectionType::Normal,
+            SnpInjectionType::Restricted => InjectionType::Restricted,
+        },
     })
 }
 
@@ -177,6 +184,7 @@ pub fn build(params: BuildParams<'_>) -> anyhow::Result<IgvmOutput> {
         memory_page_count,
         c_bit_position,
         policy,
+        injection_type,
         resources,
     } = params;
 
@@ -184,7 +192,7 @@ pub fn build(params: BuildParams<'_>) -> anyhow::Result<IgvmOutput> {
     let acpi_builder = layout.acpi_builder();
     let (mut kernel, mut initrd) = open_linux_resources(linux, resources)?;
     let initrd_config = initrd_config(&mut initrd)?;
-    let mut loader = new_loader(policy, c_bit_position, memory_page_count);
+    let mut loader = new_loader(policy, c_bit_position, memory_page_count, injection_type);
     let com1 = ComPort::Com1;
 
     let load_info = loader::linux::load_x86(
@@ -384,14 +392,21 @@ mod tests {
     const TEST_C_BIT_MASK: u64 = 1 << 51;
     const TEST_SHIM_ENTRY: u64 = 0x100000;
 
-    fn test_loader(ram_page_count: u64) -> IgvmLoader<X86Register> {
+    fn test_loader_with_injection(
+        ram_page_count: u64,
+        injection_type: InjectionType,
+    ) -> IgvmLoader<X86Register> {
         IgvmLoader::new_snp_linux_direct(SnpLinuxDirectConfig {
             policy: SnpPolicy::from(TEST_POLICY),
             c_bit_mask: TEST_C_BIT_MASK,
             ram_page_count,
             vmsa_page: Some(KVM_VMSA_GPA / PAGE_SIZE),
-            injection_type: InjectionType::Normal,
+            injection_type,
         })
+    }
+
+    fn test_loader(ram_page_count: u64) -> IgvmLoader<X86Register> {
+        test_loader_with_injection(ram_page_count, InjectionType::Normal)
     }
 
     fn import_test_registers(importer: &mut dyn ImageLoad<X86Register>, params_gpa: u64) {
@@ -595,6 +610,30 @@ mod tests {
         assert_eq!(vmsa.idtr.limit, 0xffff);
         assert_eq!(vmsa.x87_fcw, x86defs::xsave::INIT_FCW);
         assert_eq!(vmsa.mxcsr, x86defs::xsave::DEFAULT_MXCSR);
+    }
+
+    #[test]
+    fn normal_and_restricted_vmsas_use_the_selected_injection_mode() {
+        for (injection_type, restricted) in [
+            (InjectionType::Normal, false),
+            (InjectionType::Restricted, true),
+        ] {
+            let mut loader = test_loader_with_injection(1, injection_type);
+            import_test_registers(&mut loader.loader(), 0x6000);
+            let output = loader.finalize().unwrap();
+            let vmsa = output
+                .guest
+                .directives()
+                .iter()
+                .find_map(|directive| match directive {
+                    IgvmDirectiveHeader::SnpVpContext { vmsa, .. } => Some(vmsa),
+                    _ => None,
+                })
+                .unwrap();
+            assert!(vmsa.sev_features.snp());
+            assert_eq!(vmsa.sev_features.restrict_injection(), restricted);
+            assert!(!vmsa.sev_features.alternate_injection());
+        }
     }
 
     #[test]

--- a/vm/loader/igvmfilegen/src/snp_linux_direct.rs
+++ b/vm/loader/igvmfilegen/src/snp_linux_direct.rs
@@ -44,7 +44,8 @@ const PAGE_SIZE: u64 = igvm_defs::PAGE_SIZE_4K;
 /// finish, after all userspace-provided launch-update pages.
 ///
 /// Keep the BSP context at this address until KVM supports userspace-supplied
-/// VMSA pages. MSHV can import the same context at this fixed address.
+/// VMSA pages. The MSHV path validates this address against the partition's
+/// physical address width and maps separate userspace backing for the VMSA.
 const KVM_VMSA_GPA: u64 = 0xffff_ffff_f000;
 
 /// Inputs for the deterministic SNP Linux-direct guest layout.

--- a/vm/loader/igvmfilegen_config/src/lib.rs
+++ b/vm/loader/igvmfilegen_config/src/lib.rs
@@ -503,6 +503,25 @@ mod test {
     }
 
     #[test]
+    fn parse_restricted_snp_linux_direct_manifest() {
+        let config: Config = serde_json::from_str(include_str!(
+            "../../manifests/snp-linux-direct-restricted.json"
+        ))
+        .unwrap();
+        let [guest] = config.guest_configs.as_slice() else {
+            panic!("expected one guest config");
+        };
+        assert!(matches!(
+            guest.isolation_type,
+            ConfigIsolationType::Snp {
+                injection_type: SnpInjectionType::Restricted,
+                ..
+            }
+        ));
+        guest.image.validate().unwrap();
+    }
+
+    #[test]
     fn snp_linux_direct_required_resources_with_initrd() {
         let image = snp_linux_direct_image(true, 1, 40960, 51);
 

--- a/vm/loader/manifests/README.md
+++ b/vm/loader/manifests/README.md
@@ -21,8 +21,8 @@ resource file and run `igvmfilegen manifest` directly.
 The normal-injection output is a shared artifact: the same binary is intended
 to boot on KVM and MSHV. Its `SnpVpContext` uses the SNP initial-VMSA GPA
 `0xffff_ffff_f000`. KVM synthesizes its measured VMSA at that GPA, while MSHV
-maps and imports the file-provided VMSA there. Both backends submit the policy
-and SNP ID block encoded in the file.
+maps and imports the file-provided VMSA there. Both backends use the policy
+encoded in the file, but only MSHV submits its SNP ID block.
 
 The `snp-linux-direct-restricted.json` profile encodes restricted interrupt
 injection in its IGVM VMSA. It is intended only for MSHV bring-up.

--- a/vm/loader/manifests/README.md
+++ b/vm/loader/manifests/README.md
@@ -18,12 +18,21 @@ resource file and run `igvmfilegen manifest` directly.
 - SNP C-bit position 51; the value must be bit 32 or higher because the
   startup page tables identity-map the lower 4 GiB
 
+The normal-injection output is a shared artifact: the same binary is intended
+to boot on KVM and MSHV. Its `SnpVpContext` uses the SNP initial-VMSA GPA
+`0xffff_ffff_f000`. KVM synthesizes its measured VMSA at that GPA, while MSHV
+maps and imports the file-provided VMSA there. Both backends submit the policy
+and SNP ID block encoded in the file.
+
+The `snp-linux-direct-restricted.json` profile encodes restricted interrupt
+injection in its IGVM VMSA. It is intended only for MSHV bring-up.
+
 The image contains a small measured bootshim. Only pages containing the kernel,
 initrd, boot metadata, SNP special pages, bootshim, or bootshim parameters are
-included as IGVM `PageData`. After SNP launch, the bootshim accepts the remaining
-private RAM with `PVALIDATE` and then enters Linux. This avoids loading and
-measuring every configured RAM page, but still accepts all RAM before Linux
-starts.
+included as IGVM `PageData`. After SNP launch, the bootshim accepts the
+remaining private RAM with `PVALIDATE` and then enters Linux. This avoids
+loading and measuring every configured RAM page, but still accepts all RAM
+before Linux starts.
 
 The IGVM contains only the BSP VMSA, regardless of processor count. Backends
 are responsible for any AP launch state they require. Current KVM constructs
@@ -62,8 +71,9 @@ cargo build -p igvmfilegen
 Then generate the image:
 
 ```bash
+repo=/absolute/path/to/openvmm
 cargo run -p igvmfilegen -- manifest \
-  --manifest /absolute/path/to/openvmm/vm/loader/manifests/snp-linux-direct.json \
+  --manifest "$repo/vm/loader/manifests/snp-linux-direct.json" \
   --resources /absolute/path/to/snp-linux-direct-resources.json \
   --output /absolute/path/to/snp-linux-direct.bin
 ```

--- a/vm/loader/manifests/snp-linux-direct-restricted.json
+++ b/vm/loader/manifests/snp-linux-direct-restricted.json
@@ -1,0 +1,29 @@
+{
+    "guest_arch": "x64",
+    "guest_configs": [
+        {
+            "guest_svn": 1,
+            "max_vtl": 0,
+            "isolation_type": {
+                "snp": {
+                    "shared_gpa_boundary_bits": null,
+                    "policy": 196608,
+                    "enable_debug": true,
+                    "injection_type": "restricted",
+                    "secure_avic": "disabled"
+                }
+            },
+            "image": {
+                "snp_linux_direct": {
+                    "linux": {
+                        "use_initrd": true,
+                        "command_line": "console=ttyS0 earlyprintk=serial earlycon panic=-1"
+                    },
+                    "processor_count": 1,
+                    "memory_page_count": 40960,
+                    "c_bit_position": 51
+                }
+            }
+        }
+    ]
+}

--- a/vm/x86/x86defs/src/snp.rs
+++ b/vm/x86/x86defs/src/snp.rs
@@ -1086,6 +1086,60 @@ pub struct SnpPspIdBlock {
     pub policy: u64,
 }
 
+/// ECDSA signature in an SNP PSP ID authentication page.
+#[repr(C)]
+#[derive(Debug, Clone, Copy, IntoBytes, Immutable, KnownLayout, FromBytes)]
+pub struct SnpPspIdAuthSignature {
+    /// ECDSA R component.
+    pub r: [u8; 72],
+    /// ECDSA S component.
+    pub s: [u8; 72],
+    /// Reserved bytes.
+    pub reserved: [u8; 368],
+}
+
+/// ECDSA public key in an SNP PSP ID authentication page.
+#[repr(C)]
+#[derive(Debug, Clone, Copy, IntoBytes, Immutable, KnownLayout, FromBytes)]
+pub struct SnpPspIdAuthPublicKey {
+    /// Elliptic curve identifier.
+    pub curve: u32,
+    /// Public key X coordinate.
+    pub qx: [u8; 72],
+    /// Public key Y coordinate.
+    pub qy: [u8; 72],
+    /// Reserved bytes.
+    pub reserved: [u8; 880],
+}
+
+/// SNP PSP ID block authentication page.
+///
+/// This is the `ID_AUTH` structure supplied with `SNP_LAUNCH_FINISH`.
+#[repr(C)]
+#[derive(Debug, Clone, Copy, IntoBytes, Immutable, KnownLayout, FromBytes)]
+pub struct SnpPspIdAuth {
+    /// Algorithm used by the ID key.
+    pub id_key_algorithm: u32,
+    /// Algorithm used by the author key.
+    pub author_key_algorithm: u32,
+    /// Reserved bytes.
+    pub reserved0: [u8; 56],
+    /// Signature of the ID block by the ID key.
+    pub id_block_signature: SnpPspIdAuthSignature,
+    /// ID public key.
+    pub id_key: SnpPspIdAuthPublicKey,
+    /// Reserved bytes.
+    pub reserved1: [u8; 60],
+    /// Signature of the ID key by the author key.
+    pub id_key_signature: SnpPspIdAuthSignature,
+    /// Author public key.
+    pub author_key: SnpPspIdAuthPublicKey,
+    /// Reserved bytes.
+    pub reserved2: [u8; 892],
+}
+
+const_assert_eq!(size_of::<SnpPspIdAuth>(), 4096);
+
 /// ECDSA signature components used by an SNP ID block.
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub struct SnpIdBlockSignature {

--- a/vmm_core/virt/src/x86/snp.rs
+++ b/vmm_core/virt/src/x86/snp.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-//! SEV-SNP initial VMSA conversion.
+//! SEV-SNP launch helpers.
 //!
 //! [`vmsa_from_initial_regs`] is used by the shared direct-boot loader for SNP
 //! backends, including KVM and MSHV. [`state_from_vmsa`] is currently used by
@@ -46,6 +46,54 @@ pub enum SnpVmsaError {
 pub struct SnpVmsaConfig {
     /// Enables restricted interrupt injection.
     pub restricted_injection: bool,
+}
+
+/// Builds the PSP ID block for `id_block` and the launch `policy`.
+pub fn snp_id_block(id_block: &crate::SnpIdBlock, policy: u64) -> x86defs::snp::SnpPspIdBlock {
+    x86defs::snp::SnpPspIdBlock {
+        ld: id_block.launch_digest,
+        family_id: id_block.family_id,
+        image_id: id_block.image_id,
+        version: id_block.version,
+        guest_svn: id_block.guest_svn,
+        policy,
+    }
+}
+
+/// Serializes the PSP ID authentication data for `id_block`.
+pub fn snp_id_auth(id_block: &crate::SnpIdBlock) -> Box<[u8; 4096]> {
+    const ID_BLOCK_SIGNATURE: usize = 64;
+    const ID_KEY: usize = 576;
+    const AUTHOR_KEY_SIGNATURE: usize = 1664;
+    const AUTHOR_KEY: usize = 2176;
+
+    fn write_signature(
+        page: &mut [u8],
+        offset: usize,
+        signature: &x86defs::snp::SnpIdBlockSignature,
+    ) {
+        page[offset..offset + 72].copy_from_slice(&signature.r);
+        page[offset + 72..offset + 144].copy_from_slice(&signature.s);
+    }
+
+    fn write_public_key(page: &mut [u8], offset: usize, key: &x86defs::snp::SnpIdBlockPublicKey) {
+        page[offset..offset + 4].copy_from_slice(&key.curve.to_le_bytes());
+        page[offset + 4..offset + 76].copy_from_slice(&key.qx);
+        page[offset + 76..offset + 148].copy_from_slice(&key.qy);
+    }
+
+    let mut page = Box::new([0; 4096]);
+    page[0..4].copy_from_slice(&id_block.id_key_algorithm.to_le_bytes());
+    page[4..8].copy_from_slice(&id_block.author_key_algorithm.to_le_bytes());
+    write_signature(&mut *page, ID_BLOCK_SIGNATURE, &id_block.id_key_signature);
+    write_public_key(&mut *page, ID_KEY, &id_block.id_public_key);
+    write_signature(
+        &mut *page,
+        AUTHOR_KEY_SIGNATURE,
+        &id_block.author_key_signature,
+    );
+    write_public_key(&mut *page, AUTHOR_KEY, &id_block.author_public_key);
+    page
 }
 
 /// Builds the direct-boot SNP VMSA corresponding to `initial`.
@@ -193,6 +241,91 @@ fn table_from_vmsa(selector: SevSelector) -> TableRegister {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn test_id_block() -> crate::SnpIdBlock {
+        crate::SnpIdBlock {
+            author_key_enabled: 1,
+            launch_digest: [0x11; 48],
+            family_id: [0x22; 16],
+            image_id: [0x33; 16],
+            version: 1,
+            guest_svn: 7,
+            id_key_algorithm: 0x01020304,
+            author_key_algorithm: 0x05060708,
+            id_key_signature: x86defs::snp::SnpIdBlockSignature {
+                r: [0x44; 72],
+                s: [0x55; 72],
+            },
+            id_public_key: x86defs::snp::SnpIdBlockPublicKey {
+                curve: 2,
+                qx: [0x66; 72],
+                qy: [0x77; 72],
+            },
+            author_key_signature: x86defs::snp::SnpIdBlockSignature {
+                r: [0x88; 72],
+                s: [0x99; 72],
+            },
+            author_public_key: x86defs::snp::SnpIdBlockPublicKey {
+                curve: 3,
+                qx: [0xaa; 72],
+                qy: [0xbb; 72],
+            },
+        }
+    }
+
+    #[test]
+    fn snp_id_block_preserves_fields_and_policy() {
+        let source = test_id_block();
+        let id_block = snp_id_block(&source, 0x1234);
+
+        assert_eq!(id_block.ld, source.launch_digest);
+        assert_eq!(id_block.family_id, source.family_id);
+        assert_eq!(id_block.image_id, source.image_id);
+        assert_eq!(id_block.version, source.version);
+        assert_eq!(id_block.guest_svn, source.guest_svn);
+        assert_eq!(id_block.policy, 0x1234);
+    }
+
+    #[test]
+    fn snp_id_auth_serializes_algorithms() {
+        let id_block = test_id_block();
+        let id_auth = snp_id_auth(&id_block);
+
+        assert_eq!(&id_auth[0..4], &id_block.id_key_algorithm.to_le_bytes());
+        assert_eq!(&id_auth[4..8], &id_block.author_key_algorithm.to_le_bytes());
+    }
+
+    #[test]
+    fn snp_id_auth_serializes_signatures_and_keys_at_psp_offsets() {
+        let id_block = test_id_block();
+        let id_auth = snp_id_auth(&id_block);
+
+        assert_eq!(&id_auth[64..136], &id_block.id_key_signature.r);
+        assert_eq!(&id_auth[136..208], &id_block.id_key_signature.s);
+        assert_eq!(
+            &id_auth[576..580],
+            &id_block.id_public_key.curve.to_le_bytes()
+        );
+        assert_eq!(&id_auth[580..652], &id_block.id_public_key.qx);
+        assert_eq!(&id_auth[652..724], &id_block.id_public_key.qy);
+        assert_eq!(&id_auth[1664..1736], &id_block.author_key_signature.r);
+        assert_eq!(&id_auth[1736..1808], &id_block.author_key_signature.s);
+        assert_eq!(
+            &id_auth[2176..2180],
+            &id_block.author_public_key.curve.to_le_bytes()
+        );
+        assert_eq!(&id_auth[2180..2252], &id_block.author_public_key.qx);
+        assert_eq!(&id_auth[2252..2324], &id_block.author_public_key.qy);
+    }
+
+    #[test]
+    fn snp_id_auth_zero_pads_reserved_bytes() {
+        let id_auth = snp_id_auth(&test_id_block());
+
+        for reserved in [8..64, 208..576, 724..1664, 1808..2176, 2324..4096] {
+            assert!(id_auth[reserved].iter().all(|&byte| byte == 0));
+        }
+    }
 
     #[test]
     fn direct_boot_vmsa_round_trips() {

--- a/vmm_core/virt/src/x86/snp.rs
+++ b/vmm_core/virt/src/x86/snp.rs
@@ -60,40 +60,22 @@ pub fn snp_id_block(id_block: &crate::SnpIdBlock, policy: u64) -> x86defs::snp::
     }
 }
 
-/// Serializes the PSP ID authentication data for `id_block`.
-pub fn snp_id_auth(id_block: &crate::SnpIdBlock) -> Box<[u8; 4096]> {
-    const ID_BLOCK_SIGNATURE: usize = 64;
-    const ID_KEY: usize = 576;
-    const AUTHOR_KEY_SIGNATURE: usize = 1664;
-    const AUTHOR_KEY: usize = 2176;
-
-    fn write_signature(
-        page: &mut [u8],
-        offset: usize,
-        signature: &x86defs::snp::SnpIdBlockSignature,
-    ) {
-        page[offset..offset + 72].copy_from_slice(&signature.r);
-        page[offset + 72..offset + 144].copy_from_slice(&signature.s);
-    }
-
-    fn write_public_key(page: &mut [u8], offset: usize, key: &x86defs::snp::SnpIdBlockPublicKey) {
-        page[offset..offset + 4].copy_from_slice(&key.curve.to_le_bytes());
-        page[offset + 4..offset + 76].copy_from_slice(&key.qx);
-        page[offset + 76..offset + 148].copy_from_slice(&key.qy);
-    }
-
-    let mut page = Box::new([0; 4096]);
-    page[0..4].copy_from_slice(&id_block.id_key_algorithm.to_le_bytes());
-    page[4..8].copy_from_slice(&id_block.author_key_algorithm.to_le_bytes());
-    write_signature(&mut *page, ID_BLOCK_SIGNATURE, &id_block.id_key_signature);
-    write_public_key(&mut *page, ID_KEY, &id_block.id_public_key);
-    write_signature(
-        &mut *page,
-        AUTHOR_KEY_SIGNATURE,
-        &id_block.author_key_signature,
-    );
-    write_public_key(&mut *page, AUTHOR_KEY, &id_block.author_public_key);
-    page
+/// Builds the PSP ID authentication page for `id_block`.
+pub fn snp_id_auth(id_block: &crate::SnpIdBlock) -> Box<x86defs::snp::SnpPspIdAuth> {
+    let mut auth = Box::new(x86defs::snp::SnpPspIdAuth::new_zeroed());
+    auth.id_key_algorithm = id_block.id_key_algorithm;
+    auth.author_key_algorithm = id_block.author_key_algorithm;
+    auth.id_block_signature.r = id_block.id_key_signature.r;
+    auth.id_block_signature.s = id_block.id_key_signature.s;
+    auth.id_key.curve = id_block.id_public_key.curve;
+    auth.id_key.qx = id_block.id_public_key.qx;
+    auth.id_key.qy = id_block.id_public_key.qy;
+    auth.id_key_signature.r = id_block.author_key_signature.r;
+    auth.id_key_signature.s = id_block.author_key_signature.s;
+    auth.author_key.curve = id_block.author_public_key.curve;
+    auth.author_key.qx = id_block.author_public_key.qx;
+    auth.author_key.qy = id_block.author_public_key.qy;
+    auth
 }
 
 /// Builds the direct-boot SNP VMSA corresponding to `initial`.
@@ -291,40 +273,50 @@ mod tests {
         let id_block = test_id_block();
         let id_auth = snp_id_auth(&id_block);
 
-        assert_eq!(&id_auth[0..4], &id_block.id_key_algorithm.to_le_bytes());
-        assert_eq!(&id_auth[4..8], &id_block.author_key_algorithm.to_le_bytes());
+        assert_eq!(id_auth.id_key_algorithm, id_block.id_key_algorithm);
+        assert_eq!(id_auth.author_key_algorithm, id_block.author_key_algorithm);
     }
 
     #[test]
-    fn snp_id_auth_serializes_signatures_and_keys_at_psp_offsets() {
+    fn snp_id_auth_serializes_signatures_and_keys() {
         let id_block = test_id_block();
         let id_auth = snp_id_auth(&id_block);
 
-        assert_eq!(&id_auth[64..136], &id_block.id_key_signature.r);
-        assert_eq!(&id_auth[136..208], &id_block.id_key_signature.s);
-        assert_eq!(
-            &id_auth[576..580],
-            &id_block.id_public_key.curve.to_le_bytes()
-        );
-        assert_eq!(&id_auth[580..652], &id_block.id_public_key.qx);
-        assert_eq!(&id_auth[652..724], &id_block.id_public_key.qy);
-        assert_eq!(&id_auth[1664..1736], &id_block.author_key_signature.r);
-        assert_eq!(&id_auth[1736..1808], &id_block.author_key_signature.s);
-        assert_eq!(
-            &id_auth[2176..2180],
-            &id_block.author_public_key.curve.to_le_bytes()
-        );
-        assert_eq!(&id_auth[2180..2252], &id_block.author_public_key.qx);
-        assert_eq!(&id_auth[2252..2324], &id_block.author_public_key.qy);
+        assert_eq!(id_auth.id_block_signature.r, id_block.id_key_signature.r);
+        assert_eq!(id_auth.id_block_signature.s, id_block.id_key_signature.s);
+        assert_eq!(id_auth.id_key.curve, id_block.id_public_key.curve);
+        assert_eq!(id_auth.id_key.qx, id_block.id_public_key.qx);
+        assert_eq!(id_auth.id_key.qy, id_block.id_public_key.qy);
+        assert_eq!(id_auth.id_key_signature.r, id_block.author_key_signature.r);
+        assert_eq!(id_auth.id_key_signature.s, id_block.author_key_signature.s);
+        assert_eq!(id_auth.author_key.curve, id_block.author_public_key.curve);
+        assert_eq!(id_auth.author_key.qx, id_block.author_public_key.qx);
+        assert_eq!(id_auth.author_key.qy, id_block.author_public_key.qy);
     }
 
     #[test]
     fn snp_id_auth_zero_pads_reserved_bytes() {
         let id_auth = snp_id_auth(&test_id_block());
 
-        for reserved in [8..64, 208..576, 724..1664, 1808..2176, 2324..4096] {
-            assert!(id_auth[reserved].iter().all(|&byte| byte == 0));
-        }
+        assert!(id_auth.reserved0.iter().all(|&byte| byte == 0));
+        assert!(
+            id_auth
+                .id_block_signature
+                .reserved
+                .iter()
+                .all(|&byte| byte == 0)
+        );
+        assert!(id_auth.id_key.reserved.iter().all(|&byte| byte == 0));
+        assert!(id_auth.reserved1.iter().all(|&byte| byte == 0));
+        assert!(
+            id_auth
+                .id_key_signature
+                .reserved
+                .iter()
+                .all(|&byte| byte == 0)
+        );
+        assert!(id_auth.author_key.reserved.iter().all(|&byte| byte == 0));
+        assert!(id_auth.reserved2.iter().all(|&byte| byte == 0));
     }
 
     #[test]

--- a/vmm_core/virt_mshv/src/lib.rs
+++ b/vmm_core/virt_mshv/src/lib.rs
@@ -211,7 +211,7 @@ impl<'a> MshvProtoPartition<'a> {
         Ok(MshvProtoPartition {
             config,
             #[cfg(guest_arch = "x86_64")]
-            snp_disable_cpuid_offload: false,
+            isolation: arch::MshvProtoPartitionIsolation::None,
             vmfd,
             vps,
             bsp,
@@ -232,18 +232,10 @@ pub fn is_available() -> Result<bool, Error> {
 pub struct MshvProtoPartition<'a> {
     config: ProtoPartitionConfig<'a>,
     #[cfg(guest_arch = "x86_64")]
-    snp_disable_cpuid_offload: bool,
+    isolation: arch::MshvProtoPartitionIsolation,
     vmfd: VmFd,
     vps: Vec<MshvVpInner>,
     bsp: VcpuFd,
-}
-
-#[cfg(guest_arch = "x86_64")]
-impl MshvProtoPartition<'_> {
-    fn with_snp_cpuid_offload_disabled(mut self, disabled: bool) -> Self {
-        self.snp_disable_cpuid_offload = disabled;
-        self
-    }
 }
 
 /// A partition running on the /dev/mshv hypervisor.
@@ -760,6 +752,30 @@ enum ErrorInner {
     #[cfg(guest_arch = "x86_64")]
     #[error("invalid MSHV configuration: {0}")]
     InvalidConfiguration(&'static str),
+    #[cfg(guest_arch = "x86_64")]
+    #[error("SNP IGVM requests unsupported highest VTL {0}")]
+    UnsupportedSnpVtl(u8),
+    #[cfg(guest_arch = "x86_64")]
+    #[error("SNP IGVM requests unsupported shared GPA boundary {0:#x}")]
+    UnsupportedSnpSharedGpaBoundary(u64),
+    #[cfg(guest_arch = "x86_64")]
+    #[error("MSHV does not support SNP IGVM relocation")]
+    SnpIgvmRelocationUnsupported,
+    #[cfg(guest_arch = "x86_64")]
+    #[error("SNP IGVM must contain exactly one BSP VP context")]
+    InvalidSnpIgvmTopology,
+    #[cfg(guest_arch = "x86_64")]
+    #[error("invalid SNP IGVM VMSA")]
+    InvalidSnpIgvmVmsa,
+    #[cfg(guest_arch = "x86_64")]
+    #[error("SNP IGVM VMSA GPA {0:#x} is invalid")]
+    InvalidSnpVmsaGpa(u64),
+    #[cfg(guest_arch = "x86_64")]
+    #[error("SNP IGVM VMSA overlaps configured guest RAM")]
+    SnpVmsaOverlapsRam,
+    #[cfg(guest_arch = "x86_64")]
+    #[error("SNP VMSA import does not match the configured IGVM VP context")]
+    InvalidSnpVmsaImport,
     #[error("failed to stat /dev/mshv")]
     AvailableCheck(#[source] io::Error),
     #[cfg(guest_arch = "x86_64")]

--- a/vmm_core/virt_mshv/src/lib.rs
+++ b/vmm_core/virt_mshv/src/lib.rs
@@ -765,8 +765,16 @@ enum ErrorInner {
     #[error("SNP IGVM must contain exactly one BSP VP context")]
     InvalidSnpIgvmTopology,
     #[cfg(guest_arch = "x86_64")]
-    #[error("invalid SNP IGVM VMSA")]
+    #[error("failed to parse the SNP IGVM VMSA")]
     InvalidSnpIgvmVmsa,
+    #[cfg(guest_arch = "x86_64")]
+    #[error(
+        "unsupported SNP IGVM VMSA state: SEV features {sev_features:#x}, virtual TOM {virtual_tom:#x}"
+    )]
+    UnsupportedSnpIgvmVmsa { sev_features: u64, virtual_tom: u64 },
+    #[cfg(guest_arch = "x86_64")]
+    #[error("SNP IGVM VMSA backing memory is not contiguous")]
+    InvalidSnpVmsaBacking,
     #[cfg(guest_arch = "x86_64")]
     #[error("SNP IGVM VMSA GPA {0:#x} is invalid")]
     InvalidSnpVmsaGpa(u64),

--- a/vmm_core/virt_mshv/src/x86_64/mod.rs
+++ b/vmm_core/virt_mshv/src/x86_64/mod.rs
@@ -69,14 +69,24 @@ use zerocopy::IntoBytes;
 
 mod snp;
 
+pub(crate) use snp::MshvSnpConfig;
 pub(super) use snp::SnpError;
 pub(crate) use snp::SnpLaunchState;
 pub(crate) use snp::SnpPartitionState;
 pub(crate) use snp::SnpVpState;
 pub(crate) use snp::acquire_snp_host_access;
+use snp::prepare_snp_config;
 use snp::snp_cpuid_overrides;
 use snp::snp_hv_cpuid_overrides;
 use snp::snp_start_vp_vmsa_gpa;
+
+pub(crate) enum MshvProtoPartitionIsolation {
+    None,
+    Snp {
+        config: Option<Box<MshvSnpConfig>>,
+        disable_cpuid_offload: bool,
+    },
+}
 
 impl virt::Hypervisor for LinuxMshv {
     type ProtoPartition<'a> = MshvProtoPartition<'a>;
@@ -89,15 +99,17 @@ impl virt::Hypervisor for LinuxMshv {
 
     fn new_partition<'a>(
         &mut self,
-        config: ProtoPartitionConfig<'a>,
+        mut config: ProtoPartitionConfig<'a>,
     ) -> Result<MshvProtoPartition<'a>, Self::Error> {
-        let isolation = config.isolation.isolation_type();
-        validate_snp_cpuid_offload_config(isolation, self.snp_disable_cpuid_offload)?;
-        let snp = match isolation {
-            virt::IsolationType::None => false,
-            virt::IsolationType::Snp => true,
+        // An IGVM supplies SNP state that MSHV needs before partition build.
+        let igvm_snp_config = match &mut config.isolation {
+            virt::ProtoPartitionIsolation::None => None,
+            virt::ProtoPartitionIsolation::Snp(snp_config) => snp_config.take(),
             _ => return Err(ErrorInner::IsolationNotSupported.into()),
         };
+        let isolation = config.isolation.isolation_type();
+        validate_snp_cpuid_offload_config(isolation, self.snp_disable_cpuid_offload)?;
+        let snp = isolation == virt::IsolationType::Snp;
         let x2apic = matches!(
             config.processor_topology.apic_mode(),
             vm_topology::processor::x86::ApicMode::X2ApicSupported
@@ -133,11 +145,17 @@ impl virt::Hypervisor for LinuxMshv {
             .map_err(|e| ErrorInner::CreateVMInitFailed(e.into()))?;
 
         if snp {
-            let snp_policy = mshv_bindings::snp::get_default_snp_guest_policy();
+            let snp_policy = igvm_snp_config.as_ref().map_or_else(
+                || {
+                    let policy = mshv_bindings::snp::get_default_snp_guest_policy();
+                    // SAFETY: This generated C union contains a valid u64 view.
+                    unsafe { policy.as_uint64 }
+                },
+                |config| config.policy,
+            );
             let vmgexit_offloads = snp_vmgexit_offloads(self.snp_disable_cpuid_offload);
-            // SAFETY: These generated C unions always contain a valid u64 view.
-            let (snp_policy, vmgexit_offloads) =
-                unsafe { (snp_policy.as_uint64, vmgexit_offloads.as_uint64) };
+            // SAFETY: This generated C union contains a valid u64 view.
+            let vmgexit_offloads = unsafe { vmgexit_offloads.as_uint64 };
 
             for (code, value) in [
                 (HvPartitionPropertyCode::IsolationPolicy, snp_policy),
@@ -164,8 +182,29 @@ impl virt::Hypervisor for LinuxMshv {
         )
         .map_err(|e| ErrorInner::SetPartitionProperty(e.into()))?;
 
-        Ok(MshvProtoPartition::new(config, vmfd)?
-            .with_snp_cpuid_offload_disabled(self.snp_disable_cpuid_offload))
+        let snp_config = if let Some(snp_config) = igvm_snp_config {
+            let physical_address_width =
+                vmfd.get_partition_property(HvPartitionPropertyCode::PhysicalAddressWidth.0)
+                    .map_err(|e| ErrorInner::GetPartitionProperty(e.into()))? as u8;
+            Some(Box::new(prepare_snp_config(
+                *snp_config,
+                physical_address_width,
+            )?))
+        } else {
+            None
+        };
+
+        let isolation = if snp {
+            MshvProtoPartitionIsolation::Snp {
+                config: snp_config,
+                disable_cpuid_offload: self.snp_disable_cpuid_offload,
+            }
+        } else {
+            MshvProtoPartitionIsolation::None
+        };
+        let mut proto = MshvProtoPartition::new(config, vmfd)?;
+        proto.isolation = isolation;
+        Ok(proto)
     }
 }
 
@@ -374,9 +413,24 @@ impl ProtoPartition for MshvProtoPartition<'_> {
         self,
         config: PartitionConfig<'_>,
     ) -> Result<(Self::Partition, Vec<Self::ProcessorBinder>), Self::Error> {
-        let isolation = self.config.isolation.isolation_type();
+        let snp_config = match &self.isolation {
+            MshvProtoPartitionIsolation::None => None,
+            MshvProtoPartitionIsolation::Snp { config, .. } => config.as_deref(),
+        };
+        if let Some(snp_config) = snp_config {
+            let vmsa_range =
+                MemoryRange::new(snp_config.vmsa_gpa..snp_config.vmsa_gpa + hvdef::HV_PAGE_SIZE);
+            if config
+                .mem_layout
+                .ram()
+                .iter()
+                .any(|range| range.range.overlaps(&vmsa_range))
+            {
+                return Err(ErrorInner::SnpVmsaOverlapsRam.into());
+            }
+        }
         let mut cpuid = config.cpuid.to_vec();
-        if isolation == virt::IsolationType::Snp {
+        if matches!(&self.isolation, MshvProtoPartitionIsolation::Snp { .. }) {
             let expose_hypervisor = self.config.hv_config.is_some();
             cpuid.extend(snp_cpuid_overrides(expose_hypervisor));
             if expose_hypervisor {
@@ -473,12 +527,15 @@ impl ProtoPartition for MshvProtoPartition<'_> {
             .map(|vp| vp.apic_id)
             .collect();
 
-        let isolation = match self.config.isolation.isolation_type() {
-            virt::IsolationType::None => MshvIsolationState::None,
-            virt::IsolationType::Snp => {
-                MshvIsolationState::Snp(SnpPartitionState::new(self.snp_disable_cpuid_offload))
-            }
-            _ => return Err(ErrorInner::IsolationNotSupported.into()),
+        let isolation = match self.isolation {
+            MshvProtoPartitionIsolation::None => MshvIsolationState::None,
+            MshvProtoPartitionIsolation::Snp {
+                config,
+                disable_cpuid_offload,
+            } => MshvIsolationState::Snp(SnpPartitionState::with_config(
+                disable_cpuid_offload,
+                config,
+            )),
         };
         let time_frozen = isolation.is_isolated();
         let inner = Arc::new(MshvPartitionInner {
@@ -499,6 +556,7 @@ impl ProtoPartition for MshvProtoPartition<'_> {
             // SNP partition creation set TimeFreeze=1 before this object was built.
             time_frozen: Mutex::new(time_frozen),
         });
+        inner.add_snp_vmsa_mapping()?;
 
         let partition = MshvPartition {
             synic_ports: Arc::new(virt::synic::SynicPorts::new(inner.clone())),

--- a/vmm_core/virt_mshv/src/x86_64/mod.rs
+++ b/vmm_core/virt_mshv/src/x86_64/mod.rs
@@ -99,12 +99,12 @@ impl virt::Hypervisor for LinuxMshv {
 
     fn new_partition<'a>(
         &mut self,
-        mut config: ProtoPartitionConfig<'a>,
+        config: ProtoPartitionConfig<'a>,
     ) -> Result<MshvProtoPartition<'a>, Self::Error> {
         // An IGVM supplies SNP state that MSHV needs before partition build.
-        let igvm_snp_config = match &mut config.isolation {
+        let igvm_snp_config = match &config.isolation {
             virt::ProtoPartitionIsolation::None => None,
-            virt::ProtoPartitionIsolation::Snp(snp_config) => snp_config.take(),
+            virt::ProtoPartitionIsolation::Snp(snp_config) => snp_config.as_deref(),
             _ => return Err(ErrorInner::IsolationNotSupported.into()),
         };
         let isolation = config.isolation.isolation_type();
@@ -187,7 +187,7 @@ impl virt::Hypervisor for LinuxMshv {
                 vmfd.get_partition_property(HvPartitionPropertyCode::PhysicalAddressWidth.0)
                     .map_err(|e| ErrorInner::GetPartitionProperty(e.into()))? as u8;
             Some(Box::new(prepare_snp_config(
-                *snp_config,
+                snp_config,
                 physical_address_width,
             )?))
         } else {
@@ -418,6 +418,9 @@ impl ProtoPartition for MshvProtoPartition<'_> {
             MshvProtoPartitionIsolation::Snp { config, .. } => config.as_deref(),
         };
         if let Some(snp_config) = snp_config {
+            // The IGVM VMSA has separate stable userspace backing. It cannot
+            // overlap the normal RAM mapping because that would register two
+            // different host mappings for the same GPA with MSHV.
             let vmsa_range =
                 MemoryRange::new(snp_config.vmsa_gpa..snp_config.vmsa_gpa + hvdef::HV_PAGE_SIZE);
             if config

--- a/vmm_core/virt_mshv/src/x86_64/snp.rs
+++ b/vmm_core/virt_mshv/src/x86_64/snp.rs
@@ -15,8 +15,6 @@ pub(crate) enum SnpError {
     MapGhcbPage(#[source] io::Error),
     #[error("SNP launch is already in progress")]
     LaunchInProgress,
-    #[error("SNP launch is already complete")]
-    LaunchAlreadyFinished,
     #[error("SNP launch previously failed")]
     LaunchFailed,
     #[error("unsupported SNP initial page import type: {0:?}")]
@@ -66,6 +64,82 @@ pub(crate) enum SnpLaunchState {
     Failed,
 }
 
+#[derive(Debug, inspect::Inspect)]
+pub(crate) struct MshvSnpConfig {
+    #[inspect(hex)]
+    policy: u64,
+    #[inspect(rename = "id_block_enabled", with = "Option::is_some")]
+    id_block: Option<virt::SnpIdBlock>,
+    #[inspect(hex)]
+    pub(super) vmsa_gpa: u64,
+    /// Stable userspace backing for the VMSA mapping registered with MSHV.
+    #[inspect(skip)]
+    vmsa_memory: GuestMemory,
+    #[inspect(hex)]
+    sev_features: u64,
+    restricted_injection: bool,
+}
+
+pub(super) fn prepare_snp_config(
+    config: virt::SnpConfig,
+    physical_address_width: u8,
+) -> Result<MshvSnpConfig, Error> {
+    if config.highest_vtl != 0 {
+        return Err(ErrorInner::UnsupportedSnpVtl(config.highest_vtl).into());
+    }
+    if config.shared_gpa_boundary != 0 {
+        return Err(ErrorInner::UnsupportedSnpSharedGpaBoundary(config.shared_gpa_boundary).into());
+    }
+    if config.has_relocation {
+        return Err(ErrorInner::SnpIgvmRelocationUnsupported.into());
+    }
+    if config.vp_contexts.len() != 1 || config.vp_contexts[0].vp_index != VpIndex::BSP {
+        return Err(ErrorInner::InvalidSnpIgvmTopology.into());
+    }
+
+    let vmsa = &config.vp_contexts[0];
+    let vmsa_end = vmsa
+        .gpa
+        .checked_add(hvdef::HV_PAGE_SIZE)
+        .ok_or(ErrorInner::InvalidSnpVmsaGpa(vmsa.gpa))?;
+    if !vmsa.gpa.is_multiple_of(hvdef::HV_PAGE_SIZE)
+        || (physical_address_width < u64::BITS as u8 && vmsa_end > (1u64 << physical_address_width))
+    {
+        return Err(ErrorInner::InvalidSnpVmsaGpa(vmsa.gpa).into());
+    }
+
+    let (parsed_vmsa, _) = x86defs::snp::SevVmsa::read_from_prefix(vmsa.page.as_ref())
+        .map_err(|_| ErrorInner::InvalidSnpIgvmVmsa)?;
+    let allowed_features = x86defs::snp::SevFeatures::new()
+        .with_snp(true)
+        .with_restrict_injection(true);
+    if !parsed_vmsa.sev_features.snp()
+        || parsed_vmsa.sev_features.vtom()
+        || parsed_vmsa.virtual_tom != 0
+        || u64::from(parsed_vmsa.sev_features) & !u64::from(allowed_features) != 0
+    {
+        return Err(ErrorInner::InvalidSnpIgvmVmsa.into());
+    }
+
+    let mut vmsa_memory = GuestMemory::allocate(hvdef::HV_PAGE_SIZE as usize);
+    let Some(vmsa_bytes) = vmsa_memory.inner_buf_mut() else {
+        return Err(ErrorInner::InvalidSnpIgvmVmsa.into());
+    };
+    vmsa_bytes.copy_from_slice(vmsa.page.as_ref());
+    let vmsa_gpa = vmsa.gpa;
+    let sev_features = parsed_vmsa.sev_features.into_bits();
+    let restricted_injection = parsed_vmsa.sev_features.restrict_injection();
+
+    Ok(MshvSnpConfig {
+        policy: config.policy,
+        id_block: config.id_block,
+        vmsa_gpa,
+        vmsa_memory,
+        sev_features,
+        restricted_injection,
+    })
+}
+
 #[derive(inspect::Inspect)]
 pub(crate) struct SnpPartitionState {
     /// Launch progress is synchronized because loading and memory mapping use
@@ -79,6 +153,7 @@ pub(crate) struct SnpPartitionState {
     /// feature set for subsequent requests.
     pub(super) sev_features: Mutex<Option<u64>>,
     pub(super) cpuid_offloads_enabled: bool,
+    config: Option<Box<MshvSnpConfig>>,
 }
 
 impl SnpPartitionState {
@@ -87,7 +162,17 @@ impl SnpPartitionState {
             launch_state: Mutex::new(SnpLaunchState::NotStarted),
             sev_features: Mutex::new(None),
             cpuid_offloads_enabled: !disable_cpuid_offload,
+            config: None,
         }
+    }
+
+    pub(super) fn with_config(
+        disable_cpuid_offload: bool,
+        config: Option<Box<MshvSnpConfig>>,
+    ) -> Self {
+        let mut state = Self::new(disable_cpuid_offload);
+        state.config = config;
+        state
     }
 }
 
@@ -575,6 +660,29 @@ impl virt::AcceptInitialPages for MshvPartition {
 }
 
 impl MshvPartitionInner {
+    pub(super) fn add_snp_vmsa_mapping(&self) -> Result<(), Error> {
+        let Some(config) = self.isolation.snp().and_then(|snp| snp.config.as_deref()) else {
+            return Ok(());
+        };
+        let Some(vmsa_bytes) = config.vmsa_memory.inner_buf() else {
+            return Err(ErrorInner::InvalidSnpIgvmVmsa.into());
+        };
+        let flags = (1 << mshv_bindings::MSHV_SET_MEM_BIT_WRITABLE)
+            | (1 << mshv_bindings::MSHV_SET_MEM_BIT_EXECUTABLE);
+        let region = mshv_bindings::mshv_user_mem_region {
+            size: hvdef::HV_PAGE_SIZE,
+            guest_pfn: config.vmsa_gpa / hvdef::HV_PAGE_SIZE,
+            userspace_addr: vmsa_bytes.as_ptr() as u64,
+            flags,
+            rsvd: [0; 7],
+        };
+        self.memory.lock().ranges.push(Some(crate::MshvMemoryRange {
+            region,
+            mapped: false,
+        }));
+        Ok(())
+    }
+
     fn snp_launch_initial_pages(&self, pages: &[virt::InitialPageImport]) -> Result<(), Error> {
         let Some(snp) = self.isolation.snp() else {
             return Err(ErrorInner::IsolationNotSupported.into());
@@ -584,9 +692,7 @@ impl MshvPartitionInner {
             match *state {
                 SnpLaunchState::NotStarted => *state = SnpLaunchState::Started,
                 SnpLaunchState::Started => return Err(SnpError::LaunchInProgress.into()),
-                SnpLaunchState::Finished => {
-                    return Err(SnpError::LaunchAlreadyFinished.into());
-                }
+                SnpLaunchState::Finished => return Ok(()),
                 SnpLaunchState::Failed => return Err(SnpError::LaunchFailed.into()),
             }
         }
@@ -609,14 +715,22 @@ impl MshvPartitionInner {
         pages: &[virt::InitialPageImport],
     ) -> Result<(), Error> {
         let (vmsa_gpa, cpuid_gpa) = snp_launch_pages(pages)?;
-        let vmsa = self
-            .gm
-            .read_plain::<x86defs::snp::SevVmsa>(vmsa_gpa)
-            .map_err(SnpError::GuestMemory)?;
+        let sev_features = if let Some(config) = &snp.config {
+            if vmsa_gpa != config.vmsa_gpa {
+                return Err(ErrorInner::InvalidSnpVmsaImport.into());
+            }
+            config.sev_features
+        } else {
+            let vmsa = self
+                .gm
+                .read_plain::<x86defs::snp::SevVmsa>(vmsa_gpa)
+                .map_err(SnpError::GuestMemory)?;
+            vmsa.sev_features.into_bits()
+        };
         // GHCB SNP AP-creation requests supply a new VMSA. Save the BSP launch
         // features so handle_snp_ap_create can require each AP VMSA to use the
         // same guest-visible SEV feature set.
-        *snp.sev_features.lock() = Some(vmsa.sev_features.into_bits());
+        *snp.sev_features.lock() = Some(sev_features);
         self.write_snp_cpuid_page(cpuid_gpa)?;
 
         self.vmfd
@@ -640,9 +754,7 @@ impl MshvPartitionInner {
 
         let mut batch_type = None;
         let mut batch = Vec::with_capacity(SNP_IMPORT_CHUNK_PAGES);
-        let mut sorted_pages = pages.to_vec();
-        sorted_pages.sort_by_key(|page| page.range.start());
-        for page in sorted_pages {
+        for page in ordered_snp_import_pages(pages, snp.config.is_some()) {
             let Some(page_type) = snp_isolated_page_type(page.import_type)? else {
                 continue;
             };
@@ -664,7 +776,7 @@ impl MshvPartitionInner {
             self.import_isolated_pages(page_type, &batch)?;
         }
 
-        self.complete_isolated_import()?;
+        self.complete_isolated_import(snp.config.as_deref())?;
 
         let sev_control =
             mshv_bindings::snp::get_sev_control_register(vmsa_gpa / hvdef::HV_PAGE_SIZE);
@@ -766,17 +878,81 @@ impl MshvPartitionInner {
         Ok(())
     }
 
-    fn complete_isolated_import(&self) -> Result<(), Error> {
+    fn complete_isolated_import(&self, config: Option<&MshvSnpConfig>) -> Result<(), Error> {
         let mut data = mshv_bindings::mshv_complete_isolated_import::default();
-        data.import_data.psp_parameters.id_block.policy =
-            mshv_bindings::snp::get_default_snp_guest_policy();
-        data.import_data.psp_parameters.id_block_enabled = 0;
-        data.import_data.psp_parameters.author_key_enabled = 0;
+        let (parameters, policy) = snp_launch_finish_data(config);
+        tracing::info!(
+            policy,
+            identity_enabled = parameters.id_block_enabled != 0,
+            vmsa_gpa = config.map(|config| config.vmsa_gpa),
+            restricted_injection = config.map(|config| config.restricted_injection),
+            "completing MSHV SNP launch"
+        );
+        data.import_data.psp_parameters = parameters;
         self.vmfd
             .complete_isolated_import(&data)
             .map_err(|e| SnpError::CompleteIsolatedImport(e.into()))?;
         Ok(())
     }
+}
+
+fn snp_launch_finish_data(
+    config: Option<&MshvSnpConfig>,
+) -> (mshv_bindings::hv_psp_launch_finish_data, u64) {
+    let mut parameters = mshv_bindings::hv_psp_launch_finish_data::default();
+    let policy = config.map_or_else(
+        || {
+            let policy = mshv_bindings::snp::get_default_snp_guest_policy();
+            // SAFETY: This generated C union contains a valid u64 view.
+            unsafe { policy.as_uint64 }
+        },
+        |config| config.policy,
+    );
+    parameters.id_block.policy = mshv_bindings::hv_snp_guest_policy { as_uint64: policy };
+
+    if let Some(source) = config.and_then(|config| config.id_block.as_ref()) {
+        let id_block = virt::x86::snp::snp_id_block(source, policy);
+        parameters.id_block.launch_digest = id_block.ld;
+        parameters.id_block.family_id = id_block.family_id;
+        parameters.id_block.image_id = id_block.image_id;
+        parameters.id_block.version = id_block.version;
+        parameters.id_block.guest_svn = id_block.guest_svn;
+
+        let id_auth = virt::x86::snp::snp_id_auth(source);
+        parameters
+            .id_auth_info
+            .id_block_signature
+            .copy_from_slice(&id_auth[64..576]);
+        parameters
+            .id_auth_info
+            .id_key
+            .copy_from_slice(&id_auth[576..1604]);
+        parameters
+            .id_auth_info
+            .id_key_signature
+            .copy_from_slice(&id_auth[1664..2176]);
+        parameters
+            .id_auth_info
+            .author_key
+            .copy_from_slice(&id_auth[2176..3204]);
+        parameters.id_auth_info.id_key_algorithm = source.id_key_algorithm;
+        parameters.id_auth_info.auth_key_algorithm = source.author_key_algorithm;
+        parameters.id_block_enabled = 1;
+        parameters.author_key_enabled = u8::from(source.author_key_enabled != 0);
+    }
+
+    (parameters, policy)
+}
+
+fn ordered_snp_import_pages(
+    pages: &[virt::InitialPageImport],
+    preserve_order: bool,
+) -> Vec<virt::InitialPageImport> {
+    let mut ordered_pages = pages.to_vec();
+    if !preserve_order {
+        ordered_pages.sort_by_key(|page| page.range.start());
+    }
+    ordered_pages
 }
 
 /// Finds and validates the unique VMSA and CPUID pages needed for SNP launch.

--- a/vmm_core/virt_mshv/src/x86_64/snp.rs
+++ b/vmm_core/virt_mshv/src/x86_64/snp.rs
@@ -67,7 +67,7 @@ pub(crate) enum SnpLaunchState {
 #[derive(Debug, inspect::Inspect)]
 pub(crate) struct MshvSnpConfig {
     #[inspect(hex)]
-    policy: u64,
+    snp_policy: u64,
     #[inspect(rename = "id_block_enabled", with = "Option::is_some")]
     id_block: Option<virt::SnpIdBlock>,
     #[inspect(hex)]
@@ -81,7 +81,7 @@ pub(crate) struct MshvSnpConfig {
 }
 
 pub(super) fn prepare_snp_config(
-    config: virt::SnpConfig,
+    config: &virt::SnpConfig,
     physical_address_width: u8,
 ) -> Result<MshvSnpConfig, Error> {
     if config.highest_vtl != 0 {
@@ -118,12 +118,16 @@ pub(super) fn prepare_snp_config(
         || parsed_vmsa.virtual_tom != 0
         || u64::from(parsed_vmsa.sev_features) & !u64::from(allowed_features) != 0
     {
-        return Err(ErrorInner::InvalidSnpIgvmVmsa.into());
+        return Err(ErrorInner::UnsupportedSnpIgvmVmsa {
+            sev_features: parsed_vmsa.sev_features.into_bits(),
+            virtual_tom: parsed_vmsa.virtual_tom,
+        }
+        .into());
     }
 
     let mut vmsa_memory = GuestMemory::allocate(hvdef::HV_PAGE_SIZE as usize);
     let Some(vmsa_bytes) = vmsa_memory.inner_buf_mut() else {
-        return Err(ErrorInner::InvalidSnpIgvmVmsa.into());
+        return Err(ErrorInner::InvalidSnpVmsaBacking.into());
     };
     vmsa_bytes.copy_from_slice(vmsa.page.as_ref());
     let vmsa_gpa = vmsa.gpa;
@@ -131,8 +135,8 @@ pub(super) fn prepare_snp_config(
     let restricted_injection = parsed_vmsa.sev_features.restrict_injection();
 
     Ok(MshvSnpConfig {
-        policy: config.policy,
-        id_block: config.id_block,
+        snp_policy: config.policy,
+        id_block: config.id_block.clone(),
         vmsa_gpa,
         vmsa_memory,
         sev_features,
@@ -665,7 +669,7 @@ impl MshvPartitionInner {
             return Ok(());
         };
         let Some(vmsa_bytes) = config.vmsa_memory.inner_buf() else {
-            return Err(ErrorInner::InvalidSnpIgvmVmsa.into());
+            return Err(ErrorInner::InvalidSnpVmsaBacking.into());
         };
         let flags = (1 << mshv_bindings::MSHV_SET_MEM_BIT_WRITABLE)
             | (1 << mshv_bindings::MSHV_SET_MEM_BIT_EXECUTABLE);
@@ -880,10 +884,10 @@ impl MshvPartitionInner {
 
     fn complete_isolated_import(&self, config: Option<&MshvSnpConfig>) -> Result<(), Error> {
         let mut data = mshv_bindings::mshv_complete_isolated_import::default();
-        let (parameters, policy) = snp_launch_finish_data(config);
+        let (parameters, snp_policy) = snp_launch_finish_data(config);
         tracing::info!(
-            policy,
-            identity_enabled = parameters.id_block_enabled != 0,
+            snp_policy,
+            id_block_enabled = parameters.id_block_enabled != 0,
             vmsa_gpa = config.map(|config| config.vmsa_gpa),
             restricted_injection = config.map(|config| config.restricted_injection),
             "completing MSHV SNP launch"
@@ -896,6 +900,10 @@ impl MshvPartitionInner {
     }
 }
 
+/// Builds the PSP launch-finish data from the prepared MSHV SNP configuration.
+///
+/// The returned `u64` is the effective SNP policy, which the caller records in
+/// launch diagnostics.
 fn snp_launch_finish_data(
     config: Option<&MshvSnpConfig>,
 ) -> (mshv_bindings::hv_psp_launch_finish_data, u64) {
@@ -906,7 +914,7 @@ fn snp_launch_finish_data(
             // SAFETY: This generated C union contains a valid u64 view.
             unsafe { policy.as_uint64 }
         },
-        |config| config.policy,
+        |config| config.snp_policy,
     );
     parameters.id_block.policy = mshv_bindings::hv_snp_guest_policy { as_uint64: policy };
 
@@ -922,21 +930,21 @@ fn snp_launch_finish_data(
         parameters
             .id_auth_info
             .id_block_signature
-            .copy_from_slice(&id_auth[64..576]);
+            .copy_from_slice(id_auth.id_block_signature.as_bytes());
         parameters
             .id_auth_info
             .id_key
-            .copy_from_slice(&id_auth[576..1604]);
+            .copy_from_slice(id_auth.id_key.as_bytes());
         parameters
             .id_auth_info
             .id_key_signature
-            .copy_from_slice(&id_auth[1664..2176]);
+            .copy_from_slice(id_auth.id_key_signature.as_bytes());
         parameters
             .id_auth_info
             .author_key
-            .copy_from_slice(&id_auth[2176..3204]);
-        parameters.id_auth_info.id_key_algorithm = source.id_key_algorithm;
-        parameters.id_auth_info.auth_key_algorithm = source.author_key_algorithm;
+            .copy_from_slice(id_auth.author_key.as_bytes());
+        parameters.id_auth_info.id_key_algorithm = id_auth.id_key_algorithm;
+        parameters.id_auth_info.auth_key_algorithm = id_auth.author_key_algorithm;
         parameters.id_block_enabled = 1;
         parameters.author_key_enabled = u8::from(source.author_key_enabled != 0);
     }
@@ -944,12 +952,17 @@ fn snp_launch_finish_data(
     (parameters, policy)
 }
 
+/// Returns launch pages in the order required by the active launch source.
+///
+/// IGVM page directives must retain file order so MSHV reproduces the launch
+/// digest signed by the ID block. Loader-generated launches have no external
+/// measurement order, so they retain the existing deterministic GPA sort.
 fn ordered_snp_import_pages(
     pages: &[virt::InitialPageImport],
-    preserve_order: bool,
+    preserve_measurement_order: bool,
 ) -> Vec<virt::InitialPageImport> {
     let mut ordered_pages = pages.to_vec();
-    if !preserve_order {
+    if !preserve_measurement_order {
         ordered_pages.sort_by_key(|page| page.range.start());
     }
     ordered_pages
@@ -1948,6 +1961,28 @@ mod tests {
                 virt::InitialPageImportType::CpuidExtendedState
             ))))
         ));
+    }
+
+    #[test]
+    fn orders_snp_import_pages_for_launch_source() {
+        let pages = [
+            virt::InitialPageImport {
+                range: MemoryRange::new(0x3000..0x4000),
+                import_type: virt::InitialPageImportType::Normal,
+                tag: "third",
+            },
+            virt::InitialPageImport {
+                range: MemoryRange::new(0x1000..0x2000),
+                import_type: virt::InitialPageImportType::Normal,
+                tag: "first",
+            },
+        ];
+
+        assert_eq!(ordered_snp_import_pages(&pages, true), pages);
+        assert_eq!(
+            ordered_snp_import_pages(&pages, false),
+            [pages[1].clone(), pages[0].clone()]
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Add SEV-SNP IGVM launch support to the MSHV backend. OpenVMM can now launch a measured Linux direct guest from IGVM-provided launch state instead of rebuilding the BSP VMSA in the VMM.

MSHV consumes the IGVM SNP policy, BSP VMSA, and optional ID block and authentication data. It validates the IGVM platform and VMSA configuration, preserves measured page-import order, keeps stable userspace backing for the VMSA, submits the policy and optional identity during launch completion, and activates the imported VMSA through the SEV control register.

## Implementation

Prepare the IGVM SNP configuration before partition build. Validate the requested VTL, shared GPA boundary, relocation metadata, VMSA GPA and feature set, and IGVM VP contexts against the configured topology.

Add shared SNP ID-block serialization helpers to `virt` and use them to build the MSHV PSP launch-finish payload. When identity data is present, OpenVMM supplies the launch digest, image identity, guest SVN, signatures, public keys, and key algorithms, and enables the ID-block and author-key flags.

Extend the Linux direct IGVM generator and manifest configuration with a restricted-injection image variant. The generated VMSA records the selected injection mode, which MSHV preserves when it imports the VMSA. Standard interrupt injection remains supported.

Update the OpenVMM CLI and manifest documentation for MSHV SNP IGVM boot.

## Current limitations

MSHV SNP IGVM boot currently supports VTL0, with no relocation metadata and no shared GPA boundary.
