### PR TITLE
loader: fix page table relocation identity mapping

### DIFF
--- a/vm/loader/src/paravisor.rs
+++ b/vm/loader/src/paravisor.rs
@@ -409,6 +409,20 @@ where
     )?;
     offset += heap_size;
 
+    // The page table region lives immediately after the relocation region and
+    // is deliberately excluded from it, but the identity map built below uses
+    // large pages. A loader performing relocation only fixes up a leaf entry if
+    // the region it maps overlaps the relocation region, so if the page table
+    // region began exactly on a large page boundary the leaf entry mapping it
+    // would be left identity mapped at its pre-relocation address. The
+    // relocated cr3 would then be unmapped, and the first access to the page
+    // tables through the identity map faults with no IDT loaded, triple
+    // faulting the VP. Pad by a page so the page table region always shares a
+    // large page with the relocation region.
+    if offset.is_multiple_of(X64_LARGE_PAGE_SIZE) {
+        offset += HV_PAGE_SIZE;
+    }
+
     // The end of memory used by the loader, excluding pagetables.
     let end_of_underhill_mem = offset;
 
@@ -1154,6 +1168,13 @@ where
         &[],
     )?;
     next_addr += heap_size;
+
+    // See the equivalent comment in the x64 loader: the page table region must
+    // share a large page with the relocation region so that the leaf entry
+    // mapping it is fixed up when the image is relocated.
+    if next_addr.is_multiple_of(u64::from(Arm64PageSize::Large)) {
+        next_addr += HV_PAGE_SIZE;
+    }
 
     // The end of memory used by the loader, excluding pagetables.
     let end_of_underhill_mem = next_addr;


### PR DESCRIPTION
Backport of the page table relocation fix to `release/1.8.2607`. Opened ahead of the main PR because 1.8 is currently red.

A relocating loader must keep the page table region identity mapped (VA = PA) after it moves it. Both the OpenVMM loader and the Hyper-V loader only fixed up identity map entries against the `IGVM_VHS_RELOCATABLE_REGION` range, so a page table region starting exactly on a large page boundary kept its pre-relocation VA, leaving the relocated root unmapped:

```
triple fault vtl=Vtl2 vp=0x0
  faulting instruction "mov r13,[r12+0FF8h]"
  r12=0x1a4a00000  cr3=0x1a4a00000  cr2=0x80  idtr base=0 limit=ffff
```

Latent — the region start is the running total of everything loaded before it, so unrelated image growth decides whether it lands on the boundary. 1.8 landed on `0xca00000` and every test that relocates VTL2 failed.

Two commits:

1. **Loader fix.** Include the page table region in the relocation map so its own identity mapping is fixed up. Correct at any alignment.
2. **Image-side mitigation.** Pad by a page so the region never starts on a large page boundary. Needed because already-shipped Hyper-V loaders have the same defect and cannot be fixed from here. The two regions stay disjoint, as the spec requires.

The upstream crate fix is microsoft/igvm#135, which fixes this for all consumers of `PageTableRelocationBuilder`; the Hyper-V loader needs an equivalent fix separately.
