### PR TITLE
loader: fix page table relocation identity mapping

### DIFF
--- a/openvmm/openvmm_core/src/worker/vm_loaders/igvm.rs
+++ b/openvmm/openvmm_core/src/worker/vm_loaders/igvm.rs
@@ -1217,6 +1217,14 @@ fn load_igvm_x86(
             relocation_region.base_gpa..=relocation_region.base_gpa + relocation_region.size - 1,
             offset as i64,
         );
+        // The page table region is itself relocatable and must stay identity
+        // mapped, so its own range needs fixing up too. Otherwise the leaf
+        // entry mapping it keeps the pre-relocation VA and the root is
+        // unmapped.
+        reloc_regions.insert(
+            page_table_fixup.gpa..=page_table_fixup.gpa + page_table_fixup.size - 1,
+            offset as i64,
+        );
         let page_table = page_table_fixup
             .build(offset as i64, reloc_regions, page_table_cpu_state)
             .map_err(Error::PageTableBuilder)?;

--- a/vm/loader/src/paravisor.rs
+++ b/vm/loader/src/paravisor.rs
@@ -409,6 +409,12 @@ where
     )?;
     offset += heap_size;
 
+    // Some loaders only fix up identity map entries that overlap the relocation
+    // region, so keep the page table region in the same large page as it.
+    if offset.is_multiple_of(X64_LARGE_PAGE_SIZE) {
+        offset += HV_PAGE_SIZE;
+    }
+
     // The end of memory used by the loader, excluding pagetables.
     let end_of_underhill_mem = offset;
 
@@ -1154,6 +1160,12 @@ where
         &[],
     )?;
     next_addr += heap_size;
+
+    // Some loaders only fix up identity map entries that overlap the relocation
+    // region, so keep the page table region in the same large page as it.
+    if next_addr.is_multiple_of(u64::from(Arm64PageSize::Large)) {
+        next_addr += HV_PAGE_SIZE;
+    }
 
     // The end of memory used by the loader, excluding pagetables.
     let end_of_underhill_mem = next_addr;


### PR DESCRIPTION
Backport of the page table relocation fix to `release/1.8.2607`. Opened ahead of the main PR because 1.8 is currently red.

A relocating loader must keep the page table region identity mapped (VA = PA) after it moves it. Both the OpenVMM loader and the Hyper-V loader only fixed up identity map entries against the `IGVM_VHS_RELOCATABLE_REGION` range, so a page table region starting exactly on a large page boundary kept its pre-relocation VA, leaving the relocated root unmapped:

```
triple fault vtl=Vtl2 vp=0x0
  faulting instruction "mov r13,[r12+0FF8h]"
  r12=0x1a4a00000  cr3=0x1a4a00000  cr2=0x80  idtr base=0 limit=ffff
```

Latent — the region start is the running total of everything loaded before it, so unrelated image growth decides whether it lands on the boundary. 1.8 landed on `0xca00000` and every test that relocates VTL2 failed.

Two commits:

1. **Loader fix.** Include the page table region in the relocation map so its own identity mapping is fixed up. Correct at any alignment.
2. **Image-side mitigation.** Pad by a page so the region never starts on a large page boundary. Needed because already-shipped Hyper-V loaders have the same defect and cannot be fixed from here. The two regions stay disjoint, as the spec requires.

The upstream crate fix is microsoft/igvm#135, which fixes this for all consumers of `PageTableRelocationBuilder`; the Hyper-V loader needs an equivalent fix separately.
