### PR TITLE
flowey: copy junit xml instead of rename

### DIFF
--- a/flowey/flowey_lib_common/src/run_cargo_nextest_run.rs
+++ b/flowey/flowey_lib_common/src/run_cargo_nextest_run.rs
@@ -358,7 +358,7 @@ impl FlowNodeWithConfig for Node {
                             .join(junit_path);
                         let final_xml = std::env::current_dir()?.join("junit.xml");
                         // copy locally to avoid trashing the output between test runs
-                        fs_err::rename(emitted_xml, &final_xml)?;
+                        fs_err::copy(emitted_xml, &final_xml)?;
                         Some(final_xml.absolute()?)
                     } else {
                         None


### PR DESCRIPTION
I was occasionally seeing this error when running windows tests from wsl, so just copy the file like the comment says instead of moving it (across filesystem boundaries).

```
Error: failed to rename file from <vmm_tests_dir_on_windows>/target/nextest/ci/junit.xml to <openvmm_repo_dir_in_wsl>/flowey-out/.work/flowey_lib_common__run_cargo_nextest_run_0/junit.xml: Invalid cross-device link (os error 18)
```