### PR TITLE
loader: keep the page table region off a large page boundary (#4388)

### DIFF
--- a/vm/loader/src/paravisor.rs
+++ b/vm/loader/src/paravisor.rs
@@ -79,6 +79,14 @@ pub const HCL_SECURE_VTL: Vtl = Vtl::Vtl2;
 /// Size of the persisted region (2MB).
 const PERSISTED_REGION_SIZE: u64 = 2 * 1024 * 1024;
 
+fn avoid_page_table_large_page_boundary(offset: u64, large_page_size: u64) -> u64 {
+    if offset.is_multiple_of(large_page_size) {
+        offset + HV_PAGE_SIZE
+    } else {
+        offset
+    }
+}
+
 #[derive(Debug, Error)]
 pub enum Error {
     #[error("memory is unaligned: {0}")]
@@ -408,6 +416,10 @@ where
         &[],
     )?;
     offset += heap_size;
+
+    // Some loaders only fix up identity map entries that overlap the relocation
+    // region, so keep the page table region in the same large page as it.
+    offset = avoid_page_table_large_page_boundary(offset, X64_LARGE_PAGE_SIZE);
 
     // The end of memory used by the loader, excluding pagetables.
     let end_of_underhill_mem = offset;
@@ -1155,6 +1167,10 @@ where
     )?;
     next_addr += heap_size;
 
+    // Some loaders only fix up identity map entries that overlap the relocation
+    // region, so keep the page table region in the same large page as it.
+    next_addr = avoid_page_table_large_page_boundary(next_addr, u64::from(Arm64PageSize::Large));
+
     // The end of memory used by the loader, excluding pagetables.
     let end_of_underhill_mem = next_addr;
 
@@ -1471,4 +1487,26 @@ where
     importer.set_imported_regions_config_page(imported_region_base);
 
     Ok(())
+}
+
+#[cfg(test)]
+mod page_table_layout_tests {
+    use super::*;
+
+    #[test]
+    fn page_table_region_avoids_large_page_boundary() {
+        for large_page_size in [X64_LARGE_PAGE_SIZE, u64::from(Arm64PageSize::Large)] {
+            assert_eq!(
+                avoid_page_table_large_page_boundary(large_page_size, large_page_size),
+                large_page_size + HV_PAGE_SIZE
+            );
+            assert_eq!(
+                avoid_page_table_large_page_boundary(
+                    large_page_size - HV_PAGE_SIZE,
+                    large_page_size
+                ),
+                large_page_size - HV_PAGE_SIZE
+            );
+        }
+    }
 }


### PR DESCRIPTION
Cherry pick of PR #4388. The file-end conflict was resolved by omitting unrelated product-policy tests that are not present on 1.8; the boundary helper and its regression test are unchanged.