### PR TITLE
loader: keep the page table region off a large page boundary

### DIFF
--- a/vm/loader/src/paravisor.rs
+++ b/vm/loader/src/paravisor.rs
@@ -483,6 +483,13 @@ where
     )?;
     offset += heap_size;
 
+    // Relocating loaders only fix up identity map entries that overlap the
+    // relocation region, so keep the page table region sharing a large page
+    // with it. Otherwise the relocated cr3 is unmapped and VTL2 triple faults.
+    if offset.is_multiple_of(X64_LARGE_PAGE_SIZE) {
+        offset += HV_PAGE_SIZE;
+    }
+
     // The end of memory used by the loader, excluding pagetables.
     let end_of_underhill_mem = offset;
 
@@ -1241,6 +1248,12 @@ where
         &[],
     )?;
     next_addr += heap_size;
+
+    // Keep the page table region sharing a large page with the relocation
+    // region, so the identity map entry covering it is relocated with it.
+    if next_addr.is_multiple_of(u64::from(Arm64PageSize::Large)) {
+        next_addr += HV_PAGE_SIZE;
+    }
 
     // The end of memory used by the loader, excluding pagetables.
     let end_of_underhill_mem = next_addr;


### PR DESCRIPTION
The paravisor loader places the page table region immediately after the relocation region and excludes it from that region, but the boot identity map uses large pages.

A relocating loader only fixes up an identity map leaf entry when the range it maps overlaps the relocation region. When the page table region starts exactly on a large page boundary there is no overlap, so its leaf stays identity mapped at the pre-relocation address. `cr3` is relocated and the page table pages are physically moved, so the relocated `cr3` has no mapping and the first page table access triple faults VTL2 with no IDT loaded:

```
triple fault vtl=Vtl2 vp=0x0
  faulting instruction "mov r13,[r12+0FF8h]"
  r12=0x1a4a00000  cr3=0x1a4a00000  cr2=0x80  idtr base=0 limit=ffff
```

This is latent. The region start is just the running total of everything loaded before it, so unrelated image growth decides whether it lands on the boundary — roughly 1 in 512. `main` is currently at `0xcb20000` and passes by luck; `release/1.8.2607` landed on `0xca00000` and every `hyperv_openhcl_*` test fails.

Pad by a page so the region always shares a large page with the relocation region. Verified on 1.8: 713/713 tests pass with the region at `0xca01000`.
