### PR TITLE
snp: support SNP host data and guest requests

### DIFF
--- a/openvmm/openvmm_core/src/worker/dispatch.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch.rs
@@ -1276,9 +1276,6 @@ impl InitializedVm {
                     "KVM SNP guest_memfd currently only supports direct Linux or IGVM load mode"
                 );
             }
-            if cfg.hypervisor.with_hv {
-                anyhow::bail!("KVM SNP guest_memfd does not support Hyper-V enlightenments");
-            }
             if cfg.hypervisor.with_vtl2.is_some() {
                 anyhow::bail!("KVM SNP guest_memfd does not support VTL2");
             }

--- a/openvmm/openvmm_core/src/worker/dispatch.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch.rs
@@ -1058,7 +1058,12 @@ impl InitializedVm {
             virt::IsolationType::Snp => virt::ProtoPartitionIsolation::Snp(
                 igvm_file
                     .as_ref()
-                    .map(super::vm_loaders::igvm::snp_isolation_config)
+                    .map(|file| {
+                        super::vm_loaders::igvm::snp_isolation_config(
+                            file,
+                            cfg.hypervisor.snp_host_data,
+                        )
+                    })
                     .transpose()
                     .context("reading IGVM SNP configuration failed")?
                     .map(Box::new),

--- a/openvmm/openvmm_core/src/worker/vm_loaders/igvm.rs
+++ b/openvmm/openvmm_core/src/worker/vm_loaders/igvm.rs
@@ -195,8 +195,11 @@ fn selected_platform_header(
     }
 }
 
-/// Extract backend-owned SNP configuration from an IGVM file.
-pub fn snp_isolation_config(igvm_file: &IgvmFile) -> Result<virt::SnpConfig, Error> {
+/// Build effective SNP configuration from an IGVM file and host launch parameters.
+pub fn snp_isolation_config(
+    igvm_file: &IgvmFile,
+    host_data: Option<[u8; 32]>,
+) -> Result<virt::SnpConfig, Error> {
     let IgvmPlatformHeader::SupportedPlatform(platform) = snp_platform_header(igvm_file)?;
     let policy = igvm_file
         .initializations()
@@ -282,6 +285,7 @@ pub fn snp_isolation_config(igvm_file: &IgvmFile) -> Result<virt::SnpConfig, Err
     }
 
     Ok(virt::SnpConfig {
+        host_data,
         policy,
         highest_vtl: platform.highest_vtl,
         shared_gpa_boundary: platform.shared_gpa_boundary,

--- a/openvmm/openvmm_defs/src/config.rs
+++ b/openvmm/openvmm_defs/src/config.rs
@@ -538,6 +538,8 @@ pub struct HypervisorConfig {
     pub with_hv: bool,
     pub with_vtl2: Option<Vtl2Config>,
     pub with_isolation: Option<IsolationType>,
+    /// Optional host-provided data included in SNP launch finish.
+    pub snp_host_data: Option<[u8; 32]>,
     /// Expose hardware virtualization (VMX/SVM) to the guest so that it can run
     /// its own hypervisor. A backend that does not recognize this request
     /// rejects it rather than silently ignoring it (see

--- a/openvmm/openvmm_entry/src/lib.rs
+++ b/openvmm/openvmm_entry/src/lib.rs
@@ -2116,6 +2116,7 @@ async fn vm_config_from_command_line(
             arch: Some(topology_arch),
         },
         hypervisor: HypervisorConfig {
+            snp_host_data: None,
             with_hv,
             with_vtl2: opt.vtl2.then_some(Vtl2Config {
                 vtl0_alias_map: !opt.no_alias_map,

--- a/openvmm/openvmm_entry/src/ttrpc/mod.rs
+++ b/openvmm/openvmm_entry/src/ttrpc/mod.rs
@@ -781,14 +781,24 @@ impl VmService {
         // move it into whichever LoadMode is selected below.
         let smbios = Box::new(smbios_config_from_proto(req_config.smbios_config.take())?);
 
-        let isolation = match req_config
-            .isolation_config
-            .take()
-            .unwrap_or_default()
-            .isolation_type()
-        {
+        let isolation_config = req_config.isolation_config.take().unwrap_or_default();
+        let isolation = match isolation_config.isolation_type() {
             vmservice::isolation_config::Type::None => None,
             vmservice::isolation_config::Type::Snp => Some(IsolationType::Snp),
+        };
+        let snp_host_data = if isolation_config.host_data.is_empty() {
+            None
+        } else {
+            if isolation != Some(IsolationType::Snp) {
+                bail!("VM-service host data supports only SNP isolation");
+            }
+            Some(
+                isolation_config
+                    .host_data
+                    .as_slice()
+                    .try_into()
+                    .context("SNP host data must be exactly 32 bytes")?,
+            )
         };
 
         // The boot configuration also determines the base chipset, since the
@@ -1014,6 +1024,7 @@ impl VmService {
             hypervisor: HypervisorConfig {
                 with_hv: true,
                 with_isolation: isolation,
+                snp_host_data,
                 ..Default::default()
             },
             #[cfg(windows)]

--- a/openvmm/openvmm_entry/src/ttrpc/mod.rs
+++ b/openvmm/openvmm_entry/src/ttrpc/mod.rs
@@ -58,6 +58,7 @@ use openvmm_defs::config::ArchTopologyConfig;
 use openvmm_defs::config::Config;
 use openvmm_defs::config::DeviceVtl;
 use openvmm_defs::config::HypervisorConfig;
+use openvmm_defs::config::IsolationType;
 use openvmm_defs::config::LoadMode;
 use openvmm_defs::config::MemoryConfig;
 use openvmm_defs::config::NumaDistance;
@@ -75,6 +76,7 @@ use openvmm_defs::config::VirtioBus;
 use openvmm_defs::config::VmbusConfig;
 use openvmm_defs::config::VpAssignment;
 use openvmm_defs::config::VpciDeviceConfig;
+use openvmm_defs::config::Vtl2BaseAddressType;
 use openvmm_defs::rpc::VmRpc;
 use openvmm_defs::worker::VM_WORKER;
 use openvmm_defs::worker::VmWorkerParameters;
@@ -88,6 +90,7 @@ use pal_async::task::Task;
 use scsidisk_resources::SimpleScsiDiskHandle;
 use std::fs::File;
 use std::future::Future;
+use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 use storvsp_resources::ScsiControllerHandle;
@@ -778,14 +781,27 @@ impl VmService {
         // move it into whichever LoadMode is selected below.
         let smbios = Box::new(smbios_config_from_proto(req_config.smbios_config.take())?);
 
+        let isolation = match req_config
+            .isolation_config
+            .take()
+            .unwrap_or_default()
+            .isolation_type()
+        {
+            vmservice::isolation_config::Type::None => None,
+            vmservice::isolation_config::Type::Snp => Some(IsolationType::Snp),
+        };
+
         // The boot configuration also determines the base chipset, since the
         // firmware and the device model have to agree on the platform.
-        let (load_mode, base_chipset_type, uefi_config) = match req_config
+        let (load_mode, base_chipset_type, uefi_config, igvm_path, vmbus) = match req_config
             .boot_config
             .take()
             .context("missing boot configuration")?
         {
             vmservice::vm_config::BootConfig::DirectBoot(boot) => {
+                if isolation.is_some() {
+                    bail!("VM-service SNP isolation currently supports only IGVM boot");
+                }
                 let kernel = File::open(boot.kernel_path).context("failed to open kernel")?;
                 let initrd = if boot.initrd_path.is_empty() {
                     None
@@ -804,9 +820,34 @@ impl VmService {
                     },
                     vm_manifest_builder::BaseChipsetType::HyperVGen2LinuxDirect,
                     None,
+                    None,
+                    Some(VmbusConfig::default()),
+                )
+            }
+            vmservice::vm_config::BootConfig::Igvm(boot) => {
+                if isolation != Some(IsolationType::Snp) {
+                    bail!("VM-service IGVM boot currently supports only SNP isolation");
+                }
+                let igvm_path = PathBuf::from(&boot.igvm_path);
+                let file = File::open(&igvm_path)
+                    .with_context(|| format!("failed to open IGVM {}", igvm_path.display()))?;
+                (
+                    LoadMode::Igvm {
+                        file: file.into(),
+                        cmdline: String::new(),
+                        vtl2_base_address: Vtl2BaseAddressType::File,
+                        com_serial: None,
+                    },
+                    vm_manifest_builder::BaseChipsetType::EnlightenedLinuxDirect,
+                    None,
+                    Some(igvm_path),
+                    None,
                 )
             }
             vmservice::vm_config::BootConfig::Uefi(uefi) => {
+                if isolation.is_some() {
+                    bail!("VM-service SNP isolation currently supports only IGVM boot");
+                }
                 let firmware = File::open(&uefi.firmware_path).with_context(|| {
                     format!("failed to open uefi firmware {}", uefi.firmware_path)
                 })?;
@@ -872,6 +913,8 @@ impl VmService {
                     },
                     vm_manifest_builder::BaseChipsetType::HypervGen2Uefi,
                     Some((base_template, uefi.secure_boot_enabled)),
+                    None,
+                    Some(VmbusConfig::default()),
                 )
             }
         };
@@ -970,6 +1013,7 @@ impl VmService {
             },
             hypervisor: HypervisorConfig {
                 with_hv: true,
+                with_isolation: isolation,
                 ..Default::default()
             },
             #[cfg(windows)]
@@ -979,7 +1023,7 @@ impl VmService {
             vga_firmware: None,
             vtl2_gfx: false,
             virtio_devices: vec![],
-            vmbus: Some(VmbusConfig::default()),
+            vmbus,
             vtl2_vmbus: None,
             vmbus_devices: vec![],
             #[cfg(windows)]
@@ -1159,7 +1203,7 @@ impl VmService {
             ged_rpc: None,
             vm_rpc: send.clone(),
             paravisor_diag: None,
-            igvm_path: None,
+            igvm_path,
             memory_backing_file: None,
             memory,
             processors,

--- a/openvmm/openvmm_ttrpc_vmservice/src/vmservice.proto
+++ b/openvmm/openvmm_ttrpc_vmservice/src/vmservice.proto
@@ -73,6 +73,19 @@ message DirectBoot {
     string kernel_cmdline = 3;
 }
 
+message IgvmBoot {
+    string igvm_path = 1;
+}
+
+message IsolationConfig {
+    enum Type {
+        NONE = 0;
+        SNP = 1;
+    }
+
+    Type isolation_type = 1;
+}
+
 message UEFI {
     // Variables used to initialize an empty UEFI variable store. These are
     // ignored when the store already contains any variables.
@@ -566,6 +579,7 @@ message VMConfig {
     oneof BootConfig {
         DirectBoot direct_boot = 5;
         UEFI uefi = 6;
+        IgvmBoot igvm = 15;
     }
     WindowsOptions windows_options = 7;
     // Field 8 was previously map<string, string> extra_data.
@@ -586,6 +600,9 @@ message VMConfig {
     // selected; note that PCAT boot honors only the system UUID and serial
     // number.
     SMBIOSConfig smbios_config = 13;
+
+    // Confidential-computing isolation mode.
+    IsolationConfig isolation_config = 14;
 }
 
 // WindowsOptions contains virtual machine configurations that are only present on a Windows host.

--- a/openvmm/openvmm_ttrpc_vmservice/src/vmservice.proto
+++ b/openvmm/openvmm_ttrpc_vmservice/src/vmservice.proto
@@ -84,6 +84,8 @@ message IsolationConfig {
     }
 
     Type isolation_type = 1;
+    // Optional 32-byte host data bound to the SNP guest.
+    bytes host_data = 2;
 }
 
 message UEFI {

--- a/petri/src/vm/openvmm/construct.rs
+++ b/petri/src/vm/openvmm/construct.rs
@@ -660,6 +660,7 @@ impl PetriVmConfigOpenVmm {
 
             // Basic virtualization device support
             hypervisor: HypervisorConfig {
+                snp_host_data: None,
                 with_hv: !properties.no_hv,
                 with_vtl2,
                 with_isolation: match firmware.isolation() {

--- a/vmm_core/virt/src/generic.rs
+++ b/vmm_core/virt/src/generic.rs
@@ -274,9 +274,11 @@ pub struct SnpIdBlock {
     pub author_public_key: x86defs::snp::SnpIdBlockPublicKey,
 }
 
-/// Backend-neutral SNP launch configuration extracted from an IGVM file.
+/// Backend-neutral SNP launch configuration combining IGVM metadata and host parameters.
 #[derive(Eq, PartialEq, Debug, Clone)]
 pub struct SnpConfig {
+    /// Optional host-provided data included in SNP launch finish.
+    pub host_data: Option<[u8; 32]>,
     /// The SNP guest policy.
     pub policy: u64,
     /// The highest VTL requested by the selected IGVM platform.

--- a/vmm_core/virt_kvm/src/snp.rs
+++ b/vmm_core/virt_kvm/src/snp.rs
@@ -275,8 +275,15 @@ impl KvmPartitionInner {
         }
         self.prepare_snp_vmsa_register_state()?;
         tracing::debug!("KVM_SEV_SNP_LAUNCH_FINISH");
-        self.kvm
-            .sev_snp_launch_finish(sev.as_fd(), &mut Default::default())?;
+        let mut finish = kvm::kvm_sev_snp_launch_finish {
+            host_data: self
+                .snp_config
+                .as_ref()
+                .and_then(|config| config.generic.host_data)
+                .unwrap_or_default(),
+            ..Default::default()
+        };
+        self.kvm.sev_snp_launch_finish(sev.as_fd(), &mut finish)?;
         Ok(())
     }
 
@@ -814,6 +821,7 @@ mod tests {
 
     fn snp_config_with_contexts(vp_contexts: Vec<virt::SnpVpContext>) -> virt::SnpConfig {
         virt::SnpConfig {
+            host_data: None,
             policy: 0x30000,
             highest_vtl: 0,
             shared_gpa_boundary: 0,

--- a/vmm_core/virt_mshv/src/x86_64/snp.rs
+++ b/vmm_core/virt_mshv/src/x86_64/snp.rs
@@ -66,6 +66,8 @@ pub(crate) enum SnpLaunchState {
 
 #[derive(Debug, inspect::Inspect)]
 pub(crate) struct MshvSnpConfig {
+    #[inspect(skip)]
+    host_data: Option<[u8; 32]>,
     #[inspect(hex)]
     snp_policy: u64,
     #[inspect(rename = "id_block_enabled", with = "Option::is_some")]
@@ -135,6 +137,7 @@ pub(super) fn prepare_snp_config(
     let restricted_injection = parsed_vmsa.sev_features.restrict_injection();
 
     Ok(MshvSnpConfig {
+        host_data: config.host_data,
         snp_policy: config.policy,
         id_block: config.id_block.clone(),
         vmsa_gpa,
@@ -900,6 +903,12 @@ impl MshvPartitionInner {
     }
 }
 
+fn complete_snp_guest_request(ghcb: &mut x86defs::snp::GhcbPage) {
+    ghcb.save.sw_exit_info1 = 0;
+    ghcb.save.sw_exit_info2 = 0;
+    ghcb.save.valid_bitmap1 |= GHCB_SW_EXIT_INFO1_VALID_BIT | GHCB_SW_EXIT_INFO2_VALID_BIT;
+}
+
 /// Builds the PSP launch-finish data from the prepared MSHV SNP configuration.
 ///
 /// The returned `u64` is the effective SNP policy, which the caller records in
@@ -917,6 +926,7 @@ fn snp_launch_finish_data(
         |config| config.snp_policy,
     );
     parameters.id_block.policy = mshv_bindings::hv_snp_guest_policy { as_uint64: policy };
+    parameters.host_data = config.and_then(|config| config.host_data).unwrap_or_default();
 
     if let Some(source) = config.and_then(|config| config.id_block.as_ref()) {
         let id_block = virt::x86::snp::snp_id_block(source, policy);
@@ -1698,6 +1708,9 @@ impl MshvProcessor<'_> {
             exit_code if exit_code == u64::from(SVM_EXITCODE_SNP_AP_CREATION) => {
                 self.handle_snp_ap_create(info, ghcb_gpa)?;
             }
+            exit_code if exit_code == u64::from(SVM_EXITCODE_SNP_GUEST_REQUEST) => {
+                self.handle_snp_guest_request(info)?;
+            }
             exit_code => {
                 tracelimit::warn_ratelimited!(
                     exit_code,
@@ -1710,6 +1723,59 @@ impl MshvProcessor<'_> {
             }
         }
 
+        Ok(())
+    }
+
+    fn handle_snp_guest_request(
+        &mut self,
+        info: &hvdef::HvX64VmgexitInterceptMessage,
+    ) -> Result<(), VpHaltReason> {
+        let request_gpa = info.ghcb_page.standard.sw_exit_info1;
+        let response_gpa = info.ghcb_page.standard.sw_exit_info2;
+        let request_end = request_gpa
+            .checked_add(hvdef::HV_PAGE_SIZE)
+            .ok_or(VpHaltReason::TripleFault { vtl: Vtl::Vtl0 })?;
+        let response_end = response_gpa
+            .checked_add(hvdef::HV_PAGE_SIZE)
+            .ok_or(VpHaltReason::TripleFault { vtl: Vtl::Vtl0 })?;
+        let ghcb = self
+            .runner
+            .ghcb_page()
+            .ok_or(VpHaltReason::TripleFault { vtl: Vtl::Vtl0 })?;
+        if !ghcb_exit_info2_is_valid(ghcb)
+            || ghcb.save.sw_exit_info2 != response_gpa
+            || !request_gpa.is_multiple_of(hvdef::HV_PAGE_SIZE)
+            || !response_gpa.is_multiple_of(hvdef::HV_PAGE_SIZE)
+            || !self.partition.mem_layout.ram().iter().any(|range| {
+                range.range.contains(&MemoryRange::new(request_gpa..request_end))
+            })
+            || !self.partition.mem_layout.ram().iter().any(|range| {
+                range.range.contains(&MemoryRange::new(response_gpa..response_end))
+            })
+        {
+            return Err(VpHaltReason::TripleFault { vtl: Vtl::Vtl0 });
+        }
+
+        let request = mshv_bindings::mshv_issue_psp_guest_request {
+            req_gpa: request_gpa,
+            rsp_gpa: response_gpa,
+        };
+        self.partition
+            .vmfd
+            .psp_issue_guest_request(&request)
+            .map_err(|err| {
+                tracing::error!(
+                    error = &err as &dyn std::error::Error,
+                    "MSHV SNP guest request failed"
+                );
+                VpHaltReason::TripleFault { vtl: Vtl::Vtl0 }
+            })?;
+
+        let ghcb = self
+            .runner
+            .ghcb_page()
+            .ok_or(VpHaltReason::TripleFault { vtl: Vtl::Vtl0 })?;
+        complete_snp_guest_request(ghcb);
         Ok(())
     }
 
@@ -1832,6 +1898,19 @@ impl MshvProcessor<'_> {
 mod tests {
     use super::*;
     use test_with_tracing::test;
+
+    #[test]
+    fn completes_snp_guest_request() {
+        let mut ghcb = x86defs::snp::GhcbPage::new_zeroed();
+        ghcb.save.sw_exit_info1 = 0x400000;
+        ghcb.save.sw_exit_info2 = 0x500000;
+        ghcb.save.valid_bitmap1 |= GHCB_SW_EXIT_CODE_VALID_BIT;
+        complete_snp_guest_request(&mut ghcb);
+        assert_eq!(ghcb.save.sw_exit_info1, 0);
+        assert_eq!(ghcb.save.sw_exit_info2, 0);
+        assert!(ghcb_exit_fields_are_valid(&ghcb));
+        assert!(ghcb_exit_info2_is_valid(&ghcb));
+    }
 
     #[test]
     fn snp_hypercall_requires_valid_consistent_registers() {


### PR DESCRIPTION
Pass optional SNP host data from TTRPC to MSHV/KVM.

Handle SNP guest requests using the MSHV PSP guest request ioctl, allowing guests to retrieve attestation reports and verify the host data binding.

Builds on #4361 and #4399, which should be merged first.