### PR TITLE
TPM: Move backend feature declaration to alongside crypto

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5727,6 +5727,8 @@ version = "0.1.0"
 dependencies = [
  "crypto",
  "embed-resource",
+ "ms-tcg-tpm-sys",
+ "ms-tpm-20-ref",
  "openvmm_entry",
  "openvmm_hypervisors",
  "openvmm_resources",
@@ -5969,6 +5971,8 @@ name = "openvmm_hcl"
 version = "0.0.0"
 dependencies = [
  "crypto",
+ "ms-tcg-tpm-sys",
+ "ms-tpm-20-ref",
  "openssl_crypto_only",
  "openvmm_hcl_resources",
  "tracing",

--- a/openhcl/openvmm_hcl/Cargo.toml
+++ b/openhcl/openvmm_hcl/Cargo.toml
@@ -14,7 +14,11 @@ product_policy = ["underhill_entry/product_policy"]
 
 # see the `underhill_entry` crate for more info on these features
 gdb = ["underhill_entry/gdb", "openvmm_hcl_resources/debug_worker"]
-tpm = ["openvmm_hcl_resources/tpm"]
+tpm = [
+	"openvmm_hcl_resources/tpm",
+	"dep:ms-tpm-20-ref",
+	"dep:ms-tcg-tpm-sys",
+]
 mem-profile-tracing = ["underhill_entry/mem-profile-tracing"]
 
 # Enable mimalloc secure mode.
@@ -41,8 +45,24 @@ crypto = { workspace = true, features = ["openssl"] }
 # OpenVMM-HCL only needs libcrypto from openssl
 openssl_crypto_only.workspace = true
 
+[target.'cfg(all(target_os = "linux", target_env = "musl"))'.dependencies]
+# TODO: Change this to symcrypt if the OSS TPM 1.38 can be made to work with it.
+ms-tpm-20-ref = { optional = true, workspace = true, features = ["openssl"] }
+# TODO: Change this to symcrypt once it's ready.
+ms-tcg-tpm-sys = { optional = true, workspace = true, features = ["openssl"] }
+
+[target.'cfg(all(target_os = "linux", not(target_env = "musl")))'.dependencies]
+ms-tpm-20-ref = { optional = true, workspace = true, features = ["openssl", "vendored"] }
+ms-tcg-tpm-sys = { optional = true, workspace = true, features = ["openssl", "vendored"] }
+
 [package.metadata.xtask.unused-deps]
-ignored = ["tracing"] # Present to specify features from flowey
+ignored = [
+    # Present to specify TPM backend features
+	"ms-tcg-tpm-sys",
+	"ms-tpm-20-ref",
+    # Present to specify features from flowey
+	"tracing",
+]
 
 [lints]
 workspace = true

--- a/openvmm/openvmm/Cargo.toml
+++ b/openvmm/openvmm/Cargo.toml
@@ -24,7 +24,11 @@ default = [
 # see the `openvmm_entry` crate for more info on these features
 gdb = ["openvmm_resources/gdb"]
 vendored_crypto = ["crypto/vendored"]
-tpm = ["openvmm_resources/tpm"]
+tpm = [
+  "openvmm_resources/tpm",
+  "dep:ms-tpm-20-ref",
+  "dep:ms-tcg-tpm-sys",
+]
 virt_hvf = ["openvmm_resources/virt_hvf", "openvmm_hypervisors/virt_hvf"]
 virt_kvm = ["openvmm_resources/virt_kvm", "openvmm_hypervisors/virt_kvm"]
 virt_mshv = ["openvmm_resources/virt_mshv", "openvmm_hypervisors/virt_mshv"]
@@ -42,9 +46,14 @@ openvmm_entry.workspace = true
 openvmm_hypervisors.workspace = true
 openvmm_resources.workspace = true
 crypto = { workspace = true, features = ["native"] }
+ms-tpm-20-ref = { optional = true, workspace = true, features = ["openssl", "vendored"] }
+ms-tcg-tpm-sys = { optional = true, workspace = true, features = ["openssl", "vendored"] }
 
 [build-dependencies]
 embed-resource.workspace = true
+
+[package.metadata.xtask.unused-deps]
+ignored = ["ms-tcg-tpm-sys", "ms-tpm-20-ref"] # Present to specify TPM features.
 
 [lints]
 workspace = true

--- a/vm/devices/tpm/tpm_device/Cargo.toml
+++ b/vm/devices/tpm/tpm_device/Cargo.toml
@@ -8,13 +8,15 @@ rust-version.workspace = true
 
 [features]
 # Without this feature, the crate is a no-op. Disable it by default
-# to avoid requiring openssl on Windows.
+# to avoid requiring a TPM crypto backend on Windows.
 tpm = ["dep:ms-tpm-20-ref", "dep:ms-tcg-tpm-sys"]
 
 [dependencies]
 tpm_lib.workspace = true
 tpm_protocol.workspace = true
 tpm_resources.workspace = true
+ms-tpm-20-ref = { optional = true, workspace = true }
+ms-tcg-tpm-sys = { optional = true, workspace = true }
 
 chipset_device.workspace = true
 chipset_device_resources.workspace = true
@@ -39,16 +41,6 @@ tracelimit.workspace = true
 tracing.workspace = true
 zerocopy.workspace = true
 base64.workspace = true
-
-[target.'cfg(target_env = "musl")'.dependencies]
-# TODO: Change this to symcrypt if the OSS TPM 1.38 can be made to work with it
-ms-tpm-20-ref = { optional = true, workspace = true, features = ["openssl"] }
-# TODO: Change this to symcrypt once it's ready
-ms-tcg-tpm-sys = { optional = true, workspace = true, features = ["openssl"] }
-
-[target.'cfg(not(target_env = "musl"))'.dependencies]
-ms-tpm-20-ref = { optional = true, workspace = true, features = ["openssl", "vendored"] }
-ms-tcg-tpm-sys = { optional = true, workspace = true, features = ["openssl", "vendored"] }
 
 [lints]
 workspace = true

--- a/vm/devices/tpm/tpm_lib/Cargo.toml
+++ b/vm/devices/tpm/tpm_lib/Cargo.toml
@@ -12,6 +12,8 @@ test_tpm = ["dep:ms-tpm-20-ref", "dep:ms-tcg-tpm-sys"]
 
 [dependencies]
 tpm_protocol.workspace = true
+ms-tpm-20-ref = { optional = true, workspace = true }
+ms-tcg-tpm-sys = { optional = true, workspace = true }
 cvm_tracing.workspace = true
 inspect.workspace = true
 
@@ -19,16 +21,6 @@ thiserror.workspace = true
 tracelimit.workspace = true
 tracing.workspace = true
 zerocopy.workspace = true
-
-[target.'cfg(target_env = "musl")'.dependencies]
-# TODO: Change this to symcrypt if the OSS TPM 1.38 can be made to work with it
-ms-tpm-20-ref = { optional = true, workspace = true, features = ["openssl"] }
-# TODO: Change this to symcrypt once it's ready
-ms-tcg-tpm-sys = { optional = true, workspace = true, features = ["openssl"] }
-
-[target.'cfg(not(target_env = "musl"))'.dependencies]
-ms-tpm-20-ref = { optional = true, workspace = true, features = ["openssl", "vendored"] }
-ms-tcg-tpm-sys = { optional = true, workspace = true, features = ["openssl", "vendored"] }
 
 [dev-dependencies]
 getrandom.workspace = true


### PR DESCRIPTION
This not only makes all of our cryptographic backend declarations live in one place, but also enables the internal repo to change the TPM backends, just like it does with crypto today.