### PR TITLE
vmm-tests: restore incubator profile staging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3916,6 +3916,7 @@ dependencies = [
  "anyhow",
  "clap",
  "crossterm",
+ "fs-err",
  "futures",
  "futures-concurrency",
  "initrd_cpio",

--- a/flowey/flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/consume_and_test_nextest_vmm_tests_archive.rs
@@ -193,6 +193,7 @@ impl SimpleFlowNode for Node {
                     built_artifacts,
                     is_repo_root: test_content_dir_as_repo_root,
                     needs_release_igvm,
+                    needs_incubator_profiles: needs_incubator,
                     done: v,
                 });
 

--- a/flowey/flowey_lib_hvlite/src/_jobs/local_build_and_run_nextest_vmm_tests.rs
+++ b/flowey/flowey_lib_hvlite/src/_jobs/local_build_and_run_nextest_vmm_tests.rs
@@ -670,6 +670,7 @@ impl SimpleFlowNode for Node {
                 built_artifacts,
                 is_repo_root: true,
                 needs_release_igvm,
+                needs_incubator_profiles: incubator_profile.is_some(),
                 done: v,
             });
 

--- a/flowey/flowey_lib_hvlite/src/init_vmm_tests_content_dir.rs
+++ b/flowey/flowey_lib_hvlite/src/init_vmm_tests_content_dir.rs
@@ -140,6 +140,8 @@ flowey_request! {
         pub is_repo_root: bool,
         /// Whether the tests require that release igvm files are downloaded
         pub needs_release_igvm: bool,
+        /// Whether to copy incubator profiles into the test content directory.
+        pub needs_incubator_profiles: bool,
 
         pub done: WriteVar<SideEffect>
     }
@@ -166,6 +168,7 @@ impl SimpleFlowNode for Node {
             built_artifacts,
             is_repo_root,
             needs_release_igvm,
+            needs_incubator_profiles,
             done,
         } = request;
 
@@ -335,7 +338,7 @@ impl SimpleFlowNode for Node {
                         test_content_dir.join(&crate_cargo_toml_file),
                     )?;
 
-                    if incubator.is_some() {
+                    if needs_incubator_profiles {
                         let incubator_profile_dir = incubator_profile_dir();
                         fs_err::create_dir_all(test_content_dir.join(&incubator_profile_dir))?;
                         for entry in

--- a/petri/incubator/Cargo.toml
+++ b/petri/incubator/Cargo.toml
@@ -10,6 +10,7 @@ rust-version.workspace = true
 anyhow.workspace = true
 clap = { workspace = true, features = ["derive", "env"] }
 crossterm = { workspace = true, features = ["windows"] }
+fs-err.workspace = true
 futures.workspace = true
 futures-concurrency.workspace = true
 initrd_cpio.workspace = true

--- a/petri/incubator/src/profile.rs
+++ b/petri/incubator/src/profile.rs
@@ -173,7 +173,7 @@ pub struct QemuTcgConfig {
 impl IncubatorProfile {
     /// Load a profile from a TOML file.
     pub fn from_file(path: &Path) -> anyhow::Result<Self> {
-        let contents = std::fs::read_to_string(path).context("failed to read incubator profile")?;
+        let contents = fs_err::read_to_string(path).context("failed to read incubator profile")?;
         Self::from_toml(&contents)
     }
 


### PR DESCRIPTION
Stage incubator profiles based on whether the run uses an incubator rather than whether the content initializer still owns the incubator binary artifact. This fixes direct vmm-tests-run invocations whose default profile is resolved beneath the test content directory. Also preserve the failing profile path in read errors by using fs-err.