### PR TITLE
SCSI: Fix Persistent Reservation (PR) NVMe->SCSI conversion of HostID to Transport ID

### DIFF
--- a/vm/devices/storage/scsidisk/src/reservation.rs
+++ b/vm/devices/storage/scsidisk/src/reservation.rs
@@ -242,6 +242,33 @@ impl SimpleScsiDisk {
         let mut data = PriFullStatusListHeader::new_zeroed().as_bytes().to_vec();
 
         for controller in &report.controllers {
+            // SCSI Transport ID of type SAS is defined as (24 bytes):
+            // 06 00 00 00 <8-byte SAS address> <12-byte reserved>
+            // The Host ID we receive from NVMe can be 8- or 16-bytes long. We
+            // dump it starting at the SAS address field (and into reserved if
+            // it's 16-bytes).
+            //
+            // Some NVMe controllers wrongly send the first 16
+            // bytes of a SAS SCSI Transport ID as the Host ID. If we detect
+            // that, we skip the first 4 bytes of the Host ID to avoid
+            // duplicating the SAS protocol id (6) in the Transport ID.
+            let host_id = if controller.host_id.starts_with(&[6, 0, 0, 0]) {
+                tracelimit::warn_ratelimited!(
+                    ?controller.controller_id,
+                    ?controller.key,
+                    ?controller.host_id,
+                    "NVMe controller sent SAS SCSI Transport ID as Host ID"
+                );
+                &controller.host_id[4..]
+            } else {
+                &controller.host_id[..]
+            };
+            let host_id_len = host_id.len().min(16);
+
+            let mut transport_id = [0u8; 24];
+            transport_id[0] = 0x06; // Protocol Identifier: SAS
+            transport_id[4..4 + host_id_len].copy_from_slice(&host_id[..host_id_len]);
+
             let header = PriFullStatusDescriptorHeader {
                 reservation_key: controller.key.into(),
                 flags: scsi::PriFullStatusDescriptorHeaderFlags::new()
@@ -255,12 +282,12 @@ impl SimpleScsiDisk {
                         .map_or(scsi::ReservationType(0), to_scsi_reservation_type),
                 ),
                 relative_target_port_identifier: controller.controller_id.into(),
-                additional_descriptor_length: (controller.host_id.len() as u32).into(),
+                additional_descriptor_length: (transport_id.len() as u32).into(),
                 ..FromZeros::new_zeroed()
             };
 
             data.extend(header.as_bytes());
-            data.extend(&controller.host_id);
+            data.extend(&transport_id);
         }
 
         let header = PriFullStatusListHeader {

--- a/vm/devices/storage/scsidisk/src/tests/pr_tests.rs
+++ b/vm/devices/storage/scsidisk/src/tests/pr_tests.rs
@@ -268,7 +268,7 @@ fn make_read_full_status_response(
     let header = scsi::PriFullStatusListHeader {
         generation: generation.into(),
         additional_length: if key != 0 {
-            ((size_of::<scsi::PriFullStatusDescriptorHeader>() + 8) as u32).into()
+            ((size_of::<scsi::PriFullStatusDescriptorHeader>() + 24) as u32).into()
         } else {
             0_u32.into()
         },
@@ -287,13 +287,15 @@ fn make_read_full_status_response(
                 scsi::PersistentReserveTypeScope::new()
             },
             relative_target_port_identifier: 0_u16.into(),
-            additional_descriptor_length: 8_u32.into(),
+            additional_descriptor_length: 24_u32.into(),
             ..FromZeros::new_zeroed()
         };
         temp_data.extend(header.as_bytes());
-        temp_data.extend(0_u64.as_bytes());
+        temp_data.extend([6u8, 0u8, 0u8, 0u8]); // SAS SCSI Transport ID (24 bytes total)
+        temp_data.extend(&[0u8; 20]);
     }
-    data[..temp_data.len()].copy_from_slice(temp_data.as_bytes());
+    let len = data.len().min(temp_data.len());
+    data[..len].copy_from_slice(&temp_data[..len]);
 }
 
 fn make_report_capabilities_response(data: &mut [u8], aptpl: bool) {
@@ -354,7 +356,7 @@ async fn validate_pr_result(
         0u8;
         size_of::<scsi::PriFullStatusListHeader>()
             + size_of::<scsi::PriFullStatusDescriptorHeader>()
-            + 8
+            + 24
     ];
     let mut report_capabilities_response = vec![0u8; size_of::<scsi::PriReportCapabilities>()];
     let allocation_length = 4096;


### PR DESCRIPTION
Just copying it, as was done before, is wrong since HostID is 8 or 16 bytes (random-ish) and TransportID is 24 bytes (and has structure).

This change follows the [T10 SPC-3 spec](https://www.t10.org/ftp/t10/document.02/02-246r1.pdf) for the format of the TransportID retaining backward compatibility for NVMe HostIDs that start with `06 00 00 00`. This last part can happen when the NVMe HostID itself is incorrectly derived from an underlying SCSI TransportID by just copying bytes.

Before:
```
# sg_persist --in  --read-full-status /dev/sda
  OpenVMM   Disk              1.0
  Peripheral device type: disk
  PR generation=0x1
    Key=0x1234
      All target ports bit set
      not reservation holder
      Transport Id short or not multiple of 4 [length=1024]:
        SAS address: 0xbd591cd38dc846b6

# sg_raw -r 8192 /dev/sda 5e 03 00 00 00 00 00 20 00 00 | hexdump -C
SCSI Status: Good Received 48 bytes of data:
 00     00 00 00 18 00 00 00 28  ff 00 7c 80 09 2f 6d 08    .......(..|../m.
 10     00 00 00 00 02 00 00 00  00 00 00 00 00 00 00 10    ................
 20     06 00 00 00 bd 59 1c d3  8d c8 46 b6 99 68 1d 91    .....Y....F..h..
```

After:
```
alpine:~# sg_persist --out --register --param-rk=0 --param-sark=0x1234 /dev/sda
  OpenVMM   Disk              1.0
  Peripheral device type: disk

alpine:~# sg_persist --in --read-keys /dev/sda
  OpenVMM   Disk              1.0
  Peripheral device type: disk
  PR generation=0x1, 1 registered reservation key follows:
    0x1234

alpine:~# sg_persist --in --read-full-status /dev/sda
  OpenVMM   Disk              1.0
  Peripheral device type: disk
  PR generation=0x1
    Key=0x1234
      All target ports bit set
      not reservation holder
      Transport Id of initiator:
        SAS address: 0x1020304050607

alpine:~# sg_raw -r 8192 /dev/sda 5e 03 00 00 00 00 00 20 00 00
SCSI Status: Good

Received 56 bytes of data:
 00     00 00 00 01 00 00 00 30  00 00 00 00 00 00 12 34    .......0.......4
 10     00 00 00 00 02 00 00 00  00 00 00 00 00 00 00 18    ................
 20     06 00 00 00 00 01 02 03  04 05 06 07 08 09 0a 0b    ................
 30     0c 0d 0e 0f 00 00 00 00                             ........
```