### PR TITLE
ci: fix timezone and timeout for burn-in pipeline

### DIFF
--- a/.github/workflows/openvmm-burn-in.yaml
+++ b/.github/workflows/openvmm-burn-in.yaml
@@ -13,9 +13,11 @@ on:
         type: boolean
   schedule:
   - cron: 0 19 * * 1-5
+    timezone: America/Los_Angeles
 jobs:
   job0:
     name: run vmm-tests [x64-windows-all-snp]
+    timeout-minutes: 900
     runs-on:
     - self-hosted
     - Windows

--- a/flowey/flowey_cli/src/pipeline_resolver/github_yaml/github_yaml_defs.rs
+++ b/flowey/flowey_cli/src/pipeline_resolver/github_yaml/github_yaml_defs.rs
@@ -95,6 +95,8 @@ pub struct CiTrigger {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Cron {
     pub cron: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub timezone: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/flowey/flowey_cli/src/pipeline_resolver/github_yaml/mod.rs
+++ b/flowey/flowey_cli/src/pipeline_resolver/github_yaml/mod.rs
@@ -747,6 +747,7 @@ EOF
             .iter()
             .map(|s| github_yaml_defs::Cron {
                 cron: s.cron.clone(),
+                timezone: s.timezone.clone(),
             })
             .collect(),
     };

--- a/flowey/flowey_core/src/pipeline.rs
+++ b/flowey/flowey_core/src/pipeline.rs
@@ -257,6 +257,8 @@ pub enum AdoResourcesRepositoryRef<P = UseParameter<String>> {
 pub struct GhScheduleTriggers {
     /// Run the pipeline in a schedule, as specified by a cron string
     pub cron: String,
+    /// IANA timezone string
+    pub timezone: Option<String>,
 }
 
 /// Trigger Github Actions pipelines per PR

--- a/flowey/flowey_hvlite/src/pipelines/burn_in.rs
+++ b/flowey/flowey_hvlite/src/pipelines/burn_in.rs
@@ -41,6 +41,7 @@ impl IntoPipeline for BurnInCli {
             .gh_set_name("OpenVMM Burn In")
             .gh_add_schedule_trigger(GhScheduleTriggers {
                 cron: "0 19 * * 1-5".into(),
+                timezone: Some("America/Los_Angeles".into()),
             });
 
         pipeline.inject_all_jobs_with(move |job| {
@@ -59,6 +60,8 @@ impl IntoPipeline for BurnInCli {
                     GhPermission::IdToken,
                     GhPermissionValue::Write,
                 )])
+                // 15 hour timeout. Should take approximately 8.5 hours.
+                .with_timeout_in_minutes(900)
         });
 
         struct VmmTestJobParams<'a> {


### PR DESCRIPTION
Set the timezone so it starts at 7PM as intended instead of noon, and increase the timeout from the default of 6 hours to 15 hours.