### PR TITLE
vm_topology: fix aarch64 MPIDR and CPU topology

### DIFF
--- a/vm/aarch64/aarch64defs/src/lib.rs
+++ b/vm/aarch64/aarch64defs/src/lib.rs
@@ -482,6 +482,7 @@ open_enum! {
         IFSR32_EL2 = SystemRegEncoding::make(3, 4, 5, 0, 1),
 
         VPIDR_EL2 = SystemRegEncoding::make(3, 4, 0, 0, 0),
+        MPIDR_EL1 = SystemRegEncoding::make(3, 0, 0, 0, 5),
         ARM64_REVIDR_EL1 = SystemRegEncoding::make(3, 0, 0, 0, 6),
         CTR_EL0 = SystemRegEncoding::make(3, 3, 0, 0, 1),
         ARM64_VMPIDR_EL2 = SystemRegEncoding::make(3, 4, 0, 0, 5),

--- a/vm/hv1/hvdef/src/lib.rs
+++ b/vm/hv1/hvdef/src/lib.rs
@@ -2949,6 +2949,7 @@ registers! {
         Cpsr = 0x00020023,
         SpsrEl2 = 0x00021002,
 
+        MpidrEl1 = 0x00040001,
         SctlrEl1 = 0x00040002,
         Ttbr0El1 = 0x00040005,
         Ttbr1El1 = 0x00040006,

--- a/vm/vmcore/vm_topology/src/processor.rs
+++ b/vm/vmcore/vm_topology/src/processor.rs
@@ -127,6 +127,48 @@ impl<T: ArchTopology> TopologyBuilder<T> {
     }
 }
 
+impl<T: ArchTopology> ProcessorTopology<T> {
+    /// Computes the socket, core, and thread coordinates of a VP from the
+    /// configured topology.
+    ///
+    /// This describes the regular topology the VM was asked for. It is
+    /// deliberately independent of any architectural CPU identity, since those
+    /// identities are free to encode an offset, reserved holes, or a packing
+    /// that carries no topology at all.
+    ///
+    /// The result is only meaningful if `vps_per_socket` and `smt_enabled`
+    /// actually describe the VPs in this topology. That holds by construction
+    /// for [`TopologyBuilder::build`], which generates VPs from those same
+    /// values, but [`TopologyBuilder::build_with_vp_info`] takes the VP list
+    /// from its caller and keeps the declared values unchecked. A caller that
+    /// supplies VPs laid out some other way gets coordinates describing the
+    /// layout it declared, not the one it passed in.
+    ///
+    /// Irregular topologies cannot be represented at all: `vps_per_socket` is a
+    /// single value, so sockets of differing sizes, or siblings that are not
+    /// adjacent in VP index order, have nowhere to live. Supporting those would
+    /// require storing per-VP coordinates rather than deriving them here.
+    pub(crate) fn logical_topology(&self, vp_index: VpIndex) -> VpTopologyInfo {
+        let index = vp_index.index();
+        let in_socket = index % self.vps_per_socket;
+        let (core, thread) = if self.smt_enabled {
+            (in_socket / THREADS_PER_CORE, in_socket % THREADS_PER_CORE)
+        } else {
+            (in_socket, 0)
+        };
+        VpTopologyInfo {
+            socket: index / self.vps_per_socket,
+            core,
+            thread,
+        }
+    }
+}
+
+/// The number of threads per core when SMT is enabled.
+///
+/// The topology API models SMT as a boolean, so two is the only possibility.
+pub(crate) const THREADS_PER_CORE: u32 = 2;
+
 impl<
     #[cfg(feature = "inspect")] T: ArchTopology + inspect::Inspect,
     #[cfg(not(feature = "inspect"))] T: ArchTopology,
@@ -184,6 +226,11 @@ impl<
     }
 
     /// Computes the processor topology information for a VP.
+    ///
+    /// This reports the topology the VM was configured with, which is only as
+    /// accurate as that configuration. It is not recovered from the VP's
+    /// architectural identity, and callers should not treat it as a
+    /// measurement of the underlying hardware.
     pub fn vp_topology(&self, vp_index: VpIndex) -> VpTopologyInfo {
         T::vp_topology(self, &self.vp_arch(vp_index))
     }

--- a/vm/vmcore/vm_topology/src/processor/aarch64.rs
+++ b/vm/vmcore/vm_topology/src/processor/aarch64.rs
@@ -6,6 +6,7 @@
 use super::ArchTopology;
 use super::InvalidTopology;
 use super::ProcessorTopology;
+use super::THREADS_PER_CORE;
 use super::TopologyBuilder;
 use super::VpIndex;
 use super::VpInfo;
@@ -24,14 +25,54 @@ impl ArchTopology for Aarch64Topology {
     type ArchVpInfo = Aarch64VpInfo;
     type BuilderState = Aarch64TopologyBuilderState;
 
-    fn vp_topology(_topology: &ProcessorTopology<Self>, info: &Self::ArchVpInfo) -> VpTopologyInfo {
-        VpTopologyInfo {
-            socket: info.mpidr.aff2().into(),
-            core: info.mpidr.aff1().into(),
-            thread: info.mpidr.aff0().into(),
-        }
+    fn vp_topology(topology: &ProcessorTopology<Self>, info: &Self::ArchVpInfo) -> VpTopologyInfo {
+        // MPIDR is an identity, not a topology description: the non-SMT
+        // encoding below packs the VP index without regard to sockets or
+        // cores, and affinity levels only carry their conventional meanings
+        // when MT is set. Ask the configured topology instead of decoding
+        // affinity, accepting that the answer is only as good as that
+        // configuration.
+        topology.logical_topology(info.base.vp_index)
     }
 }
+
+/// Builds the MPIDR for a VP on a platform without SMT.
+///
+/// `Aff0` holds 16 VPs per affinity group because GICv3 targeted SGIs select
+/// `Aff0` through a 16-bit target list, and reaching beyond that requires
+/// Range Selector Support.
+///
+/// Note that this says nothing about sockets or cores. Logical topology is
+/// reported separately, via [`ProcessorTopology::vp_topology`].
+fn non_smt_mpidr(vp_index: u32) -> MpidrEl1 {
+    MpidrEl1::new()
+        .with_aff0((vp_index % AFF0_PER_GROUP) as u8)
+        .with_aff1((vp_index / AFF0_PER_GROUP) as u8)
+        .with_aff2((vp_index / (AFF0_PER_GROUP << 8)) as u8)
+        .with_aff3((vp_index / (AFF0_PER_GROUP << 16)) as u8)
+}
+
+/// Builds the MPIDR for a VP on a platform with SMT.
+///
+/// `MPIDR.MT` is set, so `Aff0` is a thread id and the core index packs into
+/// the fields above it. Sibling threads therefore share everything above
+/// `Aff0`.
+///
+/// Like the non-SMT encoding, this describes no socket placement; that is
+/// PPTT's job.
+fn smt_mpidr(vp_index: u32) -> MpidrEl1 {
+    let core = vp_index / THREADS_PER_CORE;
+    MpidrEl1::new()
+        .with_mt(true)
+        .with_aff0((vp_index % THREADS_PER_CORE) as u8)
+        .with_aff1(core as u8)
+        .with_aff2((core >> 8) as u8)
+        .with_aff3((core >> 16) as u8)
+}
+
+/// The number of `Aff0` values a GICv3 SGI can target in one affinity group
+/// without Range Selector Support.
+const AFF0_PER_GROUP: u32 = 16;
 
 /// Aarch64-specific [`TopologyBuilder`] state.
 pub struct Aarch64TopologyBuilderState {
@@ -189,18 +230,15 @@ impl TopologyBuilder<Aarch64Topology> {
         if !(64..=992).contains(&nr) || !nr.is_multiple_of(32) {
             return Err(InvalidTopology::InvalidGicNrIrqs(nr));
         }
+        let smt_enabled = self.effective_smt();
+        let uni_proc = proc_count == 1;
         let mpidrs = (0..proc_count).map(|vp_index| {
-            // TODO: construct mpidr appropriately for the specified
-            // topology.
-            let uni_proc = proc_count == 1;
-            let mut aff = (0..4).map(|i| (vp_index >> (8 * i)) as u8);
-            MpidrEl1::new()
-                .with_res1_31(true)
-                .with_u(uni_proc)
-                .with_aff0(aff.next().unwrap())
-                .with_aff1(aff.next().unwrap())
-                .with_aff2(aff.next().unwrap())
-                .with_aff3(aff.next().unwrap())
+            let mpidr = if smt_enabled {
+                smt_mpidr(vp_index)
+            } else {
+                non_smt_mpidr(vp_index)
+            };
+            mpidr.with_res1_31(true).with_u(uni_proc)
         });
         let gic_version = self.arch.platform.gic_version;
         self.build_with_vp_info(mpidrs.enumerate().map(move |(id, mpidr)| {
@@ -215,7 +253,7 @@ impl TopologyBuilder<Aarch64Topology> {
             Aarch64VpInfo {
                 base: VpInfo {
                     vp_index: VpIndex::new(id as u32),
-                    vnode: 0,
+                    vnode: id as u32 / self.vps_per_socket,
                 },
                 mpidr,
                 gicr,
@@ -224,26 +262,36 @@ impl TopologyBuilder<Aarch64Topology> {
         }))
     }
 
+    /// Returns whether SMT applies to this configuration.
+    ///
+    /// A socket holding a single VP has no sibling to pair with, so requesting
+    /// SMT there would claim a thread of a core that does not exist. x86 clamps
+    /// the same way.
+    fn effective_smt(&self) -> bool {
+        self.smt_enabled && self.vps_per_socket > 1
+    }
+
     /// Builds a processor topology with processors with the specified information.
+    ///
+    /// The MPIDRs are taken as given; they are not checked against the socket
+    /// and SMT configuration, and nothing derives topology from them. Logical
+    /// topology comes from `vps_per_socket` and `smt_enabled`, so a caller that
+    /// supplies VPs arranged some other way will have that arrangement
+    /// reported as whatever it declared through the builder.
     pub fn build_with_vp_info(
         &self,
         vps: impl IntoIterator<Item = Aarch64VpInfo>,
     ) -> Result<ProcessorTopology<Aarch64Topology>, InvalidTopology> {
         let vps = Vec::from_iter(vps);
-        let mut smt_enabled = false;
         for (i, vp) in vps.iter().enumerate() {
             if i != vp.base.vp_index.index() as usize {
                 return Err(InvalidTopology::InvalidVpIndices);
-            }
-
-            if vp.mpidr.mt() {
-                smt_enabled = true;
             }
         }
 
         Ok(ProcessorTopology {
             vps,
-            smt_enabled,
+            smt_enabled: self.effective_smt(),
             vps_per_socket: self.vps_per_socket,
             arch: Aarch64Topology {
                 platform: self.arch.platform,
@@ -281,5 +329,213 @@ impl ProcessorTopology<Aarch64Topology> {
     /// Returns the total number of GIC interrupts to configure.
     pub fn gic_nr_irqs(&self) -> u32 {
         self.arch.platform.gic_nr_irqs
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn platform() -> Aarch64PlatformConfig {
+        Aarch64PlatformConfig {
+            gic_distributor_base: 0xffff0000,
+            gic_version: GicVersion::V3 {
+                redistributors_base: 0xefff0000,
+            },
+            gic_msi: GicMsiController::None,
+            pmu_gsiv: None,
+            virt_timer_ppi: 20,
+            gic_nr_irqs: 992,
+        }
+    }
+
+    fn builder() -> TopologyBuilder<Aarch64Topology> {
+        TopologyBuilder::new_aarch64(platform())
+    }
+
+    /// Returns `(mpidr, socket, core, thread)` for each VP.
+    fn describe(topology: &ProcessorTopology<Aarch64Topology>) -> Vec<(u64, u32, u32, u32)> {
+        topology
+            .vps_arch()
+            .map(|vp| {
+                let t = topology.vp_topology(vp.base.vp_index);
+                (vp.mpidr.into(), t.socket, t.core, t.thread)
+            })
+            .collect()
+    }
+
+    /// Strips the RES1 and uniprocessor bits so tests can compare affinities.
+    fn affinity(mpidr: u64) -> u64 {
+        mpidr & (u64::from(MpidrEl1::AFFINITY_MASK) | 1 << 24)
+    }
+
+    /// A socket of one has no sibling to pair with, so SMT is dropped rather
+    /// than claiming a thread of a core that does not exist.
+    #[test]
+    fn single_vp_ignores_smt() {
+        let topology = builder().smt_enabled(true).build(1).unwrap();
+        assert!(!topology.smt_enabled());
+        let mpidr = topology.vp_arch(VpIndex::new(0)).mpidr;
+        assert!(mpidr.u());
+        assert!(!mpidr.mt());
+        assert_eq!(describe(&topology), [(u64::from(mpidr), 0, 0, 0)]);
+    }
+
+    /// Aff0 holds 16 VPs, then rolls into Aff1. A GICv3 targeted SGI cannot
+    /// reach an Aff0 above 15, which is what this boundary exists for.
+    #[test]
+    fn seventeen_vps_roll_into_aff1() {
+        let topology = builder().vps_per_socket(17).build(17).unwrap();
+        let vps = describe(&topology);
+        assert_eq!(affinity(vps[15].0), 0x0f);
+        assert_eq!(affinity(vps[16].0), 0x100);
+        for (i, (mpidr, socket, core, thread)) in vps.into_iter().enumerate() {
+            assert!(MpidrEl1::from(mpidr).aff0() < 16);
+            assert_eq!((socket, core, thread), (0, i as u32, 0));
+        }
+    }
+
+    /// Logical topology follows `vps_per_socket`; MPIDRs keep packing linearly
+    /// and say nothing about sockets.
+    #[test]
+    fn multiple_sockets_without_smt() {
+        let topology = builder().vps_per_socket(4).build(8).unwrap();
+        let vps = describe(&topology);
+        for (i, (mpidr, socket, core, thread)) in vps.iter().copied().enumerate() {
+            assert_eq!(affinity(mpidr), i as u64);
+            assert_eq!((socket, core, thread), (i as u32 / 4, i as u32 % 4, 0));
+        }
+        let vnodes: Vec<_> = topology.vps().map(|vp| vp.vnode).collect();
+        assert_eq!(vnodes, [0, 0, 0, 0, 1, 1, 1, 1]);
+    }
+
+    /// The exact register values a guest sees, RES1 and MT bits included,
+    /// rather than just the affinity fields.
+    #[test]
+    fn mpidr_register_values() {
+        for (vp, expected) in [
+            (0, 0x8000_0000),
+            (1, 0x8000_0001),
+            (15, 0x8000_000f),
+            (16, 0x8000_0100),
+            (17, 0x8000_0101),
+        ] {
+            assert_eq!(
+                u64::from(non_smt_mpidr(vp).with_res1_31(true)),
+                expected,
+                "non-SMT VP {vp}"
+            );
+        }
+
+        for (vp, expected) in [
+            (0, 0x8100_0000),
+            (1, 0x8100_0001),
+            (2, 0x8100_0100),
+            (3, 0x8100_0101),
+        ] {
+            assert_eq!(
+                u64::from(smt_mpidr(vp).with_res1_31(true)),
+                expected,
+                "SMT VP {vp}"
+            );
+        }
+    }
+
+    /// Sockets do not appear in the MPIDR: the core index keeps packing past
+    /// the socket boundary, and only the logical topology splits there.
+    #[test]
+    fn smt_sockets_do_not_change_affinity() {
+        let topology = builder()
+            .vps_per_socket(2)
+            .smt_enabled(true)
+            .build(4)
+            .unwrap();
+        assert!(topology.smt_enabled());
+        assert_eq!(
+            describe(&topology)
+                .into_iter()
+                .map(|(mpidr, socket, core, thread)| (affinity(mpidr), socket, core, thread))
+                .collect::<Vec<_>>(),
+            [
+                (0x0100_0000, 0, 0, 0),
+                (0x0100_0001, 0, 0, 1),
+                (0x0100_0100, 1, 0, 0),
+                (0x0100_0101, 1, 0, 1),
+            ]
+        );
+    }
+
+    /// An odd socket size just leaves the last core with one thread. The MPIDRs
+    /// stay unique, so there is nothing to reject.
+    ///
+    /// MPIDR pairs threads across the whole VM while the logical topology pairs
+    /// them within a socket, so the two disagree once a socket holds an odd
+    /// number of VPs. PPTT is what describes topology, so that is tolerable.
+    #[test]
+    fn odd_socket_size_under_smt() {
+        let topology = builder()
+            .vps_per_socket(3)
+            .smt_enabled(true)
+            .build(3)
+            .unwrap();
+        assert_eq!(
+            describe(&topology)
+                .into_iter()
+                .map(|(_, socket, core, thread)| (socket, core, thread))
+                .collect::<Vec<_>>(),
+            [(0, 0, 0), (0, 0, 1), (0, 1, 0)]
+        );
+    }
+
+    /// OpenHCL passes host MPIDRs through unmodified, including ones this code
+    /// would never generate.
+    #[test]
+    fn caller_supplied_mpidrs_are_preserved() {
+        let mpidrs = [0x81, 0x40, 0x0];
+        let topology = builder()
+            .vps_per_socket(3)
+            .build_with_vp_info(mpidrs.iter().enumerate().map(|(i, &mpidr)| Aarch64VpInfo {
+                base: VpInfo {
+                    vp_index: VpIndex::new(i as u32),
+                    vnode: 0,
+                },
+                mpidr: MpidrEl1::from(mpidr),
+                gicr: None,
+                pmu_gsiv: None,
+            }))
+            .unwrap();
+
+        assert_eq!(
+            topology
+                .vps_arch()
+                .map(|vp| u64::from(vp.mpidr))
+                .collect::<Vec<_>>(),
+            mpidrs
+        );
+        // Topology still comes from the VP index, not from the odd affinities.
+        assert_eq!(
+            describe(&topology)
+                .into_iter()
+                .map(|(_, socket, core, thread)| (socket, core, thread))
+                .collect::<Vec<_>>(),
+            [(0, 0, 0), (0, 1, 0), (0, 2, 0)]
+        );
+    }
+
+    #[test]
+    fn gicv2_vp_limit() {
+        let gicv2 = || {
+            TopologyBuilder::new_aarch64(Aarch64PlatformConfig {
+                gic_version: GicVersion::V2 {
+                    cpu_interface_base: 0xefff0000,
+                },
+                ..platform()
+            })
+        };
+        assert!(gicv2().vps_per_socket(8).build(8).is_ok());
+        assert!(matches!(
+            gicv2().vps_per_socket(9).build(9),
+            Err(InvalidTopology::TooManyCpusForGicV2(9))
+        ));
     }
 }

--- a/vmm_core/virt_kvm/src/arch/aarch64/mod.rs
+++ b/vmm_core/virt_kvm/src/arch/aarch64/mod.rs
@@ -193,6 +193,7 @@ open_enum::open_enum! {
         SYS_SPSR_EL1 = sys_reg64(SystemReg::SPSR_EL1),
         SYS_VBAR_EL1 = sys_reg64(SystemReg::VBAR),
         SYS_ID_AA64PFR0_EL1 = sys_reg64(SystemReg::ID_AA64PFR0_EL1),
+        SYS_MPIDR_EL1 = sys_reg64(SystemReg::MPIDR_EL1),
     }
 }
 
@@ -785,6 +786,19 @@ impl virt::ProtoPartition for KvmProtoPartition<'_> {
         // this matters for the Hyper-V enlightenment fast paths.
         for (vp_idx, _vp_info) in self.config.processor_topology.vps_arch().enumerate() {
             self.vm.add_vp(vp_idx as u32)?;
+        }
+
+        // KVM_ARM_VCPU_INIT resets MPIDR_EL1 to KVM's own vcpu-id mapping, so
+        // this has to run after add_vp, and before the GIC starts resolving
+        // redistributor affinities.
+        for (vp_idx, vp_info) in self.config.processor_topology.vps_arch().enumerate() {
+            self.vm
+                .vp(vp_idx as u32)
+                .set_reg64(KvmRegisterId::SYS_MPIDR_EL1.into(), vp_info.mpidr.into())
+                .map_err(|err| KvmError::SetMpidr {
+                    vp_index: vp_idx as u32,
+                    err,
+                })?;
         }
 
         // Set up the GIC device matching the topology's GIC version.

--- a/vmm_core/virt_kvm/src/lib.rs
+++ b/vmm_core/virt_kvm/src/lib.rs
@@ -75,6 +75,13 @@ pub enum KvmError {
     NoGic,
     #[error("host does not support required cpu capabilities")]
     Capabilities(virt::PartitionCapabilitiesError),
+    #[cfg(guest_arch = "aarch64")]
+    #[error("failed to set MPIDR_EL1 for VP {vp_index}")]
+    SetMpidr {
+        vp_index: u32,
+        #[source]
+        err: kvm::Error,
+    },
     #[cfg(guest_arch = "x86_64")]
     #[error("nested virtualization was requested but the host does not support it")]
     NestedVirtUnsupported,

--- a/vmm_core/virt_mshv/src/aarch64/mod.rs
+++ b/vmm_core/virt_mshv/src/aarch64/mod.rs
@@ -387,8 +387,8 @@ impl virt::BindProcessor for MshvProcessorBinder {
             self.vcpufd.as_ref().unwrap()
         };
 
-        // The hypervisor assigns its own MPIDR otherwise, which would not match
-        // the identity firmware advertises for this VP.
+        // Set the MPIDR for this VP; otherwise, the hypervisor assigns a value
+        // that would not match the identity firmware advertises.
         vcpufd
             .set_hvdef_regs(&[HvRegisterAssoc::from((
                 HvArm64RegisterName::MpidrEl1,

--- a/vmm_core/virt_mshv/src/aarch64/mod.rs
+++ b/vmm_core/virt_mshv/src/aarch64/mod.rs
@@ -387,6 +387,15 @@ impl virt::BindProcessor for MshvProcessorBinder {
             self.vcpufd.as_ref().unwrap()
         };
 
+        // The hypervisor assigns its own MPIDR otherwise, which would not match
+        // the identity firmware advertises for this VP.
+        vcpufd
+            .set_hvdef_regs(&[HvRegisterAssoc::from((
+                HvArm64RegisterName::MpidrEl1,
+                u64::from(inner.vp_info.mpidr),
+            ))])
+            .map_err(ErrorInner::Register)?;
+
         // Set the GIC redistributor base for this VP (GICv3 only).
         if let Some(gicr) = inner.vp_info.gicr {
             vcpufd

--- a/vmm_tests/vmm_tests/tests/tests/aarch64_exclusive.rs
+++ b/vmm_tests/vmm_tests/tests/tests/aarch64_exclusive.rs
@@ -8,11 +8,13 @@ use pal_async::DefaultDriver;
 use pal_async::timer::PolledTimer;
 use petri::PetriVmBuilder;
 use petri::PetriVmmBackend;
+use petri::ProcessorTopology;
 use petri::openvmm::OpenVmmPetriBackend;
 use petri::pipette::cmd;
 use std::time::Duration;
 use vfio_assigned_device_resources::BarAddressConfig;
 use vm_resource::IntoResource;
+use vmm_test_macros::openvmm_test;
 use vmm_test_macros::vmm_test;
 use vmm_test_macros::vmm_test_with;
 
@@ -843,4 +845,231 @@ async fn assigned_device_smmu_accel_fault_aarch64_tcg(
          fault did not reach the guest Event queue. SMMU lines:\n{}",
         smmu_lines.join("\n")
     )
+}
+
+/// Boot past the 16-VP `Aff0` boundary and verify the MPIDRs the guest sees.
+///
+/// This is the case the whole non-SMT encoding exists for. GICv3 can only
+/// target 16 `Aff0` values within one affinity group without Range Selector
+/// support, so `Aff0` rolls into `Aff1` every 16 VPs, which is also what KVM's
+/// `reset_mpidr()` does. Firmware and the hypervisor have to agree on every
+/// VP's identity: if they diverge above VP 15, PSCI `CPU_ON` cannot resolve
+/// the MPIDRs the MADT advertises and those CPUs never come online.
+///
+/// 17 VPs is the smallest count that crosses the boundary. SMT cannot reach it
+/// at all — under the SMT encoding `Aff0` is only ever 0 or 1 — so this needs
+/// to be a separate non-SMT configuration from [`smt_topology_aarch64_tcg`].
+///
+/// The `_aarch64_tcg` name suffix opts this test into the QEMU incubator pass.
+#[openvmm_test(linux_direct_aarch64)]
+async fn mpidr_affinity_rollover_aarch64_tcg(
+    config: PetriVmBuilder<OpenVmmPetriBackend>,
+) -> anyhow::Result<()> {
+    const VP_COUNT: u32 = 17;
+
+    let (vm, agent) = config
+        .with_processor_topology(ProcessorTopology {
+            vp_count: VP_COUNT,
+            enable_smt: Some(false),
+            vps_per_socket: Some(VP_COUNT),
+            ..Default::default()
+        })
+        // KVM/aarch64 has no synic, so VMBus cannot come up and pipette has to
+        // reach the guest over virtio-vsock, which needs a PCIe root.
+        .with_no_hv()
+        .modify_backend(|b| b.with_pcie_root_topology(1, 1, 3))
+        .run()
+        .await?;
+
+    let sh = agent.unix_shell();
+
+    // VP 16 is the one that only comes online if the MADT and KVM agree on its
+    // MPIDR, so this assertion is the point of the test.
+    let online = sh.read_file("/sys/devices/system/cpu/online").await?;
+    assert_eq!(
+        online.trim(),
+        format!("0-{}", VP_COUNT - 1),
+        "not every VP came online; VP 16 dropping out means firmware and KVM \
+         disagree about its MPIDR"
+    );
+
+    // Linux logs each secondary's MPIDR as it boots. Non-SMT packs 16 VPs per
+    // affinity group, so VP 15 is the last of group 0 and VP 16 opens group 1.
+    let dmesg = cmd!(sh, "dmesg").read().await?;
+    let booted: Vec<u64> = dmesg
+        .lines()
+        .filter(|l| l.contains("Booted secondary processor"))
+        .filter_map(|l| {
+            let token = l.split_whitespace().find(|t| t.starts_with("0x"))?;
+            u64::from_str_radix(token.trim_start_matches("0x"), 16).ok()
+        })
+        .collect();
+    let expected: Vec<u64> = (1..VP_COUNT as u64)
+        .map(|vp| (vp % 16) | ((vp / 16) << 8))
+        .collect();
+    assert_eq!(
+        booted,
+        expected,
+        "unexpected secondary MPIDRs; guest logged:\n{}",
+        dmesg
+            .lines()
+            .filter(|l| l.contains("Booted secondary processor"))
+            .collect::<Vec<_>>()
+            .join("\n")
+    );
+
+    // Without SMT every VP is its own core, so PPTT must describe one socket
+    // holding VP_COUNT distinct cores.
+    //
+    // These ids are opaque: Linux returns the PPTT node's offset within the
+    // table unless the node sets ACPI_PROCESSOR_ID_VALID, which OpenVMM's
+    // socket nodes do not. Only their grouping is meaningful.
+    let mut sockets = std::collections::BTreeSet::new();
+    let mut cores = std::collections::BTreeSet::new();
+    for cpu in 0..VP_COUNT {
+        let base = format!("/sys/devices/system/cpu/cpu{cpu}/topology");
+        sockets.insert(
+            sh.read_file(format!("{base}/physical_package_id"))
+                .await?
+                .trim()
+                .to_string(),
+        );
+        cores.insert(
+            sh.read_file(format!("{base}/core_id"))
+                .await?
+                .trim()
+                .to_string(),
+        );
+    }
+    assert_eq!(
+        sockets.len(),
+        1,
+        "expected a single socket, got {sockets:?}"
+    );
+    assert_eq!(
+        cores.len(),
+        VP_COUNT as usize,
+        "expected {VP_COUNT} distinct cores, got {}",
+        cores.len()
+    );
+
+    agent.power_off().await?;
+    vm.wait_for_clean_teardown().await?;
+    Ok(())
+}
+
+/// Boot an SMT guest and verify the MPIDRs and CPU topology the guest observes.
+///
+/// This covers the whole MPIDR chain end to end. Under SMT the generated MPIDRs
+/// use `Aff0` as a thread id and `Aff1` as a core id, which deliberately
+/// diverges from KVM's default vcpu-id mapping: VP 2 is `0x100` here but `0x2`
+/// after `KVM_ARM_VCPU_INIT`. So if OpenVMM stopped programming `MPIDR_EL1`
+/// into KVM, PSCI `CPU_ON` could not resolve the MPIDRs firmware advertises in
+/// the MADT and the secondary CPUs would never come online. Four VPs is the
+/// smallest count that distinguishes the two mappings.
+///
+/// The topology assertions cover the PPTT builder. MPIDR is an identity rather
+/// than a topology description, so socket/core/thread have to come from the
+/// configured topology instead of the affinity fields.
+///
+/// The `_aarch64_tcg` name suffix opts this test into the QEMU incubator pass.
+#[openvmm_test(linux_direct_aarch64)]
+async fn smt_topology_aarch64_tcg(
+    config: PetriVmBuilder<OpenVmmPetriBackend>,
+) -> anyhow::Result<()> {
+    const VP_COUNT: u32 = 4;
+
+    let (vm, agent) = config
+        .with_processor_topology(ProcessorTopology {
+            vp_count: VP_COUNT,
+            enable_smt: Some(true),
+            vps_per_socket: Some(VP_COUNT),
+            ..Default::default()
+        })
+        // KVM/aarch64 has no synic, so VMBus cannot come up and pipette has to
+        // reach the guest over virtio-vsock, which needs a PCIe root.
+        .with_no_hv()
+        .modify_backend(|b| b.with_pcie_root_topology(1, 1, 3))
+        .run()
+        .await?;
+
+    let sh = agent.unix_shell();
+
+    // Every VP must come online. This is the assertion that fails if the
+    // firmware-visible MPIDRs and KVM's runtime MPIDRs disagree.
+    let online = sh.read_file("/sys/devices/system/cpu/online").await?;
+    assert_eq!(
+        online.trim(),
+        format!("0-{}", VP_COUNT - 1),
+        "not every VP came online"
+    );
+
+    // Linux logs each secondary's MPIDR as it boots, which is the guest's own
+    // view of the register rather than anything OpenVMM reports about itself.
+    // Expected values for 4 VPs, one socket, two-way SMT:
+    //   VP 0 -> Aff1=0 Aff0=0 (boot CPU, not logged here)
+    //   VP 1 -> Aff1=0 Aff0=1 = 0x001
+    //   VP 2 -> Aff1=1 Aff0=0 = 0x100
+    //   VP 3 -> Aff1=1 Aff0=1 = 0x101
+    let dmesg = cmd!(sh, "dmesg").read().await?;
+    let booted: Vec<u64> = dmesg
+        .lines()
+        .filter(|l| l.contains("Booted secondary processor"))
+        .filter_map(|l| {
+            let token = l.split_whitespace().find(|t| t.starts_with("0x"))?;
+            u64::from_str_radix(token.trim_start_matches("0x"), 16).ok()
+        })
+        .collect();
+    assert_eq!(
+        booted,
+        vec![0x001, 0x100, 0x101],
+        "unexpected secondary MPIDRs; guest logged:\n{}",
+        dmesg
+            .lines()
+            .filter(|l| l.contains("Booted secondary processor"))
+            .collect::<Vec<_>>()
+            .join("\n")
+    );
+
+    // Two-way SMT over four VPs is two cores of two threads, all in one socket.
+    //
+    // The socket and core ids are opaque PPTT node offsets, so compare them
+    // against each other rather than against expected values.
+    let mut sockets = std::collections::BTreeSet::new();
+    let mut cores = Vec::new();
+    for cpu in 0..VP_COUNT {
+        let base = format!("/sys/devices/system/cpu/cpu{cpu}/topology");
+        sockets.insert(
+            sh.read_file(format!("{base}/physical_package_id"))
+                .await?
+                .trim()
+                .to_string(),
+        );
+        cores.push(
+            sh.read_file(format!("{base}/core_id"))
+                .await?
+                .trim()
+                .to_string(),
+        );
+
+        let siblings = sh.read_file(format!("{base}/thread_siblings_list")).await?;
+        let expected = if cpu < 2 { "0-1" } else { "2-3" };
+        assert_eq!(
+            siblings.trim(),
+            expected,
+            "cpu{cpu} reported unexpected thread siblings"
+        );
+    }
+    assert_eq!(
+        sockets.len(),
+        1,
+        "expected a single socket, got {sockets:?}"
+    );
+    assert_eq!(cores[0], cores[1], "cpu0 and cpu1 should share a core");
+    assert_eq!(cores[2], cores[3], "cpu2 and cpu3 should share a core");
+    assert_ne!(cores[0], cores[2], "cpu0 and cpu2 should be distinct cores");
+
+    agent.power_off().await?;
+    vm.wait_for_clean_teardown().await?;
+    Ok(())
 }

--- a/vmm_tests/vmm_tests/tests/tests/aarch64_exclusive.rs
+++ b/vmm_tests/vmm_tests/tests/tests/aarch64_exclusive.rs
@@ -883,8 +883,7 @@ async fn mpidr_affinity_rollover_aarch64_tcg(
 
     let sh = agent.unix_shell();
 
-    // VP 16 is the one that only comes online if the MADT and KVM agree on its
-    // MPIDR, so this assertion is the point of the test.
+    // VP 16 only comes online if the MADT and KVM agree on its MPIDR.
     let online = sh.read_file("/sys/devices/system/cpu/online").await?;
     assert_eq!(
         online.trim(),

--- a/vmm_tests/vmm_tests/tests/tests/aarch64_exclusive.rs
+++ b/vmm_tests/vmm_tests/tests/tests/aarch64_exclusive.rs
@@ -861,6 +861,7 @@ async fn assigned_device_smmu_accel_fault_aarch64_tcg(
 /// to be a separate non-SMT configuration from [`smt_topology_aarch64_tcg`].
 ///
 /// The `_aarch64_tcg` name suffix opts this test into the QEMU incubator pass.
+/// TODO: enable this for non-TCG passes (WHP, MSHV) as well, once this is convenient.
 #[openvmm_test(linux_direct_aarch64)]
 async fn mpidr_affinity_rollover_aarch64_tcg(
     config: PetriVmBuilder<OpenVmmPetriBackend>,


### PR DESCRIPTION
Fix how MPIDR gets computed for aarch64 VMs. Update virt_kvm and virt_mshv to set MPIDR, rather than relying on whatever the hypervisors set it to automatically. Update --smt=force to work for aarch64 VMs. Enable vNUMA automatic assignment for aarch64 VMs.