### PR TITLE
net_consomme: decouple control requests from packet processing path

### DIFF
--- a/vm/devices/net/net_backend_resources/src/lib.rs
+++ b/vm/devices/net/net_backend_resources/src/lib.rs
@@ -90,13 +90,26 @@ pub mod consomme {
         pub guest_port: u16,
     }
 
-    /// A runtime request to bind or unbind a port on a running Consomme endpoint.
+    /// Configuration for adding a static DNS record to the endpoint.
+    #[derive(Debug, MeshPayload)]
+    pub struct DnsRecordConfig {
+        /// The type and data of the record (currently only `A` is supported).
+        pub record: [u8; 4],
+        /// The query name in presentation form (e.g. `"example.com"`).
+        pub name: String,
+    }
+
+    /// A runtime request that can cross a process boundary to a Consomme endpoint.
     #[derive(MeshPayload)]
     pub enum ConsommeRequest {
         /// Bind a host port to forward traffic to the guest.
         Bind(mesh::rpc::FailableRpc<HostPortConfig, ()>),
         /// Unbind a previously forwarded port.
         Unbind(mesh::rpc::FailableRpc<HostPortConfig, ()>),
+        /// Allocate a virtual address mapped to a host destination.
+        CreateVirtualAddress(mesh::rpc::Rpc<HostIpAddress, Option<HostIpAddress>>),
+        /// Add a static DNS record to the endpoint.
+        AddDnsRecord(mesh::rpc::FailableRpc<DnsRecordConfig, ()>),
     }
 
     /// Handle to a Consomme network endpoint.
@@ -106,7 +119,7 @@ pub mod consomme {
         pub cidr: Option<String>,
         /// Ports to forward from the host into the guest at creation time.
         pub ports: Vec<HostPortConfig>,
-        /// Optional channel for runtime port bind/unbind after the endpoint starts.
+        /// Optional channel for runtime requests after the endpoint starts.
         pub recv: Option<mesh::Receiver<ConsommeRequest>>,
     }
 

--- a/vm/devices/net/net_consomme/consomme/src/lib.rs
+++ b/vm/devices/net/net_consomme/consomme/src/lib.rs
@@ -67,6 +67,7 @@ use std::net::Ipv4Addr;
 use std::net::SocketAddr;
 use std::net::SocketAddrV4;
 use std::net::SocketAddrV6;
+use std::sync::Arc;
 use std::task::Context;
 use std::time::Duration;
 use thiserror::Error;
@@ -120,6 +121,52 @@ pub struct Consomme {
     icmp: icmp::Icmp,
     dns: dns_resolver::DnsResolver,
     host_has_ipv6: bool,
+}
+
+/// Control handle for listener-only operations that do not access connection
+/// or packet-processing state.
+#[derive(Clone)]
+pub struct ListenerControl {
+    driver: Arc<dyn Driver>,
+    inner: ListenerControlInner,
+}
+
+/// Cloneable listener registry retained across queue restarts.
+#[derive(Clone)]
+pub struct ListenerControlInner {
+    tcp: tcp::TcpListenerControl,
+    udp: udp::UdpListenerControl,
+}
+
+impl ListenerControl {
+    /// Creates a listener control handle using `driver` to register sockets.
+    pub fn new(driver: Arc<dyn Driver>, inner: ListenerControlInner) -> Self {
+        Self { driver, inner }
+    }
+
+    /// Binds a TCP listener to forward connections to the guest.
+    pub fn bind_tcp_port(&self, socket: socket2::Socket, guest_port: u16) -> Result<(), BindError> {
+        self.inner
+            .tcp
+            .bind(self.driver.as_ref(), socket, guest_port)
+    }
+
+    /// Binds a UDP listener to forward packets to the guest.
+    pub fn bind_udp_port(&self, socket: socket2::Socket, guest_port: u16) -> Result<(), BindError> {
+        self.inner
+            .udp
+            .bind(self.driver.as_ref(), socket, guest_port)
+    }
+
+    /// Unbinds a TCP listener.
+    pub fn unbind_tcp_port(&self, family: IpVersion, port: u16) -> Result<(), BindError> {
+        self.inner.tcp.unbind(family, port)
+    }
+
+    /// Unbinds a UDP listener.
+    pub fn unbind_udp_port(&self, family: IpVersion, port: u16) -> Result<(), BindError> {
+        self.inner.udp.unbind(family, port)
+    }
 }
 
 #[derive(Inspect)]
@@ -910,6 +957,14 @@ impl Consomme {
         Access {
             inner: self,
             client,
+        }
+    }
+
+    /// Returns the listener registry used to create control handles.
+    pub fn listener_control_inner(&self) -> ListenerControlInner {
+        ListenerControlInner {
+            tcp: self.tcp.listener_control(),
+            udp: self.udp.listener_control(),
         }
     }
 }

--- a/vm/devices/net/net_consomme/consomme/src/lib.rs
+++ b/vm/devices/net/net_consomme/consomme/src/lib.rs
@@ -135,18 +135,13 @@ pub struct ListenerControl {
 
 /// Cloneable listener registry retained across queue restarts.
 #[derive(Clone)]
-pub struct ListenerControlInner {
+struct ListenerControlInner {
     tcp: tcp::TcpListenerControl,
     udp: udp::UdpListenerControl,
     waker: Arc<futures::task::AtomicWaker>,
 }
 
 impl ListenerControl {
-    /// Creates a listener control handle using `driver` to register sockets.
-    pub fn new(driver: Arc<dyn Driver>, inner: ListenerControlInner) -> Self {
-        Self { driver, inner }
-    }
-
     /// Binds a TCP listener to forward connections to the guest.
     pub fn bind_tcp_port(&self, socket: socket2::Socket, guest_port: u16) -> Result<(), BindError> {
         self.inner
@@ -972,12 +967,15 @@ impl Consomme {
         }
     }
 
-    /// Returns the listener registry used to create control handles.
-    pub fn listener_control_inner(&self) -> ListenerControlInner {
-        ListenerControlInner {
-            tcp: self.tcp.listener_control(),
-            udp: self.udp.listener_control(),
-            waker: self.listener_waker.clone(),
+    /// Creates a listener control handle using `driver` to register sockets.
+    pub fn listener_control(&self, driver: Arc<dyn Driver>) -> ListenerControl {
+        ListenerControl {
+            driver,
+            inner: ListenerControlInner {
+                tcp: self.tcp.listener_control(),
+                udp: self.udp.listener_control(),
+                waker: self.listener_waker.clone(),
+            },
         }
     }
 }

--- a/vm/devices/net/net_consomme/consomme/src/lib.rs
+++ b/vm/devices/net/net_consomme/consomme/src/lib.rs
@@ -121,6 +121,8 @@ pub struct Consomme {
     icmp: icmp::Icmp,
     dns: dns_resolver::DnsResolver,
     host_has_ipv6: bool,
+    #[inspect(skip)]
+    listener_waker: Arc<futures::task::AtomicWaker>,
 }
 
 /// Control handle for listener-only operations that do not access connection
@@ -136,6 +138,7 @@ pub struct ListenerControl {
 pub struct ListenerControlInner {
     tcp: tcp::TcpListenerControl,
     udp: udp::UdpListenerControl,
+    waker: Arc<futures::task::AtomicWaker>,
 }
 
 impl ListenerControl {
@@ -148,24 +151,32 @@ impl ListenerControl {
     pub fn bind_tcp_port(&self, socket: socket2::Socket, guest_port: u16) -> Result<(), BindError> {
         self.inner
             .tcp
-            .bind(self.driver.as_ref(), socket, guest_port)
+            .bind(self.driver.as_ref(), socket, guest_port)?;
+        self.inner.waker.wake();
+        Ok(())
     }
 
     /// Binds a UDP listener to forward packets to the guest.
     pub fn bind_udp_port(&self, socket: socket2::Socket, guest_port: u16) -> Result<(), BindError> {
         self.inner
             .udp
-            .bind(self.driver.as_ref(), socket, guest_port)
+            .bind(self.driver.as_ref(), socket, guest_port)?;
+        self.inner.waker.wake();
+        Ok(())
     }
 
     /// Unbinds a TCP listener.
     pub fn unbind_tcp_port(&self, family: IpVersion, port: u16) -> Result<(), BindError> {
-        self.inner.tcp.unbind(family, port)
+        self.inner.tcp.unbind(family, port)?;
+        self.inner.waker.wake();
+        Ok(())
     }
 
     /// Unbinds a UDP listener.
     pub fn unbind_udp_port(&self, family: IpVersion, port: u16) -> Result<(), BindError> {
-        self.inner.udp.unbind(family, port)
+        self.inner.udp.unbind(family, port)?;
+        self.inner.waker.wake();
+        Ok(())
     }
 }
 
@@ -894,6 +905,7 @@ impl Consomme {
             icmp: icmp::Icmp::new(),
             dns,
             host_has_ipv6,
+            listener_waker: Arc::new(futures::task::AtomicWaker::new()),
         }
     }
 
@@ -965,6 +977,7 @@ impl Consomme {
         ListenerControlInner {
             tcp: self.tcp.listener_control(),
             udp: self.udp.listener_control(),
+            waker: self.listener_waker.clone(),
         }
     }
 }
@@ -982,6 +995,7 @@ impl<T: Client> Access<'_, T> {
 
     /// Polls for work, transmitting any ready packets to the client.
     pub fn poll(&mut self, cx: &mut Context<'_>) {
+        self.inner.listener_waker.register(cx.waker());
         self.poll_udp(cx);
         self.poll_tcp(cx);
         self.poll_icmp(cx);

--- a/vm/devices/net/net_consomme/consomme/src/tcp.rs
+++ b/vm/devices/net/net_consomme/consomme/src/tcp.rs
@@ -29,6 +29,7 @@ use pal_async::socket::PollReady;
 use pal_async::socket::PolledSocket;
 use pal_async::timer::Instant as TimerInstant;
 use pal_async::timer::PolledTimer as TcpTimer;
+use parking_lot::Mutex;
 use smoltcp::phy::ChecksumCapabilities;
 use smoltcp::wire::ETHERNET_HEADER_LEN;
 use smoltcp::wire::EthernetFrame;
@@ -61,6 +62,7 @@ use std::net::SocketAddr;
 use std::net::SocketAddrV4;
 use std::net::SocketAddrV6;
 use std::pin::Pin;
+use std::sync::Arc;
 use std::task::Context;
 use std::task::Poll;
 use std::time::Duration;
@@ -70,8 +72,10 @@ use thiserror::Error;
 pub(crate) struct Tcp {
     #[inspect(iter_by_key)]
     connections: HashMap<FourTuple, TcpConnection>,
-    #[inspect(iter_by_key)]
-    listeners: HashMap<PortForwardKey, TcpListener>,
+    #[inspect(
+        with = "|listeners| inspect::adhoc(|req| inspect::iter_by_key(&*listeners.lock()).inspect(req))"
+    )]
+    listeners: Arc<Mutex<HashMap<PortForwardKey, TcpListener>>>,
     #[inspect(skip)]
     timer: Option<TcpTimer>,
     connection_params: ConnectionParams,
@@ -162,7 +166,7 @@ impl Tcp {
     pub fn new(rx_buffer: crate::TcpBufferBounds, tx_buffer: crate::TcpBufferBounds) -> Self {
         Self {
             connections: HashMap::new(),
-            listeners: HashMap::new(),
+            listeners: Arc::new(Mutex::new(HashMap::new())),
             timer: None,
             connection_params: ConnectionParams {
                 rx_buffer: NormalizedBufferBounds::from_bounds(rx_buffer),
@@ -170,6 +174,48 @@ impl Tcp {
             },
             aggregate_stats: TcpAggregateStats::default(),
         }
+    }
+
+    pub(crate) fn listener_control(&self) -> TcpListenerControl {
+        TcpListenerControl {
+            listeners: self.listeners.clone(),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct TcpListenerControl {
+    listeners: Arc<Mutex<HashMap<PortForwardKey, TcpListener>>>,
+}
+
+impl TcpListenerControl {
+    pub(crate) fn bind(
+        &self,
+        driver: &dyn Driver,
+        socket: Socket,
+        guest_port: u16,
+    ) -> Result<(), BindError> {
+        let host_addr = socket
+            .local_addr()
+            .map_err(BindError::Io)?
+            .as_socket()
+            .ok_or_else(|| BindError::Io(io::Error::other("socket local address is invalid")))?;
+        let key = PortForwardKey::from_socket_addr(host_addr, guest_port);
+        match self.listeners.lock().entry(key) {
+            hash_map::Entry::Occupied(_) => Err(BindError::PortAlreadyBound(guest_port)),
+            hash_map::Entry::Vacant(entry) => {
+                entry.insert(TcpListener::from_socket(driver, socket)?);
+                Ok(())
+            }
+        }
+    }
+
+    pub(crate) fn unbind(&self, family: IpVersion, port: u16) -> Result<(), BindError> {
+        self.listeners
+            .lock()
+            .remove(&PortForwardKey::new(family, port))
+            .map(|_| ())
+            .ok_or(BindError::PortNotBound)
     }
 }
 
@@ -778,10 +824,8 @@ impl TcpState {
 impl<T: Client> Access<'_, T> {
     pub(crate) fn poll_tcp(&mut self, cx: &mut Context<'_>) {
         // Check for any new incoming connections
-        self.inner
-            .tcp
-            .listeners
-            .retain(|key, listener| match listener.poll_listener(cx) {
+        if let Some(mut listeners) = self.inner.tcp.listeners.try_lock() {
+            listeners.retain(|key, listener| match listener.poll_listener(cx) {
                 Ok(result) => {
                     if let Some((socket, mut other_addr)) = result {
                         // If this packet was originally from the guest, update the port to match
@@ -857,8 +901,9 @@ impl<T: Client> Access<'_, T> {
                     }
                     true
                 }
-                Err(_) => false,
-            });
+                    Err(_) => false,
+                });
+        }
         // Check for any new incoming data.
         let mut now = None;
         let mut next_deadline: Option<TimerInstant> = None;
@@ -1104,7 +1149,8 @@ impl<T: Client> Access<'_, T> {
                         let key =
                             PortForwardKey::from_socket_addr(resolved_dst, resolved_dst.port());
                         let ft = if is_local_address
-                            && let Some(listener) = self.inner.tcp.listeners.get(&key)
+                            && let Some(listeners) = self.inner.tcp.listeners.try_lock()
+                            && let Some(listener) = listeners.get(&key)
                         {
                             FourTuple {
                                 src: sender.ft.src,
@@ -1148,42 +1194,15 @@ impl<T: Client> Access<'_, T> {
     /// Binds to the specified host IP and port for listening for incoming
     /// connections.
     pub fn bind_tcp_port(&mut self, socket: Socket, guest_port: u16) -> Result<(), BindError> {
-        let host_addr = Self::socket_local_addr(&socket)?;
-        let key = PortForwardKey::from_socket_addr(host_addr, guest_port);
-        match self.inner.tcp.listeners.entry(key) {
-            hash_map::Entry::Occupied(_) => {
-                return Err(BindError::PortAlreadyBound(guest_port));
-            }
-            hash_map::Entry::Vacant(e) => {
-                let listener = TcpListener::from_socket(self.client.driver(), socket)?;
-                e.insert(listener);
-            }
-        };
-        Ok(())
+        self.inner
+            .tcp
+            .listener_control()
+            .bind(self.client.driver(), socket, guest_port)
     }
 
     /// Unbinds from the specified guest port and IP family.
     pub fn unbind_tcp_port(&mut self, family: IpVersion, port: u16) -> Result<(), BindError> {
-        match self
-            .inner
-            .tcp
-            .listeners
-            .entry(PortForwardKey::new(family, port))
-        {
-            hash_map::Entry::Occupied(e) => {
-                e.remove();
-                Ok(())
-            }
-            hash_map::Entry::Vacant(_) => Err(BindError::PortNotBound),
-        }
-    }
-
-    fn socket_local_addr(socket: &Socket) -> Result<SocketAddr, BindError> {
-        socket
-            .local_addr()
-            .map_err(BindError::Io)?
-            .as_socket()
-            .ok_or_else(|| BindError::Io(io::Error::other("socket local address is invalid")))
+        self.inner.tcp.listener_control().unbind(family, port)
     }
 }
 

--- a/vm/devices/net/net_consomme/consomme/src/tcp.rs
+++ b/vm/devices/net/net_consomme/consomme/src/tcp.rs
@@ -201,10 +201,11 @@ impl TcpListenerControl {
             .as_socket()
             .ok_or_else(|| BindError::Io(io::Error::other("socket local address is invalid")))?;
         let key = PortForwardKey::from_socket_addr(host_addr, guest_port);
+        let listener = TcpListener::from_socket(driver, socket)?;
         match self.listeners.lock().entry(key) {
             hash_map::Entry::Occupied(_) => Err(BindError::PortAlreadyBound(guest_port)),
             hash_map::Entry::Vacant(entry) => {
-                entry.insert(TcpListener::from_socket(driver, socket)?);
+                entry.insert(listener);
                 Ok(())
             }
         }
@@ -824,7 +825,8 @@ impl TcpState {
 impl<T: Client> Access<'_, T> {
     pub(crate) fn poll_tcp(&mut self, cx: &mut Context<'_>) {
         // Check for any new incoming connections
-        if let Some(mut listeners) = self.inner.tcp.listeners.try_lock() {
+        {
+            let mut listeners = self.inner.tcp.listeners.lock();
             listeners.retain(|key, listener| match listener.poll_listener(cx) {
                 Ok(result) => {
                     if let Some((socket, mut other_addr)) = result {
@@ -1148,13 +1150,20 @@ impl<T: Client> Access<'_, T> {
                         let is_local_address = sender.state.params.is_local_address(&resolved_dst);
                         let key =
                             PortForwardKey::from_socket_addr(resolved_dst, resolved_dst.port());
-                        let ft = if is_local_address
-                            && let Some(listeners) = self.inner.tcp.listeners.try_lock()
-                            && let Some(listener) = listeners.get(&key)
-                        {
+                        let host_port = if is_local_address {
+                            self.inner
+                                .tcp
+                                .listeners
+                                .lock()
+                                .get(&key)
+                                .map(|listener| listener.host_port)
+                        } else {
+                            None
+                        };
+                        let ft = if let Some(host_port) = host_port {
                             FourTuple {
                                 src: sender.ft.src,
-                                dst: SocketAddr::new(resolved_dst.ip(), listener.host_port),
+                                dst: SocketAddr::new(resolved_dst.ip(), host_port),
                             }
                         } else if resolved_dst != sender.ft.dst {
                             FourTuple {

--- a/vm/devices/net/net_consomme/consomme/src/tcp.rs
+++ b/vm/devices/net/net_consomme/consomme/src/tcp.rs
@@ -1009,6 +1009,32 @@ impl<T: Client> Access<'_, T> {
 
     pub(crate) fn refresh_tcp_driver(&mut self) {
         self.inner.tcp.timer = Some(TcpTimer::new(self.client.driver()));
+        let mut listeners = self.inner.tcp.listeners.lock();
+        *listeners = listeners
+            .drain()
+            .filter_map(|(key, listener)| {
+                let socket = listener.socket.into_inner();
+                match PolledSocket::new(self.client.driver(), socket) {
+                    Ok(socket) => Some((
+                        key,
+                        TcpListener {
+                            socket,
+                            host_port: listener.host_port,
+                        },
+                    )),
+                    Err(err) => {
+                        tracelimit::warn_ratelimited!(
+                            guest_port = key.guest_port,
+                            family = %key.family,
+                            error = &err as &dyn std::error::Error,
+                            "failed to update driver for tcp listener"
+                        );
+                        None
+                    }
+                }
+            })
+            .collect();
+        drop(listeners);
         self.inner.tcp.connections.retain(|ft, conn| {
             let TcpBackend::Socket {
                 socket: opt_socket, ..

--- a/vm/devices/net/net_consomme/consomme/src/tcp/tests.rs
+++ b/vm/devices/net/net_consomme/consomme/src/tcp/tests.rs
@@ -1113,6 +1113,7 @@ async fn test_tcp_bind_port_forward(driver: DefaultDriver) {
                 .inner
                 .tcp
                 .listeners
+                .lock()
                 .contains_key(&PortForwardKey::new(IpVersion::Ipv4, guest_port)),
             "listener should be registered"
         );
@@ -1749,6 +1750,7 @@ async fn test_tcp_bind_same_port_different_families(driver: DefaultDriver) {
             .inner
             .tcp
             .listeners
+            .lock()
             .contains_key(&PortForwardKey::new(IpVersion::Ipv6, guest_port)),
         "IPv6 listener should remain registered"
     );

--- a/vm/devices/net/net_consomme/consomme/src/tests.rs
+++ b/vm/devices/net/net_consomme/consomme/src/tests.rs
@@ -56,7 +56,7 @@ impl ArcWake for WakeCounter {
 #[pal_async::async_test]
 async fn listener_changes_wake_packet_queue(driver: DefaultDriver) {
     let mut consomme = Consomme::new(ConsommeParams::new().unwrap());
-    let control = ListenerControl::new(Arc::new(driver.clone()), consomme.listener_control_inner());
+    let control = consomme.listener_control(Arc::new(driver.clone()));
     let mut client = TestClient::new(driver);
 
     for is_tcp in [true, false] {

--- a/vm/devices/net/net_consomme/consomme/src/tests.rs
+++ b/vm/devices/net/net_consomme/consomme/src/tests.rs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 use super::*;
+use futures::task::ArcWake;
 use pal_async::DefaultDriver;
 use smoltcp::phy::ChecksumCapabilities;
 use smoltcp::wire::DnsQueryType;
@@ -16,6 +17,8 @@ use smoltcp::wire::TcpPacket;
 use smoltcp::wire::TcpRepr;
 use smoltcp::wire::UDP_HEADER_LEN;
 use smoltcp::wire::UdpPacket;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
 
 const ETHERNET_HEADER_LEN: usize = 14;
 
@@ -38,6 +41,62 @@ impl Client for TestClient {
 
     fn rx_mtu(&mut self) -> usize {
         1514
+    }
+}
+
+#[derive(Default)]
+struct WakeCounter(AtomicUsize);
+
+impl ArcWake for WakeCounter {
+    fn wake_by_ref(arc_self: &Arc<Self>) {
+        arc_self.0.fetch_add(1, Ordering::SeqCst);
+    }
+}
+
+#[pal_async::async_test]
+async fn listener_changes_wake_packet_queue(driver: DefaultDriver) {
+    let mut consomme = Consomme::new(ConsommeParams::new().unwrap());
+    let control = ListenerControl::new(Arc::new(driver.clone()), consomme.listener_control_inner());
+    let mut client = TestClient::new(driver);
+
+    for is_tcp in [true, false] {
+        let counter = Arc::new(WakeCounter::default());
+        let waker = futures::task::waker(counter.clone());
+        let mut cx = Context::from_waker(&waker);
+        consomme.access(&mut client).poll(&mut cx);
+
+        let socket = if is_tcp {
+            socket2::Socket::new(socket2::Domain::IPV4, socket2::Type::STREAM, None)
+        } else {
+            socket2::Socket::new(socket2::Domain::IPV4, socket2::Type::DGRAM, None)
+        }
+        .unwrap();
+        socket
+            .bind(&SocketAddr::from((Ipv4Addr::LOCALHOST, 0)).into())
+            .unwrap();
+
+        counter.0.store(0, Ordering::SeqCst);
+        if is_tcp {
+            control.bind_tcp_port(socket, 8080).unwrap();
+        } else {
+            control.bind_udp_port(socket, 8080).unwrap();
+        }
+        assert!(
+            counter.0.load(Ordering::SeqCst) > 0,
+            "bind must wake the queue"
+        );
+
+        consomme.access(&mut client).poll(&mut cx);
+        counter.0.store(0, Ordering::SeqCst);
+        if is_tcp {
+            control.unbind_tcp_port(IpVersion::Ipv4, 8080).unwrap();
+        } else {
+            control.unbind_udp_port(IpVersion::Ipv4, 8080).unwrap();
+        }
+        assert!(
+            counter.0.load(Ordering::SeqCst) > 0,
+            "unbind must wake the queue"
+        );
     }
 }
 

--- a/vm/devices/net/net_consomme/consomme/src/udp.rs
+++ b/vm/devices/net/net_consomme/consomme/src/udp.rs
@@ -25,6 +25,7 @@ use inspect_counters::Counter;
 use pal_async::interest::InterestSlot;
 use pal_async::interest::PollEvents;
 use pal_async::socket::PolledSocket;
+use parking_lot::Mutex;
 use smoltcp::phy::ChecksumCapabilities;
 use smoltcp::wire::ETHERNET_HEADER_LEN;
 use smoltcp::wire::EthernetAddress;
@@ -53,6 +54,7 @@ use std::net::SocketAddr;
 use std::net::SocketAddrV4;
 use std::net::SocketAddrV6;
 use std::net::UdpSocket;
+use std::sync::Arc;
 use std::task::Context;
 use std::task::Poll;
 use std::time::Duration;
@@ -67,7 +69,7 @@ use crate::windows as platform;
 
 pub(crate) struct Udp {
     connections: HashMap<SocketAddr, UdpConnection>,
-    listeners: HashMap<PortForwardKey, UdpListener>,
+    listeners: Arc<Mutex<HashMap<PortForwardKey, UdpListener>>>,
     timeout: Duration,
 }
 
@@ -75,9 +77,56 @@ impl Udp {
     pub fn new(timeout: Duration) -> Self {
         Self {
             connections: HashMap::new(),
-            listeners: HashMap::new(),
+            listeners: Arc::new(Mutex::new(HashMap::new())),
             timeout,
         }
+    }
+
+    pub(crate) fn listener_control(&self) -> UdpListenerControl {
+        UdpListenerControl {
+            listeners: self.listeners.clone(),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct UdpListenerControl {
+    listeners: Arc<Mutex<HashMap<PortForwardKey, UdpListener>>>,
+}
+
+impl UdpListenerControl {
+    pub(crate) fn bind(
+        &self,
+        driver: &dyn super::Driver,
+        socket: Socket,
+        guest_port: u16,
+    ) -> Result<(), BindError> {
+        let socket: UdpSocket = socket.into();
+        let socket = PolledSocket::new(driver, socket).map_err(BindError::Io)?;
+        let host_addr = socket.get().local_addr().map_err(BindError::Io)?;
+        let key = PortForwardKey::from_socket_addr(host_addr, guest_port);
+        let mut listeners = self.listeners.lock();
+        if listeners.contains_key(&key) {
+            return Err(BindError::PortAlreadyBound(guest_port));
+        }
+        listeners.insert(
+            key,
+            UdpListener {
+                socket: Some(socket),
+                host_addr,
+                guest_port,
+                stats: Default::default(),
+            },
+        );
+        Ok(())
+    }
+
+    pub(crate) fn unbind(&self, family: IpVersion, port: u16) -> Result<(), BindError> {
+        self.listeners
+            .lock()
+            .remove(&PortForwardKey::new(family, port))
+            .map(|_| ())
+            .ok_or(BindError::PortNotBound)
     }
 }
 
@@ -88,13 +137,16 @@ impl InspectMut for Udp {
             let key = addr.to_string();
             resp.field_mut(&key, conn);
         }
-        for (key, listener) in &mut self.listeners {
-            resp.field_mut(&format!("listener:{key}"), listener);
-        }
+        resp.field(
+            "listeners",
+            inspect::adhoc(|req| {
+                Inspect::inspect(&inspect::iter_by_key(&*self.listeners.lock()), req)
+            }),
+        );
     }
 }
 
-#[derive(InspectMut)]
+#[derive(Inspect, InspectMut)]
 struct UdpListener {
     #[inspect(skip)]
     socket: Option<PolledSocket<UdpSocket>>,
@@ -312,13 +364,15 @@ impl<T: Client> Access<'_, T> {
             conn.poll_conn(cx, dst_addr, &mut self.inner.state, self.client)
         });
 
-        for listener in self.inner.udp.listeners.values_mut() {
-            listener.poll_listener(
-                cx,
-                &mut self.inner.state,
-                self.client,
-                &self.inner.udp.connections,
-            );
+        if let Some(mut listeners) = self.inner.udp.listeners.try_lock() {
+            for listener in listeners.values_mut() {
+                listener.poll_listener(
+                    cx,
+                    &mut self.inner.state,
+                    self.client,
+                    &self.inner.udp.connections,
+                );
+            }
         }
 
         while let Poll::Ready(Some(response)) = self.inner.dns.poll_udp_response(cx) {
@@ -346,7 +400,7 @@ impl<T: Client> Access<'_, T> {
                 }
             }
         });
-        self.inner.udp.listeners.retain(|key, listener| {
+        self.inner.udp.listeners.lock().retain(|key, listener| {
             let socket = listener.socket.take().unwrap().into_inner();
             match PolledSocket::new(self.client.driver(), socket) {
                 Ok(socket) => {
@@ -459,7 +513,9 @@ impl<T: Client> Access<'_, T> {
             // This packet is destined for a local address. If the port matches a listener,
             // translate it so that the connection loops back to the expected destination.
             let key = PortForwardKey::from_socket_addr(dst_sock_addr, dst_sock_addr.port());
-            if let Some(listener) = self.inner.udp.listeners.get(&key) {
+            if let Some(listeners) = self.inner.udp.listeners.try_lock()
+                && let Some(listener) = listeners.get(&key)
+            {
                 dst_sock_addr.set_port(listener.host_addr.port());
             }
         }
@@ -573,38 +629,15 @@ impl<T: Client> Access<'_, T> {
     /// Binds to the specified host IP and port for forwarding inbound UDP
     /// packets to the guest.
     pub fn bind_udp_port(&mut self, socket: Socket, guest_port: u16) -> Result<(), BindError> {
-        let socket: UdpSocket = socket.into();
-        let socket = PolledSocket::new(self.client.driver(), socket).map_err(BindError::Io)?;
-        let host_addr = socket.get().local_addr().map_err(BindError::Io)?;
-        let key = PortForwardKey::from_socket_addr(host_addr, guest_port);
-        if self.inner.udp.listeners.contains_key(&key) {
-            return Err(BindError::PortAlreadyBound(guest_port));
-        }
-        self.inner.udp.listeners.insert(
-            key,
-            UdpListener {
-                socket: Some(socket),
-                host_addr,
-                guest_port,
-                stats: Default::default(),
-            },
-        );
-        Ok(())
+        self.inner
+            .udp
+            .listener_control()
+            .bind(self.client.driver(), socket, guest_port)
     }
 
     /// Unbinds from the specified guest port and IP family.
     pub fn unbind_udp_port(&mut self, family: IpVersion, port: u16) -> Result<(), BindError> {
-        if self
-            .inner
-            .udp
-            .listeners
-            .remove(&PortForwardKey::new(family, port))
-            .is_some()
-        {
-            Ok(())
-        } else {
-            Err(BindError::PortNotBound)
-        }
+        self.inner.udp.listener_control().unbind(family, port)
     }
 
     fn handle_dns(
@@ -935,6 +968,7 @@ mod tests {
                 .inner
                 .udp
                 .listeners
+                .lock()
                 .contains_key(&PortForwardKey::new(IpVersion::Ipv4, guest_port)),
             "listener should be registered"
         );
@@ -1054,6 +1088,7 @@ mod tests {
                 .inner
                 .udp
                 .listeners
+                .lock()
                 .contains_key(&PortForwardKey::new(IpVersion::Ipv6, guest_port)),
             "IPv6 listener should remain registered"
         );

--- a/vm/devices/net/net_consomme/consomme/src/udp.rs
+++ b/vm/devices/net/net_consomme/consomme/src/udp.rs
@@ -364,7 +364,8 @@ impl<T: Client> Access<'_, T> {
             conn.poll_conn(cx, dst_addr, &mut self.inner.state, self.client)
         });
 
-        if let Some(mut listeners) = self.inner.udp.listeners.try_lock() {
+        {
+            let mut listeners = self.inner.udp.listeners.lock();
             for listener in listeners.values_mut() {
                 listener.poll_listener(
                     cx,
@@ -513,10 +514,15 @@ impl<T: Client> Access<'_, T> {
             // This packet is destined for a local address. If the port matches a listener,
             // translate it so that the connection loops back to the expected destination.
             let key = PortForwardKey::from_socket_addr(dst_sock_addr, dst_sock_addr.port());
-            if let Some(listeners) = self.inner.udp.listeners.try_lock()
-                && let Some(listener) = listeners.get(&key)
-            {
-                dst_sock_addr.set_port(listener.host_addr.port());
+            let host_port = self
+                .inner
+                .udp
+                .listeners
+                .lock()
+                .get(&key)
+                .map(|listener| listener.host_addr.port());
+            if let Some(host_port) = host_port {
+                dst_sock_addr.set_port(host_port);
             }
         }
 

--- a/vm/devices/net/net_consomme/src/lib.rs
+++ b/vm/devices/net/net_consomme/src/lib.rs
@@ -21,6 +21,7 @@ use mesh::rpc::Rpc;
 use mesh::rpc::RpcError;
 use mesh::rpc::RpcSend;
 use net_backend::BufferAccess;
+use net_backend::EndpointAction;
 use net_backend::L4Protocol;
 use net_backend::QueueConfig;
 use net_backend::RssConfig;
@@ -33,6 +34,8 @@ use net_backend::TxOffloadSupport;
 use net_backend::TxSegment;
 use net_backend::TxSegmentType;
 use net_backend_resources::consomme::ConsommeRequest;
+use net_backend_resources::consomme::DnsRecordConfig;
+use net_backend_resources::consomme::HostIpAddress;
 use net_backend_resources::consomme::HostPortConfig;
 use net_backend_resources::consomme::HostPortProtocol;
 use pal_async::driver::Driver;
@@ -95,6 +98,46 @@ fn socket_family(socket: &socket2::Socket) -> Result<IpVersion, consomme::BindEr
 
 pub struct ConsommeEndpoint {
     endpoint_state: Arc<Mutex<Option<EndpointState>>>,
+    /// Listener control capability available while a queue owns the endpoint.
+    listener_control: Option<consomme::ListenerControl>,
+    /// In-process state updates, which cannot cross a process boundary.
+    state_update_recv: Option<mesh::Receiver<StateUpdateRequest>>,
+    /// Serializable requests originating either in-process or remotely.
+    request_recv: Option<mesh::Receiver<ConsommeRequest>>,
+    /// Requests buffered while the queue owns the consomme state, applied in
+    /// order on the next queue restart.
+    pending: VecDeque<PendingRequest>,
+}
+
+/// Drains all currently-available items from `recv` into `buffer`, registering a
+/// waker when nothing is ready and dropping the receiver if the channel closed.
+/// Returns whether any item was read.
+fn drain_receiver<T>(
+    recv: &mut Option<mesh::Receiver<T>>,
+    cx: &mut Context<'_>,
+    channel: &'static str,
+    mut buffer: impl FnMut(T),
+) -> bool {
+    let mut received = false;
+    loop {
+        let polled = recv.as_mut().map(|r| r.poll_recv(cx));
+        match polled {
+            Some(Poll::Ready(Ok(item))) => {
+                buffer(item);
+                received = true;
+            }
+            Some(Poll::Ready(Err(err))) => {
+                tracing::warn!(
+                    err = &err as &dyn std::error::Error,
+                    channel,
+                    "consomme request channel closed"
+                );
+                *recv = None;
+            }
+            Some(Poll::Pending) | None => break,
+        }
+    }
+    received
 }
 
 /// Configuration for a port to forward from the host to the guest.
@@ -109,66 +152,104 @@ pub struct PortForwardConfig {
 
 struct EndpointState {
     consomme: Consomme,
-    recv: Option<mesh::Receiver<ConsommeMessage>>,
-    port_recv: Option<mesh::Receiver<ConsommeRequest>>,
     port_forwards: Vec<PortForwardConfig>,
 }
 
 impl ConsommeEndpoint {
     pub fn new(state: ConsommeParams) -> Self {
-        Self {
-            endpoint_state: Arc::new(Mutex::new(Some(EndpointState {
-                consomme: Consomme::new(state),
-                recv: None,
-                port_recv: None,
-                port_forwards: Vec::new(),
-            }))),
-        }
+        Self::with_state(state, Vec::new(), None, None)
     }
 
     /// Creates a new endpoint with ports to forward once the queue starts.
     pub fn new_with_ports(state: ConsommeParams, ports: Vec<PortForwardConfig>) -> Self {
-        Self {
-            endpoint_state: Arc::new(Mutex::new(Some(EndpointState {
-                consomme: Consomme::new(state),
-                recv: None,
-                port_recv: None,
-                port_forwards: ports,
-            }))),
-        }
+        Self::with_state(state, ports, None, None)
     }
 
+    /// Creates a new endpoint with an in-process [`ConsommeControl`] handle for
+    /// runtime bind/unbind and state updates.
     pub fn new_dynamic(state: ConsommeParams) -> (Self, ConsommeControl) {
-        let consomme = Consomme::new(state);
-        let (send, recv) = mesh::channel();
+        let (request_send, request_recv) = mesh::channel();
+        let (state_update_send, state_update_recv) = mesh::channel();
         (
-            Self {
-                endpoint_state: Arc::new(Mutex::new(Some(EndpointState {
-                    consomme,
-                    recv: Some(recv),
-                    port_recv: None,
-                    port_forwards: Vec::new(),
-                }))),
+            Self::with_state(
+                state,
+                Vec::new(),
+                Some(request_recv),
+                Some(state_update_recv),
+            ),
+            ConsommeControl {
+                request_send,
+                state_update_send,
             },
-            ConsommeControl { send },
         )
     }
 
-    /// Creates a new endpoint with initial ports and a channel for runtime
-    /// port bind/unbind requests from an external source (e.g. ttrpc server).
-    pub fn new_with_port_channel(
+    /// Creates a new endpoint with initial ports and a channel for serializable
+    /// runtime requests from an external source (e.g. ttrpc server).
+    pub fn new_with_request_channel(
         state: ConsommeParams,
         ports: Vec<PortForwardConfig>,
-        port_recv: mesh::Receiver<ConsommeRequest>,
+        request_recv: mesh::Receiver<ConsommeRequest>,
     ) -> Self {
-        Self {
+        Self::with_state(state, ports, Some(request_recv), None)
+    }
+
+    fn with_state(
+        state: ConsommeParams,
+        ports: Vec<PortForwardConfig>,
+        request_recv: Option<mesh::Receiver<ConsommeRequest>>,
+        state_update_recv: Option<mesh::Receiver<StateUpdateRequest>>,
+    ) -> Self {
+        let consomme = Consomme::new(state);
+        ConsommeEndpoint {
             endpoint_state: Arc::new(Mutex::new(Some(EndpointState {
-                consomme: Consomme::new(state),
-                recv: None,
-                port_recv: Some(port_recv),
+                consomme,
                 port_forwards: ports,
             }))),
+            listener_control: None,
+            state_update_recv,
+            request_recv,
+            pending: VecDeque::new(),
         }
+    }
+
+    /// Drains available requests, applying listener-only requests directly and
+    /// buffering requests that need queue-owned state. Registers wakers for
+    /// channels with nothing ready and returns whether a restart is needed.
+    fn drain_channels(&mut self, cx: &mut Context<'_>) -> bool {
+        let mut restart_required =
+            drain_receiver(&mut self.state_update_recv, cx, "state update", |request| {
+                self.pending.push_back(PendingRequest::StateUpdate(request))
+            });
+        loop {
+            let polled = self.request_recv.as_mut().map(|recv| recv.poll_recv(cx));
+            match polled {
+                Some(Poll::Ready(Ok(request))) => {
+                    if let Some(listener_control) = &self.listener_control {
+                        match process_listener_request(listener_control, request) {
+                            Ok(()) => {}
+                            Err(request) => {
+                                self.pending.push_back(PendingRequest::Request(request));
+                                restart_required = true;
+                            }
+                        }
+                    } else {
+                        self.pending.push_back(PendingRequest::Request(request));
+                        restart_required = true;
+                    }
+                }
+                Some(Poll::Ready(Err(err))) => {
+                    tracing::warn!(
+                        err = &err as &dyn std::error::Error,
+                        channel = "request",
+                        "consomme request channel closed"
+                    );
+                    self.request_recv = None;
+                }
+                Some(Poll::Pending) | None => break,
+            }
+        }
+        restart_required
     }
 }
 
@@ -184,7 +265,8 @@ impl InspectMut for ConsommeEndpoint {
 
 /// Provide dynamic updates during runtime.
 pub struct ConsommeControl {
-    send: mesh::Sender<ConsommeMessage>,
+    request_send: mesh::Sender<ConsommeRequest>,
+    state_update_send: mesh::Sender<StateUpdateRequest>,
 }
 
 /// Error type returned from some dynamic update functions like bind_port.
@@ -203,10 +285,15 @@ pub enum ConsommeMessageError {
     /// could be allocated.
     #[error("virtual address pool exhausted")]
     VirtualAddressPoolExhausted,
+    /// Error from a remote operation on the endpoint.
+    #[error(transparent)]
+    Remote(mesh::error::RemoteError),
 }
 
 /// Callback to modify network state dynamically.
-pub type ConsommeParamsUpdateFn = Box<dyn Fn(&mut ConsommeParams) + Send>;
+pub type ConsommeParamsUpdateFn = Box<dyn Fn(&mut ConsommeParams) + Send + Sync>;
+
+type StateUpdateRequest = Rpc<ConsommeParamsUpdateFn, ()>;
 
 #[derive(Debug, Clone, Copy)]
 pub enum IpProtocol {
@@ -223,29 +310,19 @@ impl From<HostPortProtocol> for IpProtocol {
     }
 }
 
-/// Configuration for unbinding a previously forwarded port.
-struct PortUnbindConfig {
-    /// The protocol that was forwarded.
-    protocol: IpProtocol,
-    /// The IP address family that was forwarded.
-    family: IpVersion,
-    /// The guest port that was forwarded.
-    guest_port: u16,
+impl From<IpProtocol> for HostPortProtocol {
+    fn from(p: IpProtocol) -> Self {
+        match p {
+            IpProtocol::Tcp => HostPortProtocol::Tcp,
+            IpProtocol::Udp => HostPortProtocol::Udp,
+        }
+    }
 }
 
-struct AddDnsRecordConfig {
-    /// The type and data of the record (currently only `A` is supported).
-    record: StaticDnsRecord,
-    /// The query name in presentation form (e.g. `"example.com"`).
-    name: String,
-}
-
-enum ConsommeMessage {
-    BindPort(Rpc<PortForwardConfig, Result<(), consomme::BindError>>),
-    UnbindPort(Rpc<PortUnbindConfig, Result<(), consomme::BindError>>),
-    UpdateState(Rpc<ConsommeParamsUpdateFn, ()>),
-    AddDnsRecord(Rpc<AddDnsRecordConfig, Result<(), StaticDnsRecordError>>),
-    CreateVirtualAddress(Rpc<IpAddr, Option<IpAddr>>),
+/// A request buffered until the endpoint regains ownership of the Consomme state.
+enum PendingRequest {
+    Request(ConsommeRequest),
+    StateUpdate(StateUpdateRequest),
 }
 
 impl ConsommeControl {
@@ -257,54 +334,61 @@ impl ConsommeControl {
         host_port: u16,
         guest_port: u16,
     ) -> Result<u16, ConsommeMessageError> {
-        let socket = create_bound_socket(&protocol, ip_addr, host_port)
-            .map_err(|e| ConsommeMessageError::Bind(consomme::BindError::Io(e)))?;
-        let host_addr = socket_addr(&socket).map_err(ConsommeMessageError::Bind)?;
-        self.send
+        let (host_port_config, assigned_port) = if host_port == 0 {
+            let (send, recv) = mesh::oneshot();
+            (
+                net_backend_resources::consomme::HostPort::Dynamic(send),
+                Some(recv),
+            )
+        } else {
+            (
+                net_backend_resources::consomme::HostPort::Fixed(host_port),
+                None,
+            )
+        };
+        self.request_send
             .call(
-                ConsommeMessage::BindPort,
-                PortForwardConfig {
-                    protocol,
-                    socket,
+                ConsommeRequest::Bind,
+                HostPortConfig {
+                    protocol: protocol.into(),
+                    host_address: ip_addr.map(HostIpAddress::from),
+                    host_port: host_port_config,
                     guest_port,
                 },
             )
             .await
             .map_err(ConsommeMessageError::Mesh)?
-            .map(|()| {
-                let bound_host_port = host_addr.port();
-                tracing::info!(
-                    ?protocol,
-                    requested_host_port = host_port,
-                    bound_host_addr = %host_addr,
-                    bound_host_port,
-                    guest_port,
-                    "port forward bound"
-                );
-                bound_host_port
-            })
-            .map_err(ConsommeMessageError::Bind)
+            .map_err(ConsommeMessageError::Remote)?;
+        match assigned_port {
+            Some(recv) => recv
+                .await
+                .map_err(|err| ConsommeMessageError::Mesh(RpcError::Channel(err))),
+            None => Ok(host_port),
+        }
     }
 
-    /// Unbinds a port and IP family previously reserved with bind_port().
+    /// Unbinds a port previously reserved with bind_port(); `ip_addr` (or `None`)
+    /// selects the address family to unbind.
     pub async fn unbind_port(
         &self,
         protocol: IpProtocol,
-        family: IpVersion,
+        ip_addr: Option<IpAddr>,
         guest_port: u16,
     ) -> Result<(), ConsommeMessageError> {
-        self.send
+        self.request_send
             .call(
-                ConsommeMessage::UnbindPort,
-                PortUnbindConfig {
-                    protocol,
-                    family,
+                ConsommeRequest::Unbind,
+                HostPortConfig {
+                    protocol: protocol.into(),
+                    host_address: ip_addr.map(HostIpAddress::from),
+                    // Unbind identifies a forward by protocol, family, and guest port.
+                    host_port: net_backend_resources::consomme::HostPort::Fixed(0),
                     guest_port,
                 },
             )
             .await
             .map_err(ConsommeMessageError::Mesh)?
-            .map_err(ConsommeMessageError::Bind)
+            .map_err(ConsommeMessageError::Remote)
     }
 
     /// Updates dynamic network state
@@ -312,8 +396,8 @@ impl ConsommeControl {
         &self,
         f: ConsommeParamsUpdateFn,
     ) -> Result<(), ConsommeMessageError> {
-        self.send
-            .call(ConsommeMessage::UpdateState, f)
+        self.state_update_send
+            .call(|rpc| rpc, f)
             .await
             .map_err(ConsommeMessageError::Mesh)
     }
@@ -325,14 +409,15 @@ impl ConsommeControl {
         record: StaticDnsRecord,
         name: String,
     ) -> Result<(), ConsommeMessageError> {
-        self.send
+        let StaticDnsRecord::A(addr) = record;
+        self.request_send
             .call(
-                ConsommeMessage::AddDnsRecord,
-                AddDnsRecordConfig { record, name },
+                ConsommeRequest::AddDnsRecord,
+                DnsRecordConfig { record: addr, name },
             )
             .await
             .map_err(ConsommeMessageError::Mesh)?
-            .map_err(ConsommeMessageError::DnsRecord)
+            .map_err(ConsommeMessageError::Remote)
     }
 
     /// Allocates a virtual IP address within the endpoint's subnet and routes
@@ -344,10 +429,14 @@ impl ConsommeControl {
         &self,
         destination: IpAddr,
     ) -> Result<IpAddr, ConsommeMessageError> {
-        self.send
-            .call(ConsommeMessage::CreateVirtualAddress, destination)
+        self.request_send
+            .call(
+                ConsommeRequest::CreateVirtualAddress,
+                HostIpAddress::from(destination),
+            )
             .await
             .map_err(ConsommeMessageError::Mesh)?
+            .map(IpAddr::from)
             .ok_or(ConsommeMessageError::VirtualAddressPoolExhausted)
     }
 }
@@ -366,6 +455,16 @@ impl net_backend::Endpoint for ConsommeEndpoint {
     ) -> anyhow::Result<()> {
         assert_eq!(config.len(), 1);
         let config = config.into_iter().next().unwrap();
+        let driver: Arc<dyn Driver> = config.driver.into();
+        let listener_control_inner = self
+            .endpoint_state
+            .lock()
+            .as_ref()
+            .unwrap()
+            .consomme
+            .listener_control_inner();
+        let listener_control =
+            consomme::ListenerControl::new(driver.clone(), listener_control_inner);
         let mut queue = Box::new(ConsommeQueue {
             slot: self.endpoint_state.clone(),
             endpoint_state: self.endpoint_state.lock().take(),
@@ -377,7 +476,7 @@ impl net_backend::Endpoint for ConsommeEndpoint {
                 tx_scratch: Vec::new(),
             },
             stats: Default::default(),
-            driver: config.driver,
+            driver,
         });
         let port_forwards =
             std::mem::take(&mut queue.endpoint_state.as_mut().unwrap().port_forwards);
@@ -413,13 +512,42 @@ impl net_backend::Endpoint for ConsommeEndpoint {
             }
             Ok(bound)
         });
+
+        // Apply requests buffered while the queue owned the Consomme state (see
+        // `wait_for_endpoint_action`). This runs regardless of whether the
+        // static port-forward binding above succeeded, so the buffered RPCs
+        // always complete here instead of stalling until some unrelated future
+        // request triggers the next restart.
+        let pending = std::mem::take(&mut self.pending);
+        queue.with_consomme_no_pool(|c| {
+            for request in pending {
+                match request {
+                    PendingRequest::Request(request) => {
+                        if let Err(request) = process_listener_request(&listener_control, request) {
+                            process_request(c, request);
+                        }
+                    }
+                    PendingRequest::StateUpdate(rpc) => {
+                        rpc.handle_sync(|f| {
+                            f(c.get_mut().params_mut());
+                            c.get_mut().clear_local_addr_map();
+                            c.update_dns_nameservers()
+                        });
+                    }
+                }
+            }
+        });
+
         bind_result?;
+
+        self.listener_control = Some(listener_control);
         queues.push(queue);
         Ok(())
     }
 
     async fn stop(&mut self) {
         assert!(self.endpoint_state.lock().is_some());
+        self.listener_control = None;
     }
 
     fn is_ordered(&self) -> bool {
@@ -435,6 +563,18 @@ impl net_backend::Endpoint for ConsommeEndpoint {
             uso: true,
         }
     }
+
+    async fn wait_for_endpoint_action(&mut self) -> EndpointAction {
+        std::future::poll_fn(|cx| {
+            if self.drain_channels(cx) {
+                Poll::Ready(())
+            } else {
+                Poll::Pending
+            }
+        })
+        .await;
+        EndpointAction::RestartRequired
+    }
 }
 
 pub struct ConsommeQueue {
@@ -442,7 +582,7 @@ pub struct ConsommeQueue {
     endpoint_state: Option<EndpointState>,
     state: QueueState,
     stats: Stats,
-    driver: Box<dyn Driver>,
+    driver: Arc<dyn Driver>,
 }
 
 impl InspectMut for ConsommeQueue {
@@ -494,62 +634,11 @@ impl ConsommeQueue {
                 pool,
             }))
     }
-
-    fn poll_message(&mut self, cx: &mut Context<'_>, pool: &mut dyn BufferAccess) {
-        // process all pending messages
-        let state = self.endpoint_state.as_mut().unwrap();
-        while let Some(recv) = &mut state.recv {
-            match recv.poll_recv(cx) {
-                Poll::Ready(Err(err)) => {
-                    tracing::warn!(
-                        err = &err as &dyn std::error::Error,
-                        "Consomme dynamic update channel failure"
-                    );
-                    state.recv = None;
-                    break;
-                }
-                Poll::Ready(Ok(message)) => process_message(
-                    &mut state.consomme.access(&mut Client {
-                        state: &mut self.state,
-                        stats: &mut self.stats,
-                        driver: &self.driver,
-                        pool,
-                    }),
-                    message,
-                ),
-                Poll::Pending => break,
-            }
-        }
-
-        // Poll cross-proc port request channel.
-        while let Some(recv) = &mut state.port_recv {
-            match recv.poll_recv(cx) {
-                Poll::Ready(Err(err)) => {
-                    tracing::warn!(
-                        err = &err as &dyn std::error::Error,
-                        "Consomme port request channel failure"
-                    );
-                    state.port_recv = None;
-                    return;
-                }
-                Poll::Ready(Ok(request)) => process_port_request(
-                    &mut state.consomme.access(&mut Client {
-                        state: &mut self.state,
-                        stats: &mut self.stats,
-                        driver: &self.driver,
-                        pool,
-                    }),
-                    request,
-                ),
-                Poll::Pending => return,
-            }
-        }
-    }
 }
 
 /// Execute a port bind: create a socket and forward it to the consomme stack.
 fn execute_bind(
-    consomme: &mut consomme::Access<'_, impl consomme::Client>,
+    listener_control: &consomme::ListenerControl,
     cfg: HostPortConfig,
 ) -> anyhow::Result<()> {
     use net_backend_resources::consomme::HostPort;
@@ -580,8 +669,8 @@ fn execute_bind(
         None => None,
     };
     let result = match protocol {
-        IpProtocol::Tcp => consomme.bind_tcp_port(socket, cfg.guest_port),
-        IpProtocol::Udp => consomme.bind_udp_port(socket, cfg.guest_port),
+        IpProtocol::Tcp => listener_control.bind_tcp_port(socket, cfg.guest_port),
+        IpProtocol::Udp => listener_control.bind_udp_port(socket, cfg.guest_port),
     };
     result.context("failed to bind port")?;
     if let Some((sender, port)) = dynamic_port {
@@ -592,89 +681,76 @@ fn execute_bind(
 
 /// Execute a port unbind.
 fn execute_unbind(
-    consomme: &mut consomme::Access<'_, impl consomme::Client>,
+    listener_control: &consomme::ListenerControl,
     cfg: &HostPortConfig,
 ) -> anyhow::Result<()> {
-    use net_backend_resources::consomme::HostIpAddress;
-
     let protocol: IpProtocol = cfg.protocol.clone().into();
     let family = match &cfg.host_address {
         Some(HostIpAddress::Ipv4(_)) | None => IpVersion::Ipv4,
         Some(HostIpAddress::Ipv6(_)) => IpVersion::Ipv6,
     };
     let result = match protocol {
-        IpProtocol::Tcp => consomme.unbind_tcp_port(family, cfg.guest_port),
-        IpProtocol::Udp => consomme.unbind_udp_port(family, cfg.guest_port),
+        IpProtocol::Tcp => listener_control.unbind_tcp_port(family, cfg.guest_port),
+        IpProtocol::Udp => listener_control.unbind_udp_port(family, cfg.guest_port),
     };
     result.context("failed to unbind port")
 }
 
-/// Handle a `ConsommeRequest` (shared by both in-proc and cross-proc paths).
-fn process_port_request(
-    consomme: &mut consomme::Access<'_, impl consomme::Client>,
+/// Handles a listener-only request without accessing the queue-owned state.
+/// Returns requests that require a queue restart unchanged.
+fn process_listener_request(
+    listener_control: &consomme::ListenerControl,
     request: ConsommeRequest,
-) {
+) -> Result<(), ConsommeRequest> {
     match request {
         ConsommeRequest::Bind(rpc) => {
             rpc.handle_failable_sync(
                 |cfg| -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
                     let guest_port = cfg.guest_port;
-                    execute_bind(consomme, cfg)?;
+                    execute_bind(listener_control, cfg)?;
                     tracing::info!(guest_port, "port forward bound");
                     Ok(())
                 },
             );
+            Ok(())
         }
         ConsommeRequest::Unbind(rpc) => {
             rpc.handle_failable_sync(
                 |cfg| -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-                    execute_unbind(consomme, &cfg)?;
+                    execute_unbind(listener_control, &cfg)?;
                     tracing::info!(guest_port = cfg.guest_port, "port forward unbound");
                     Ok(())
                 },
             );
+            Ok(())
         }
+        request => Err(request),
     }
 }
 
-/// Handle an in-process `ConsommeMessage` from a `ConsommeControl`.
-fn process_message(
+/// Handles a request that needs access to the queue-owned Consomme state.
+fn process_request(
     consomme: &mut consomme::Access<'_, impl consomme::Client>,
-    message: ConsommeMessage,
+    request: ConsommeRequest,
 ) {
-    match message {
-        ConsommeMessage::BindPort(rpc) => {
-            rpc.handle_sync(|bind_message| match bind_message.protocol {
-                IpProtocol::Tcp => {
-                    consomme.bind_tcp_port(bind_message.socket, bind_message.guest_port)
-                }
-                IpProtocol::Udp => {
-                    consomme.bind_udp_port(bind_message.socket, bind_message.guest_port)
-                }
+    match request {
+        ConsommeRequest::CreateVirtualAddress(rpc) => {
+            rpc.handle_sync(|destination| {
+                consomme
+                    .get_mut()
+                    .create_virtual_address(destination.into())
+                    .map(HostIpAddress::from)
             });
         }
-        ConsommeMessage::UnbindPort(rpc) => {
-            rpc.handle_sync(|unbind_message| match unbind_message.protocol {
-                IpProtocol::Tcp => {
-                    consomme.unbind_tcp_port(unbind_message.family, unbind_message.guest_port)
-                }
-                IpProtocol::Udp => {
-                    consomme.unbind_udp_port(unbind_message.family, unbind_message.guest_port)
-                }
+        ConsommeRequest::AddDnsRecord(rpc) => {
+            rpc.handle_failable_sync(|cfg: DnsRecordConfig| {
+                consomme
+                    .get_mut()
+                    .add_dns_record(StaticDnsRecord::A(cfg.record), &cfg.name)
             });
         }
-        ConsommeMessage::UpdateState(rpc) => {
-            rpc.handle_sync(|f| {
-                f(consomme.get_mut().params_mut());
-                consomme.get_mut().clear_local_addr_map();
-                consomme.update_dns_nameservers()
-            });
-        }
-        ConsommeMessage::AddDnsRecord(rpc) => {
-            rpc.handle_sync(|cfg| consomme.get_mut().add_dns_record(cfg.record, &cfg.name));
-        }
-        ConsommeMessage::CreateVirtualAddress(rpc) => {
-            rpc.handle_sync(|destination| consomme.get_mut().create_virtual_address(destination));
+        ConsommeRequest::Bind(_) | ConsommeRequest::Unbind(_) => {
+            unreachable!("listener request was not handled by the endpoint")
         }
     }
 }
@@ -753,12 +829,6 @@ impl net_backend::Queue for ConsommeQueue {
 
             self.state.tx_ready.push_back(tx_id);
         }
-
-        // TODO: handle messages asynchronously from any queue processing, since
-        // there is no guarantee the queue will be processed at all (e.g., if
-        // the guest stops processing traffic). This will probably require adding
-        // a lock around the consomme state.
-        self.poll_message(cx, pool);
 
         self.with_consomme(pool, |c| c.poll(cx));
 

--- a/vm/devices/net/net_consomme/src/lib.rs
+++ b/vm/devices/net/net_consomme/src/lib.rs
@@ -17,6 +17,7 @@ pub use consomme::StaticDnsRecordError;
 use inspect::Inspect;
 use inspect::InspectMut;
 use inspect_counters::Counter;
+use mesh::rpc::FailableRpc;
 use mesh::rpc::Rpc;
 use mesh::rpc::RpcError;
 use mesh::rpc::RpcSend;
@@ -225,18 +226,23 @@ impl ConsommeEndpoint {
             let polled = self.request_recv.as_mut().map(|recv| recv.poll_recv(cx));
             match polled {
                 Some(Poll::Ready(Ok(request))) => {
-                    if let Some(listener_control) = &self.listener_control {
-                        match process_listener_request(listener_control, request) {
-                            Ok(()) => {}
-                            Err(request) => {
-                                self.pending.push_back(PendingRequest::Request(request));
-                                restart_required = true;
-                            }
+                    restart_required |= match request {
+                        ConsommeRequest::Bind(rpc) => {
+                            self.handle_listener_request(ListenerRequest::Bind(rpc))
                         }
-                    } else {
-                        self.pending.push_back(PendingRequest::Request(request));
-                        restart_required = true;
-                    }
+                        ConsommeRequest::Unbind(rpc) => {
+                            self.handle_listener_request(ListenerRequest::Unbind(rpc))
+                        }
+                        ConsommeRequest::CreateVirtualAddress(rpc) => {
+                            self.pending
+                                .push_back(PendingRequest::CreateVirtualAddress(rpc));
+                            true
+                        }
+                        ConsommeRequest::AddDnsRecord(rpc) => {
+                            self.pending.push_back(PendingRequest::AddDnsRecord(rpc));
+                            true
+                        }
+                    };
                 }
                 Some(Poll::Ready(Err(err))) => {
                     tracing::warn!(
@@ -250,6 +256,16 @@ impl ConsommeEndpoint {
             }
         }
         restart_required
+    }
+
+    fn handle_listener_request(&mut self, request: ListenerRequest) -> bool {
+        if let Some(listener_control) = &self.listener_control {
+            process_listener_request(listener_control, request);
+            false
+        } else {
+            self.pending.push_back(PendingRequest::Listener(request));
+            true
+        }
     }
 }
 
@@ -319,10 +335,18 @@ impl From<IpProtocol> for HostPortProtocol {
     }
 }
 
-/// A request buffered until the endpoint regains ownership of the Consomme state.
+enum ListenerRequest {
+    Bind(FailableRpc<HostPortConfig, ()>),
+    Unbind(FailableRpc<HostPortConfig, ()>),
+}
+
+/// A request buffered until queue startup provides the required state or driver.
 enum PendingRequest {
-    Request(ConsommeRequest),
+    /// Listener requests received before a queue driver is available.
+    Listener(ListenerRequest),
     StateUpdate(StateUpdateRequest),
+    CreateVirtualAddress(Rpc<HostIpAddress, Option<HostIpAddress>>),
+    AddDnsRecord(FailableRpc<DnsRecordConfig, ()>),
 }
 
 impl ConsommeControl {
@@ -456,18 +480,11 @@ impl net_backend::Endpoint for ConsommeEndpoint {
         assert_eq!(config.len(), 1);
         let config = config.into_iter().next().unwrap();
         let driver: Arc<dyn Driver> = config.driver.into();
-        let listener_control_inner = self
-            .endpoint_state
-            .lock()
-            .as_ref()
-            .unwrap()
-            .consomme
-            .listener_control_inner();
-        let listener_control =
-            consomme::ListenerControl::new(driver.clone(), listener_control_inner);
+        let endpoint_state = self.endpoint_state.lock().take().unwrap();
+        let listener_control = endpoint_state.consomme.listener_control(driver.clone());
         let mut queue = Box::new(ConsommeQueue {
             slot: self.endpoint_state.clone(),
-            endpoint_state: self.endpoint_state.lock().take(),
+            endpoint_state: Some(endpoint_state),
             state: QueueState {
                 rx_avail: VecDeque::new(),
                 rx_ready: VecDeque::new(),
@@ -478,65 +495,15 @@ impl net_backend::Endpoint for ConsommeEndpoint {
             stats: Default::default(),
             driver,
         });
-        let port_forwards =
-            std::mem::take(&mut queue.endpoint_state.as_mut().unwrap().port_forwards);
-        let bind_result: Result<Vec<_>, _> = queue.with_consomme_no_pool(|c| {
-            c.refresh_driver();
-            let mut bound: Vec<(IpProtocol, IpVersion, u16)> = Vec::new();
-            for fwd in port_forwards {
-                let protocol = fwd.protocol;
-                let guest_port = fwd.guest_port;
-                let result = match socket_family(&fwd.socket) {
-                    Ok(family) => {
-                        let result = match protocol {
-                            IpProtocol::Tcp => c.bind_tcp_port(fwd.socket, guest_port),
-                            IpProtocol::Udp => c.bind_udp_port(fwd.socket, guest_port),
-                        };
-                        result.map(|()| (protocol, family, guest_port))
-                    }
-                    Err(err) => Err(err),
-                };
-                match result {
-                    Ok(bound_entry) => bound.push(bound_entry),
-                    Err(err) => {
-                        // Roll back successful binds before returning error.
-                        for (protocol, family, guest_port) in &bound {
-                            let _ = match protocol {
-                                IpProtocol::Tcp => c.unbind_tcp_port(*family, *guest_port),
-                                IpProtocol::Udp => c.unbind_udp_port(*family, *guest_port),
-                            };
-                        }
-                        return Err(anyhow::anyhow!(err).context("failed to bind port"));
-                    }
-                }
-            }
-            Ok(bound)
-        });
+        queue.with_consomme_no_pool(|c| c.refresh_driver());
+        let bind_result = queue.bind_static_ports();
 
         // Apply requests buffered while the queue owned the Consomme state (see
         // `wait_for_endpoint_action`). This runs regardless of whether the
         // static port-forward binding above succeeded, so the buffered RPCs
         // always complete here instead of stalling until some unrelated future
         // request triggers the next restart.
-        let pending = std::mem::take(&mut self.pending);
-        queue.with_consomme_no_pool(|c| {
-            for request in pending {
-                match request {
-                    PendingRequest::Request(request) => {
-                        if let Err(request) = process_listener_request(&listener_control, request) {
-                            process_request(c, request);
-                        }
-                    }
-                    PendingRequest::StateUpdate(rpc) => {
-                        rpc.handle_sync(|f| {
-                            f(c.get_mut().params_mut());
-                            c.get_mut().clear_local_addr_map();
-                            c.update_dns_nameservers()
-                        });
-                    }
-                }
-            }
-        });
+        queue.apply_pending_requests(std::mem::take(&mut self.pending), &listener_control);
 
         bind_result?;
 
@@ -604,6 +571,54 @@ impl Drop for ConsommeQueue {
 }
 
 impl ConsommeQueue {
+    fn bind_static_ports(&mut self) -> anyhow::Result<()> {
+        let port_forwards =
+            std::mem::take(&mut self.endpoint_state.as_mut().unwrap().port_forwards);
+        self.with_consomme_no_pool(|c| {
+            let mut bound: Vec<(IpProtocol, IpVersion, u16)> = Vec::new();
+            for fwd in port_forwards {
+                let protocol = fwd.protocol;
+                let guest_port = fwd.guest_port;
+                let result = match socket_family(&fwd.socket) {
+                    Ok(family) => {
+                        let result = match protocol {
+                            IpProtocol::Tcp => c.bind_tcp_port(fwd.socket, guest_port),
+                            IpProtocol::Udp => c.bind_udp_port(fwd.socket, guest_port),
+                        };
+                        result.map(|()| (protocol, family, guest_port))
+                    }
+                    Err(err) => Err(err),
+                };
+                match result {
+                    Ok(bound_entry) => bound.push(bound_entry),
+                    Err(err) => {
+                        // Roll back successful binds before returning error.
+                        for (protocol, family, guest_port) in &bound {
+                            let _ = match protocol {
+                                IpProtocol::Tcp => c.unbind_tcp_port(*family, *guest_port),
+                                IpProtocol::Udp => c.unbind_udp_port(*family, *guest_port),
+                            };
+                        }
+                        return Err(anyhow::anyhow!(err).context("failed to bind port"));
+                    }
+                }
+            }
+            Ok(())
+        })
+    }
+
+    fn apply_pending_requests(
+        &mut self,
+        pending: VecDeque<PendingRequest>,
+        listener_control: &consomme::ListenerControl,
+    ) {
+        self.with_consomme_no_pool(|c| {
+            for request in pending {
+                process_pending_request(c, listener_control, request);
+            }
+        });
+    }
+
     fn with_consomme_no_pool<F, R>(&mut self, f: F) -> R
     where
         F: FnOnce(&mut consomme::Access<'_, ClientNoPool<'_>>) -> R,
@@ -697,13 +712,12 @@ fn execute_unbind(
 }
 
 /// Handles a listener-only request without accessing the queue-owned state.
-/// Returns requests that require a queue restart unchanged.
 fn process_listener_request(
     listener_control: &consomme::ListenerControl,
-    request: ConsommeRequest,
-) -> Result<(), ConsommeRequest> {
+    request: ListenerRequest,
+) {
     match request {
-        ConsommeRequest::Bind(rpc) => {
+        ListenerRequest::Bind(rpc) => {
             rpc.handle_failable_sync(
                 |cfg| -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
                     let guest_port = cfg.guest_port;
@@ -712,9 +726,8 @@ fn process_listener_request(
                     Ok(())
                 },
             );
-            Ok(())
         }
-        ConsommeRequest::Unbind(rpc) => {
+        ListenerRequest::Unbind(rpc) => {
             rpc.handle_failable_sync(
                 |cfg| -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
                     execute_unbind(listener_control, &cfg)?;
@@ -722,19 +735,28 @@ fn process_listener_request(
                     Ok(())
                 },
             );
-            Ok(())
         }
-        request => Err(request),
     }
 }
 
-/// Handles a request that needs access to the queue-owned Consomme state.
-fn process_request(
+/// Handles a request deferred until queue startup.
+fn process_pending_request(
     consomme: &mut consomme::Access<'_, impl consomme::Client>,
-    request: ConsommeRequest,
+    listener_control: &consomme::ListenerControl,
+    request: PendingRequest,
 ) {
     match request {
-        ConsommeRequest::CreateVirtualAddress(rpc) => {
+        PendingRequest::Listener(request) => {
+            process_listener_request(listener_control, request);
+        }
+        PendingRequest::StateUpdate(rpc) => {
+            rpc.handle_sync(|f| {
+                f(consomme.get_mut().params_mut());
+                consomme.get_mut().clear_local_addr_map();
+                consomme.update_dns_nameservers()
+            });
+        }
+        PendingRequest::CreateVirtualAddress(rpc) => {
             rpc.handle_sync(|destination| {
                 consomme
                     .get_mut()
@@ -742,15 +764,12 @@ fn process_request(
                     .map(HostIpAddress::from)
             });
         }
-        ConsommeRequest::AddDnsRecord(rpc) => {
+        PendingRequest::AddDnsRecord(rpc) => {
             rpc.handle_failable_sync(|cfg: DnsRecordConfig| {
                 consomme
                     .get_mut()
                     .add_dns_record(StaticDnsRecord::A(cfg.record), &cfg.name)
             });
-        }
-        ConsommeRequest::Bind(_) | ConsommeRequest::Unbind(_) => {
-            unreachable!("listener request was not handled by the endpoint")
         }
     }
 }

--- a/vm/devices/net/net_consomme/src/resolver.rs
+++ b/vm/devices/net/net_consomme/src/resolver.rs
@@ -96,8 +96,8 @@ impl ResolveResource<NetEndpointHandleKind, ConsommeHandle> for ConsommeResolver
                 })
             })
             .collect::<Result<Vec<_>, ResolveConsommeError>>()?;
-        let endpoint = if let Some(port_recv) = resource.recv {
-            ConsommeEndpoint::new_with_port_channel(state, port_forwards, port_recv)
+        let endpoint = if let Some(request_recv) = resource.recv {
+            ConsommeEndpoint::new_with_request_channel(state, port_forwards, request_recv)
         } else {
             ConsommeEndpoint::new_with_ports(state, port_forwards)
         };

--- a/vmm_tests/vmm_tests/tests/tests/ttrpc.rs
+++ b/vmm_tests/vmm_tests/tests/tests/ttrpc.rs
@@ -21,6 +21,7 @@ use pal_async::process::PolledChild;
 use pal_async::socket::PolledSocket;
 use pal_async::task::Spawn;
 use pal_async::task::Task;
+use pal_async::timer::PolledTimer;
 use petri::ResolvedArtifact;
 use petri::pipette::cmd;
 use petri_artifacts_vmm_test::artifacts;
@@ -46,6 +47,19 @@ petri::test!(test_ttrpc_interface, |resolver| {
             .erase(),
     };
     Some([openvmm.erase(), kernel.erase(), initrd.erase(), pipette])
+});
+
+petri::test!(test_ttrpc_consomme_port_forward, |resolver| {
+    // Only supported on x86_64 for now.
+    if petri_artifacts_common::tags::MachineArch::host()
+        != petri_artifacts_common::tags::MachineArch::X86_64
+    {
+        return None;
+    }
+    let openvmm = resolver.require(artifacts::OPENVMM_NATIVE);
+    let kernel = resolver.require(artifacts::loadable::LINUX_DIRECT_TEST_KERNEL_NATIVE);
+    let initrd = resolver.require(artifacts::loadable::LINUX_DIRECT_TEST_INITRD_NATIVE);
+    Some([openvmm.erase(), kernel.erase(), initrd.erase()])
 });
 
 async fn test_ttrpc_interface(
@@ -1177,6 +1191,292 @@ async fn validate_pcie_config(agent: &pipette_client::PipetteClient) -> anyhow::
     anyhow::ensure!(
         acs_capabilities == 1,
         "expected ACS capability mask 0x0001, got {acs_capabilities:#06x}"
+    );
+
+    Ok(())
+}
+
+/// End-to-end test of consomme host port forwarding driven over the ttrpc
+/// interface: boot a guest that listens on a guest port, bind a host port to it
+/// via `ModifyResource`, then connect from the host and verify the connection
+/// reaches the in-guest listener. Finally unbind and verify the host port stops
+/// accepting connections.
+async fn test_ttrpc_consomme_port_forward(
+    params: petri::PetriTestParams<'_>,
+    driver: DefaultDriver,
+    [openvmm, kernel_path, initrd_path]: [ResolvedArtifact; 3],
+) -> anyhow::Result<()> {
+    /// Guest TCP port the in-guest `nc` listener binds to.
+    const GUEST_PORT: u16 = 8080;
+    /// Banner the guest sends to each accepted connection.
+    const BANNER: &[u8] = b"CONSOMME_OK";
+
+    let tempdir = tempfile::tempdir()?;
+    let socket_path = tempdir.path().join("ttrpc.sock");
+
+    tracing::info!(socket_path = %socket_path.display(), "launching OpenVMM with ttrpc");
+
+    let (stderr_read, stderr_write) = pal::pipe_pair()?;
+    let (stdout_read, stdout_write) = pal::pipe_pair()?;
+    let child = std::process::Command::new(openvmm)
+        .arg("--ttrpc")
+        .arg(&socket_path)
+        .stdin(Stdio::null())
+        .stdout(stdout_write)
+        .stderr(stderr_write)
+        .spawn()?;
+
+    let mut child = PolledChild::<std::process::Child>::new(&driver, child)?;
+
+    let _stderr_task = driver.spawn(
+        "stderr",
+        petri::log_task(
+            params.logger.log_file("stderr")?,
+            PolledPipe::new(&driver, stderr_read)?,
+            "openvmm stderr",
+        ),
+    );
+
+    // Wait for stdout to close (readiness signal).
+    let mut stdout = PolledPipe::new(&driver, stdout_read)?;
+    let mut buf = [0u8; 1];
+    let n = stdout
+        .read(&mut buf)
+        .await
+        .context("reading from openvmm stdout")?;
+    anyhow::ensure!(n == 0, "openvmm wrote unexpected data to stdout");
+    drop(stdout);
+
+    let client = mesh_rpc::Client::new(
+        &driver,
+        mesh_rpc::client::UnixDialier::new(driver.clone(), socket_path.clone()),
+    );
+
+    let nic_id = Guid::new_random().to_string();
+    let mac = "00-15-5D-12-12-12".to_string();
+
+    // Bring up eth0 (consomme's DHCP assigns 10.0.0.2) and serve the banner
+    // on GUEST_PORT, re-listening after each connection so repeated probes
+    // from the host all get served.
+    let banner = std::str::from_utf8(BANNER).unwrap();
+    let kernel_cmdline = format!(
+        "console=ttyS0 rdinit=/bin/busybox panic=-1 -- \
+             sh -c \"ifconfig eth0 up; udhcpc eth0; \
+             while true; do echo {banner} | nc -l -p {GUEST_PORT}; done\""
+    );
+
+    client
+        .call()
+        .start(
+            vmservice::Vm::CreateVm,
+            vmservice::CreateVmRequest {
+                config: Some(vmservice::VmConfig {
+                    memory_config: Some(vmservice::MemoryConfig {
+                        memory_mb: 256,
+                        ..Default::default()
+                    }),
+                    processor_config: Some(vmservice::ProcessorConfig {
+                        processor_count: 2,
+                        ..Default::default()
+                    }),
+                    boot_config: Some(vmservice::vm_config::BootConfig::DirectBoot(
+                        vmservice::DirectBoot {
+                            kernel_path: kernel_path.get().to_string_lossy().to_string(),
+                            initrd_path: initrd_path.get().to_string_lossy().to_string(),
+                            kernel_cmdline,
+                        },
+                    )),
+                    devices_config: Some(vmservice::DevicesConfig {
+                        nic_config: vec![vmservice::NicConfig {
+                            nic_id: nic_id.clone(),
+                            mac_address: mac.clone(),
+                            backend: Some(vmservice::nic_config::Backend::Consomme(
+                                vmservice::ConsommeBackend {
+                                    cidr: String::new(),
+                                    ports: vec![],
+                                },
+                            )),
+                            ..Default::default()
+                        }],
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                }),
+                log_id: String::new(),
+            },
+        )
+        .await
+        .unwrap();
+
+    client
+        .call()
+        .start(vmservice::Vm::ResumeVm, ())
+        .await
+        .unwrap();
+
+    let operation_result: anyhow::Result<()> = async {
+        // Pick an ephemeral host port and bind it via ModifyResource. Retry
+        // with a fresh port if another process claims it first.
+        let mut host_port = 0u16;
+        let modify_request =
+            |port: u16, modify_type: vmservice::ModifyType| vmservice::ModifyResourceRequest {
+                r#type: modify_type as i32,
+                resource: Some(vmservice::modify_resource_request::Resource::NicConfig(
+                    vmservice::NicConfig {
+                        nic_id: nic_id.clone(),
+                        mac_address: mac.clone(),
+                        backend: Some(vmservice::nic_config::Backend::Consomme(
+                            vmservice::ConsommeBackend {
+                                cidr: String::new(),
+                                ports: vec![vmservice::PortConfig {
+                                    host_port: port as u32,
+                                    guest_port: GUEST_PORT as u32,
+                                    protocol: vmservice::IpProtocol::Tcp as i32,
+                                }],
+                            },
+                        )),
+                        ..Default::default()
+                    },
+                )),
+            };
+
+        const MAX_PORT_ATTEMPTS: u32 = 5;
+        let mut bound = false;
+        let mut last_bind_error = None;
+        for attempt in 0..MAX_PORT_ATTEMPTS {
+            host_port = std::net::TcpListener::bind((std::net::Ipv4Addr::UNSPECIFIED, 0))?
+                .local_addr()?
+                .port();
+
+            match client
+                .call()
+                .start(
+                    vmservice::Vm::ModifyResource,
+                    modify_request(host_port, vmservice::ModifyType::Update),
+                )
+                .await
+            {
+                Ok(()) => {
+                    tracing::info!(attempt, host_port, "port forward bound successfully");
+                    bound = true;
+                    break;
+                }
+                Err(err) => {
+                    tracing::warn!(
+                        attempt,
+                        host_port,
+                        error = ?err,
+                        "ModifyResource bind failed, retrying with new port"
+                    );
+                    last_bind_error = Some(err);
+                }
+            }
+        }
+        anyhow::ensure!(
+            bound,
+            "could not bind a host port after {MAX_PORT_ATTEMPTS} attempts: \
+                 {last_bind_error:?}"
+        );
+
+        // From the host, connect to the forwarded port and confirm the guest's
+        // banner comes back. Retry to absorb guest boot/DHCP/listener latency
+        // and the fact that consomme may drop the initial SYN to the guest
+        // before RX buffers exist (a reconnect forces a fresh SYN).
+        let addr = std::net::SocketAddr::from((std::net::Ipv4Addr::LOCALHOST, host_port));
+        let mut timer = PolledTimer::new(&driver);
+        let mut got_banner = false;
+        for attempt in 0..60 {
+            let probe = async {
+                let mut socket = PolledSocket::connect_tcp(&driver, addr).await?;
+                let mut buf = vec![0u8; BANNER.len()];
+                socket.read_exact(&mut buf).await?;
+                anyhow::Ok(buf)
+            };
+            match CancelContext::new()
+                .with_timeout(Duration::from_secs(5))
+                .until_cancelled(probe)
+                .await
+            {
+                Ok(Ok(buf)) if buf == BANNER => {
+                    tracing::info!(
+                        attempt,
+                        host_port,
+                        "received guest banner over forwarded port"
+                    );
+                    got_banner = true;
+                    break;
+                }
+                other => {
+                    tracing::debug!(attempt, ?other, "forwarded connection not ready, retrying");
+                    timer.sleep(Duration::from_secs(1)).await;
+                }
+            }
+        }
+        anyhow::ensure!(
+            got_banner,
+            "did not receive guest banner over forwarded host port {host_port}"
+        );
+
+        // Unbind the port and confirm the host stops accepting connections.
+        client
+            .call()
+            .start(
+                vmservice::Vm::ModifyResource,
+                modify_request(host_port, vmservice::ModifyType::Remove),
+            )
+            .await
+            .map_err(|err| anyhow::anyhow!(err.message))?;
+
+        let mut refused = false;
+        for attempt in 0..30 {
+            match CancelContext::new()
+                .with_timeout(Duration::from_secs(5))
+                .until_cancelled(PolledSocket::connect_tcp(&driver, addr))
+                .await
+            {
+                Ok(Err(err)) if err.kind() == std::io::ErrorKind::ConnectionRefused => {
+                    tracing::info!(attempt, host_port, "forwarded port refused after unbind");
+                    refused = true;
+                    break;
+                }
+                Ok(Ok(_)) => {
+                    tracing::debug!(attempt, "forwarded port still accepting connections");
+                    timer.sleep(Duration::from_secs(1)).await;
+                }
+                Ok(Err(err)) => {
+                    tracing::debug!(
+                        attempt,
+                        error = &err as &dyn std::error::Error,
+                        "forwarded connection failed without refusal"
+                    );
+                    timer.sleep(Duration::from_secs(1)).await;
+                }
+                Err(err) => {
+                    tracing::debug!(attempt, ?err, "forwarded connection attempt timed out");
+                    timer.sleep(Duration::from_secs(1)).await;
+                }
+            }
+        }
+        anyhow::ensure!(
+            refused,
+            "forwarded host port {host_port} still accepting connections after unbind"
+        );
+        Ok(())
+    }
+    .await;
+
+    // Tear down the VM and quit OpenVMM.
+    let teardown_result = client.call().start(vmservice::Vm::TeardownVm, ()).await;
+    let _ = client.call().start(vmservice::Vm::Quit, ()).await;
+
+    let exit_status = child.wait().await;
+    operation_result?;
+    teardown_result.map_err(|err| anyhow::anyhow!(err.message))?;
+    let exit_status = exit_status?;
+    tracing::info!(?exit_status, "openvmm exited");
+    anyhow::ensure!(
+        exit_status.success(),
+        "openvmm exited abnormally: {exit_status:?}"
     );
 
     Ok(())


### PR DESCRIPTION
Currently, consommé control messages are only dequeued/handled when the backend is being polled for network packets. If a guest stops driving the NIC for packets, control requests are never dequeued/handled by consommé.

This PR moves control requests polling to the endpoint control path, so requests continue to make progress independent of packet flows. 

Control requests fall into two categories based on whether they require access to queue-owned consommé state.

Requests such as adding static DNS records, creating virtual addresses, and updating network parameters modify broader protocol state. These requests are buffered by the endpoint and applied when it regains ownership of the consommé state, which requires restarting the network queues.

Port bind and unbind requests only modify the TCP or UDP listener tables. They also occur much more frequently than the other control operations. Restarting the queues for every bind or unbind would repeatedly interrupt packet processing and impose a significant throughput penalty, particularly for workloads that frequently create and remove port forwards.

To avoid that cost, the listener tables use a locking mechanism and expose a separate listener-control capability. Bind and unbind requests can therefore be applied directly while the queues continue running. Requests that require broader mutable state still use the deferred queue-restart path.