### PR TITLE
aarch64: make GICv2m SPI count configurable

### DIFF
--- a/openvmm/openvmm_entry/src/cli_args.rs
+++ b/openvmm/openvmm_entry/src/cli_args.rs
@@ -612,7 +612,7 @@ options:
     #[clap(long, default_value = "auto", value_parser = parse_x2apic)]
     pub x2apic: X2ApicConfig,
 
-    /// configure PCIe MSI controller for aarch64 (auto | its | v2m)
+    /// configure PCIe MSI controller for aarch64 (auto | its | v2m[,spi_count=N])
     #[cfg(guest_arch = "aarch64")]
     #[clap(long, default_value = "auto")]
     pub gic_msi: GicMsiCli,
@@ -2824,7 +2824,7 @@ pub enum Vtl0LateMapPolicyCli {
 }
 
 /// PCIe MSI controller selection for aarch64.
-#[derive(Debug, Copy, Clone, Default, ValueEnum)]
+#[derive(Debug, Copy, Clone, Default, PartialEq, Eq)]
 pub enum GicMsiCli {
     /// Use ITS when available, fall back to GICv2m.
     #[default]
@@ -2832,7 +2832,52 @@ pub enum GicMsiCli {
     /// Force GICv3 ITS (LPI-based MSIs).
     Its,
     /// Force GICv2m (SPI-based MSIs).
-    V2m,
+    V2m {
+        /// Number of SPIs reserved for MSI delivery.
+        spi_count: Option<u32>,
+    },
+}
+
+impl FromStr for GicMsiCli {
+    type Err = anyhow::Error;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "auto" => return Ok(Self::Auto),
+            "its" => return Ok(Self::Its),
+            "v2m" => return Ok(Self::V2m { spi_count: None }),
+            _ => {}
+        }
+
+        let options = value
+            .strip_prefix("v2m,")
+            .context("expected auto, its, v2m, or v2m,spi_count=N")?;
+        let mut spi_count = None;
+        for option in options.split(',') {
+            let count = option
+                .strip_prefix("spi_count=")
+                .context("expected v2m,spi_count=N")?
+                .parse::<u32>()
+                .context("spi_count must be a positive integer")?;
+            anyhow::ensure!(count != 0, "spi_count must be a positive integer");
+            anyhow::ensure!(
+                spi_count.replace(count).is_none(),
+                "duplicate spi_count option"
+            );
+        }
+
+        Ok(Self::V2m { spi_count })
+    }
+}
+
+impl GicMsiCli {
+    pub fn into_config(self) -> openvmm_defs::config::GicMsiConfig {
+        match self {
+            Self::Auto => openvmm_defs::config::GicMsiConfig::Auto,
+            Self::Its => openvmm_defs::config::GicMsiConfig::Its,
+            Self::V2m { spi_count } => openvmm_defs::config::GicMsiConfig::V2m { spi_count },
+        }
+    }
 }
 
 #[derive(Debug, Copy, Clone, ValueEnum)]
@@ -4962,6 +5007,36 @@ mod tests {
             Options::try_parse_from(["openvmm", "--uefi", "--no-hv", "--no-vmbus", "--hv"])
                 .is_err()
         );
+    }
+
+    #[test]
+    fn test_gic_msi_cli_from_str() {
+        assert_eq!(GicMsiCli::from_str("auto").unwrap(), GicMsiCli::Auto);
+        assert_eq!(GicMsiCli::from_str("its").unwrap(), GicMsiCli::Its);
+        assert_eq!(
+            GicMsiCli::from_str("v2m").unwrap(),
+            GicMsiCli::V2m { spi_count: None }
+        );
+        assert_eq!(
+            GicMsiCli::from_str("v2m,spi_count=512").unwrap(),
+            GicMsiCli::V2m {
+                spi_count: Some(512)
+            }
+        );
+        assert!(matches!(
+            GicMsiCli::from_str("v2m,spi_count=512")
+                .unwrap()
+                .into_config(),
+            openvmm_defs::config::GicMsiConfig::V2m {
+                spi_count: Some(512)
+            }
+        ));
+
+        assert!(GicMsiCli::from_str("v2m,spi_count=0").is_err());
+        assert!(GicMsiCli::from_str("v2m,spi_count=abc").is_err());
+        assert!(GicMsiCli::from_str("v2m,spi_count=64,spi_count=512").is_err());
+        assert!(GicMsiCli::from_str("v2m,unknown=512").is_err());
+        assert!(GicMsiCli::from_str("other").is_err());
     }
 
     #[test]

--- a/openvmm/openvmm_entry/src/cli_args.rs
+++ b/openvmm/openvmm_entry/src/cli_args.rs
@@ -2824,6 +2824,7 @@ pub enum Vtl0LateMapPolicyCli {
 }
 
 /// PCIe MSI controller selection for aarch64.
+#[cfg(guest_arch = "aarch64")]
 #[derive(Debug, Copy, Clone, Default, PartialEq, Eq)]
 pub enum GicMsiCli {
     /// Use ITS when available, fall back to GICv2m.
@@ -2838,6 +2839,7 @@ pub enum GicMsiCli {
     },
 }
 
+#[cfg(guest_arch = "aarch64")]
 impl FromStr for GicMsiCli {
     type Err = anyhow::Error;
 
@@ -2870,6 +2872,7 @@ impl FromStr for GicMsiCli {
     }
 }
 
+#[cfg(guest_arch = "aarch64")]
 impl GicMsiCli {
     pub fn into_config(self) -> openvmm_defs::config::GicMsiConfig {
         match self {
@@ -5009,6 +5012,7 @@ mod tests {
         );
     }
 
+    #[cfg(guest_arch = "aarch64")]
     #[test]
     fn test_gic_msi_cli_from_str() {
         assert_eq!(GicMsiCli::from_str("auto").unwrap(), GicMsiCli::Auto);

--- a/openvmm/openvmm_entry/src/lib.rs
+++ b/openvmm/openvmm_entry/src/lib.rs
@@ -1638,13 +1638,7 @@ async fn vm_config_from_command_line(
             // TODO: allow this to be configured from the command line
             gic_config: None,
             pmu_gsiv: openvmm_defs::config::PmuGsivConfig::Platform,
-            gic_msi: match opt.gic_msi {
-                cli_args::GicMsiCli::Auto => openvmm_defs::config::GicMsiConfig::Auto,
-                cli_args::GicMsiCli::Its => openvmm_defs::config::GicMsiConfig::Its,
-                cli_args::GicMsiCli::V2m => {
-                    openvmm_defs::config::GicMsiConfig::V2m { spi_count: None }
-                }
-            },
+            gic_msi: opt.gic_msi.into_config(),
         },
     );
     #[cfg(guest_arch = "x86_64")]


### PR DESCRIPTION
## Summary

Allow ARM64 command-line users to choose the GICv2m MSI SPI pool size with `--gic-msi v2m,spi_count=N`.

## Changes

- Preserve the existing behavior of `auto`, `its`, and bare `v2m`.
- Pass an explicit v2m SPI count through to the existing `GicMsiConfig` field.
- Reject zero, duplicate, malformed, and unknown options.
- Keep the global 64-SPI default unchanged, preserving deterministic layouts for existing configurations.

This is an independent follow-up found while validating a device-heavy ARM64 guest for #4344.

## Validation

- `cargo test -p openvmm_entry --lib` (88 passed)
- `OPENVMM_GUEST_TARGET=aarch64 cargo check -p openvmm_entry`
- `cargo xtask fmt --only-diffed`
- A 512-SPI GICv2m pool was validated with a 112-vCPU guest using NVMe, networking, and four GB200 GPUs; the default 64-SPIs was exhausted by MSI-X allocation.
