### PR TITLE
vm_topology: fix mpidr generation to match kvm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10107,6 +10107,7 @@ dependencies = [
  "memory_range",
  "mesh_protobuf",
  "safe_intrinsics",
+ "test_with_tracing",
  "thiserror 2.0.16",
  "x86defs",
 ]

--- a/vm/vmcore/vm_topology/Cargo.toml
+++ b/vm/vmcore/vm_topology/Cargo.toml
@@ -28,5 +28,8 @@ safe_intrinsics.workspace = true
 [build-dependencies]
 build_rs_guest_arch.workspace = true
 
+[dev-dependencies]
+test_with_tracing.workspace = true
+
 [lints]
 workspace = true

--- a/vm/vmcore/vm_topology/src/processor/aarch64.rs
+++ b/vm/vmcore/vm_topology/src/processor/aarch64.rs
@@ -149,6 +149,22 @@ impl AsMut<VpInfo> for Aarch64VpInfo {
     }
 }
 
+/// Constructs the default MPIDR for a VP index.
+///
+/// `ICC_SGI1R_EL1.TargetList` directly addresses 16 affinity level 0 values.
+/// Without GIC range selector support, bit N targets the PE whose Aff0 is N,
+/// so Aff0 must remain in 0..=15 for every VP to receive SGIs. Carrying the
+/// remaining index bits into Aff1 and Aff2 also matches KVM's default
+/// vCPU-ID-to-MPIDR mapping.
+fn mpidr_from_vp_index(vp_index: u32, uniprocessor: bool) -> MpidrEl1 {
+    MpidrEl1::new()
+        .with_res1_31(true)
+        .with_u(uniprocessor)
+        .with_aff0((vp_index & 0xf) as u8)
+        .with_aff1(((vp_index >> 4) & 0xff) as u8)
+        .with_aff2(((vp_index >> 12) & 0xff) as u8)
+}
+
 impl TopologyBuilder<Aarch64Topology> {
     /// Returns a builder for creating an aarch64 processor topology.
     pub fn new_aarch64(platform: Aarch64PlatformConfig) -> Self {
@@ -189,19 +205,7 @@ impl TopologyBuilder<Aarch64Topology> {
         if !(64..=992).contains(&nr) || !nr.is_multiple_of(32) {
             return Err(InvalidTopology::InvalidGicNrIrqs(nr));
         }
-        let mpidrs = (0..proc_count).map(|vp_index| {
-            // TODO: construct mpidr appropriately for the specified
-            // topology.
-            let uni_proc = proc_count == 1;
-            let mut aff = (0..4).map(|i| (vp_index >> (8 * i)) as u8);
-            MpidrEl1::new()
-                .with_res1_31(true)
-                .with_u(uni_proc)
-                .with_aff0(aff.next().unwrap())
-                .with_aff1(aff.next().unwrap())
-                .with_aff2(aff.next().unwrap())
-                .with_aff3(aff.next().unwrap())
-        });
+        let mpidrs = (0..proc_count).map(|vp_index| mpidr_from_vp_index(vp_index, proc_count == 1));
         let gic_version = self.arch.platform.gic_version;
         self.build_with_vp_info(mpidrs.enumerate().map(move |(id, mpidr)| {
             // GICv3 assigns a per-VP redistributor region; GICv2 has no
@@ -281,5 +285,41 @@ impl ProcessorTopology<Aarch64Topology> {
     /// Returns the total number of GIC interrupts to configure.
     pub fn gic_nr_irqs(&self) -> u32 {
         self.arch.platform.gic_nr_irqs
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::MpidrEl1;
+    use super::mpidr_from_vp_index;
+    use std::collections::HashSet;
+    use test_with_tracing::test;
+
+    #[test]
+    fn default_mpidr_crosses_aff0_boundary_at_16() {
+        let mpidr15 = mpidr_from_vp_index(15, false);
+        assert_eq!(mpidr15.aff0(), 15);
+        assert_eq!(mpidr15.aff1(), 0);
+
+        let mpidr16 = mpidr_from_vp_index(16, false);
+        assert_eq!(mpidr16.aff0(), 0);
+        assert_eq!(mpidr16.aff1(), 1);
+
+        let mpidr17 = mpidr_from_vp_index(17, false);
+        assert_eq!(mpidr17.aff0(), 1);
+        assert_eq!(mpidr17.aff1(), 1);
+    }
+
+    #[test]
+    fn default_mpidrs_are_unique_and_sgi_addressable() {
+        let mut affinities = HashSet::new();
+
+        for vp_index in 0..u32::from(u8::MAX) {
+            let mpidr = mpidr_from_vp_index(vp_index, false);
+            let affinity = u64::from(mpidr) & u64::from(MpidrEl1::AFFINITY_MASK);
+
+            assert!(mpidr.aff0() < 16);
+            assert!(affinities.insert(affinity));
+        }
     }
 }

--- a/vmm_tests/vmm_tests/tests/tests/aarch64_exclusive.rs
+++ b/vmm_tests/vmm_tests/tests/tests/aarch64_exclusive.rs
@@ -8,6 +8,7 @@ use pal_async::DefaultDriver;
 use pal_async::timer::PolledTimer;
 use petri::PetriVmBuilder;
 use petri::PetriVmmBackend;
+use petri::ProcessorTopology;
 use petri::openvmm::OpenVmmPetriBackend;
 use petri::pipette::cmd;
 use std::time::Duration;
@@ -15,6 +16,48 @@ use vfio_assigned_device_resources::BarAddressConfig;
 use vm_resource::IntoResource;
 use vmm_test_macros::vmm_test;
 use vmm_test_macros::vmm_test_with;
+
+/// Verify that a vCPU above the GICv3 Aff0 boundary can boot and be hotplugged.
+///
+/// The `_aarch64_tcg` suffix opts this test into the QEMU incubator CI pass.
+#[cfg(target_os = "linux")]
+#[vmm_test_with(openvmm, configs(linux_direct_aarch64))]
+async fn cpu_affinity_over_16_aarch64_tcg(
+    config: PetriVmBuilder<OpenVmmPetriBackend>,
+) -> anyhow::Result<()> {
+    const VP_COUNT: u32 = 17;
+    const TARGET_CPU: u32 = 16;
+
+    let (vm, agent) = config
+        .with_processor_topology(ProcessorTopology {
+            vp_count: VP_COUNT,
+            vps_per_socket: Some(16),
+            enable_smt: Some(false),
+            apic_mode: None,
+        })
+        .with_no_hv()
+        .modify_backend(|b| b.with_pcie_root_topology(1, 1, 1))
+        .run()
+        .await?;
+
+    let sh = agent.unix_shell();
+    let online = cmd!(sh, "cat /sys/devices/system/cpu/online")
+        .read()
+        .await?;
+    assert_eq!(online.trim(), "0-16", "not all configured CPUs came online");
+
+    let online_path = format!("/sys/devices/system/cpu/cpu{TARGET_CPU}/online");
+    let hotplug = format!("echo 0 > {online_path} && echo 1 > {online_path}");
+    cmd!(sh, "sh -c {hotplug}").run().await?;
+
+    let target_online = cmd!(sh, "cat {online_path}").read().await?;
+    assert_eq!(target_online.trim(), "1", "CPU 16 did not come back online");
+
+    drop(agent);
+    tracing::info!("dropping VM");
+    drop(vm);
+    Ok(())
+}
 
 /// Boot Linux and verify the PMU interrupt is available.
 ///


### PR DESCRIPTION
MPIDR generation was TODO and did not generate the correct values that matched what KVM internally created, so a guest was not able to start any processors if there are more than 16 of them. Fix this and add a vmm_test to verify that the guest can start a vm with more than 16 processors. 