### PR TITLE
vmm_tests: Mark one more test as unstable due to WHP lost interrupt bug

### DIFF
--- a/vmm_tests/vmm_tests/tests/tests/multiarch.rs
+++ b/vmm_tests/vmm_tests/tests/tests/multiarch.rs
@@ -440,7 +440,10 @@ async fn boot_nvme<T: PetriVmmBackend>(config: PetriVmBuilder<T>) -> anyhow::Res
             reason = "WHP lacks ARM64 VTL2 support",
             openvmm_openhcl_uefi_aarch64(vhd(ubuntu_2404_server_aarch64))
         ),
-        openvmm_openhcl_uefi_x64(vhd(windows_datacenter_core_2022_x64)),
+        unstable(
+            reason = "known WHP lost interrupt bug",
+            openvmm_openhcl_uefi_x64(vhd(windows_datacenter_core_2022_x64))
+        ),
         ignore(
             reason = "Linux initrd lacks a VPCI driver",
             openvmm_openhcl_uefi_x64(vhd(ubuntu_2504_server_x64))


### PR DESCRIPTION
This test seems to hit this bug pretty frequently. Mark it as unstable until the fix is available.