### PR TITLE
[nvme_driver] set width limits on fields in nvme_driver fuzzer

### DIFF
--- a/vm/devices/storage/disk_nvme/nvme_driver/fuzz/fuzz_nvme_driver.rs
+++ b/vm/devices/storage/disk_nvme/nvme_driver/fuzz/fuzz_nvme_driver.rs
@@ -292,6 +292,9 @@ pub enum NvmeDriverAction {
     },
     ReservationAcquire {
         target_cpu: u32,
+        #[arbitrary(with = |u: &mut Unstructured<'_>| {
+            u.int_in_range(0..=nvm::RESERVATION_ACTION_MAX)
+        })]
         action: u8,
         crkey: u64,
         prkey: u64,
@@ -299,12 +302,18 @@ pub enum NvmeDriverAction {
     },
     ReservationRelease {
         target_cpu: u32,
+        #[arbitrary(with = |u: &mut Unstructured<'_>| {
+            u.int_in_range(0..=nvm::RESERVATION_ACTION_MAX)
+        })]
         action: u8,
         crkey: u64,
         reservation_type: u8,
     },
     ReservationRegister {
         target_cpu: u32,
+        #[arbitrary(with = |u: &mut Unstructured<'_>| {
+            u.int_in_range(0..=nvm::RESERVATION_ACTION_MAX)
+        })]
         action: u8,
         crkey: Option<u64>,
         nrkey: u64,

--- a/vm/devices/storage/nvme_spec/src/nvm.rs
+++ b/vm/devices/storage/nvme_spec/src/nvm.rs
@@ -319,6 +319,14 @@ pub struct Cdw10ReservationRelease {
     _rsvd2: u16,
 }
 
+const RESERVATION_ACTION_BITS: usize = 3;
+/// Width of the action field of a reservation command, for use by fuzzer
+pub const RESERVATION_ACTION_MAX: u8 = (1u8 << RESERVATION_ACTION_BITS) - 1;
+
+const _: () = assert!(Cdw10ReservationRegister::RREGA_BITS == RESERVATION_ACTION_BITS);
+const _: () = assert!(Cdw10ReservationAcquire::RACQA_BITS == RESERVATION_ACTION_BITS);
+const _: () = assert!(Cdw10ReservationRelease::RRELA_BITS == RESERVATION_ACTION_BITS);
+
 open_enum! {
     pub enum ReservationReleaseAction: u8 {
         RELEASE = 0,

--- a/vm/devices/storage/nvme_spec/src/nvm.rs
+++ b/vm/devices/storage/nvme_spec/src/nvm.rs
@@ -320,7 +320,7 @@ pub struct Cdw10ReservationRelease {
 }
 
 const RESERVATION_ACTION_BITS: usize = 3;
-/// Width of the action field of a reservation command, for use by fuzzer
+/// Width of the action field of a reservation command, for use by the fuzzer
 pub const RESERVATION_ACTION_MAX: u8 = (1u8 << RESERVATION_ACTION_BITS) - 1;
 
 const _: () = assert!(Cdw10ReservationRegister::RREGA_BITS == RESERVATION_ACTION_BITS);

--- a/vm/devices/storage/nvme_spec/src/nvm.rs
+++ b/vm/devices/storage/nvme_spec/src/nvm.rs
@@ -320,7 +320,7 @@ pub struct Cdw10ReservationRelease {
 }
 
 const RESERVATION_ACTION_BITS: usize = 3;
-/// Width of the action field of a reservation command, for use by the fuzzer
+/// Maximum value of the action field of a reservation command, for use by the fuzzer
 pub const RESERVATION_ACTION_MAX: u8 = (1u8 << RESERVATION_ACTION_BITS) - 1;
 
 const _: () = assert!(Cdw10ReservationRegister::RREGA_BITS == RESERVATION_ACTION_BITS);


### PR DESCRIPTION
This PR stops the nvme_driver fuzzer from creating false positives panics. Previously, the fuzzer would submit reservation commands with 8-bit action fields, though the field is only 3 bits wide.