### PR TITLE
tpm_lib: bound preserved AK cert by the re-created NV index size

### DIFF
--- a/vm/devices/tpm/tpm_lib/src/lib.rs
+++ b/vm/devices/tpm/tpm_lib/src/lib.rs
@@ -873,7 +873,17 @@ impl<E: TpmEngine> TpmEngineHelper<E> {
                     Ok(_) => {
                         tracing::info!("Successfully allocated AK cert nv index");
 
-                        if params.preserve_ak_cert {
+                        // `take_existing_ak_cert` sizes `cert` from the previous
+                        // index, which can be larger than the index re-created
+                        // above (up to 16k on TPM v1.85 vs `TPM_DEFAULT_AKCERT_SIZE`).
+                        if params.preserve_ak_cert && cert.len() > size as usize {
+                            tracing::error!(
+                                CVM_ALLOWED,
+                                cert_size = cert.len(),
+                                nv_index_size = size,
+                                "previous AK cert does not fit in the new nv index; not preserving it"
+                            );
+                        } else if params.preserve_ak_cert {
                             // For resiliency, write the previous AK cert to the
                             // newly created nv index in case the following
                             // boot-time AK cert request fails.

--- a/vm/devices/tpm/tpm_lib/tests/common/mod.rs
+++ b/vm/devices/tpm/tpm_lib/tests/common/mod.rs
@@ -1882,3 +1882,64 @@ fn test_restore_owner_defined() {
     let nv_bits = TpmaNvBits::from(result.nv_public.nv_public.attributes.0.get());
     assert!(!nv_bits.nv_platformcreate());
 }
+
+#[test]
+fn test_oversized_platform_ak_cert_index() {
+    // The index is re-created at `TPM_DEFAULT_AKCERT_SIZE`, so an existing
+    // larger index is only reachable on backends whose maximum exceeds it.
+    if (test_tpm::MAX_NV_INDEX_SIZE as usize) <= TPM_DEFAULT_AKCERT_SIZE {
+        return;
+    }
+
+    let oversized_size = test_tpm::MAX_NV_INDEX_SIZE;
+
+    let mut tpm_engine_helper = create_tpm_engine_helper();
+    restart_tpm_engine(&mut tpm_engine_helper, false, true);
+
+    let result = tpm_engine_helper.nv_define_space(
+        TPM20_RH_PLATFORM,
+        AUTH_VALUE,
+        TPM_NV_INDEX_AIK_CERT,
+        oversized_size,
+    );
+    assert!(result.is_ok(), "{result:?}");
+
+    let ak_cert_input = vec![7u8; oversized_size as usize];
+    let result =
+        tpm_engine_helper.write_to_nv_index(AUTH_VALUE, TPM_NV_INDEX_AIK_CERT, &ak_cert_input);
+    assert!(result.is_ok(), "{result:?}");
+
+    let result = tpm_engine_helper.allocate_guest_attestation_nv_indices(
+        AUTH_VALUE,
+        AllocateNvIndicesParams {
+            preserve_ak_cert: true,
+            support_attestation_report: true,
+            mitigate_legacy_akcert: false,
+            create_if_missing: true,
+        },
+    );
+    assert!(result.is_ok(), "{result:?}");
+
+    // The AK cert index is re-created at the default size and the previous cert
+    // is dropped because it no longer fits.
+    let result = tpm_engine_helper
+        .find_nv_index(TPM_NV_INDEX_AIK_CERT)
+        .expect("find_nv_index should succeed")
+        .expect("AKCert NV index present");
+    assert_eq!(
+        result.nv_public.nv_public.data_size.get() as usize,
+        TPM_DEFAULT_AKCERT_SIZE
+    );
+
+    let mut ak_cert_output = [0u8; TPM_DEFAULT_AKCERT_SIZE];
+    let result = tpm_engine_helper.read_from_nv_index(TPM_NV_INDEX_AIK_CERT, &mut ak_cert_output);
+    assert!(matches!(result.unwrap(), NvIndexState::Uninitialized));
+
+    // The attestation report index is still allocated.
+    let mut attestation_report_output = [0u8; MAX_ATTESTATION_INDEX_SIZE as usize];
+    let result = tpm_engine_helper.read_from_nv_index(
+        TPM_NV_INDEX_ATTESTATION_REPORT,
+        &mut attestation_report_output,
+    );
+    assert!(matches!(result.unwrap(), NvIndexState::Uninitialized));
+}


### PR DESCRIPTION
take_existing_ak_cert now sizes its output buffer from the TPM's maximum NV index size (16k on v1.85) instead of a fixed 4k, so the returned platform-owned cert is no longer statically bounded by TPM_DEFAULT_AKCERT_SIZE. The preserve path in
allocate_guest_attestation_nv_indices re-defines the index at TPM_DEFAULT_AKCERT_SIZE and then writes the cert with a raw nv_write, which has no size validation (unlike write_to_nv_index). Skip the preserve write when the cert does not fit rather than failing the whole allocation, which would also skip the attestation report index.

Add a regression test that defines an oversized platform-created AKCert index; it self-skips on backends whose max NV index size does not exceed TPM_DEFAULT_AKCERT_SIZE, so it only runs against v1.85.