### PR TITLE
openhcl: use confidential secure boot templates for isolated VMs

### DIFF
--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -2588,12 +2588,28 @@ async fn new_underhill_vm(
         use firmware_uefi_resources::x64_secure_boot_templates as secure_boot_templates;
         let base_template = match &dps.general.secure_boot_template {
             SecureBootTemplateType::None => None,
-            SecureBootTemplateType::MicrosoftWindows => {
-                Some(secure_boot_templates::microsoft_windows())
-            }
-            SecureBootTemplateType::MicrosoftUefiCertificateAuthority => {
-                Some(secure_boot_templates::microsoft_uefi_ca())
-            }
+            SecureBootTemplateType::MicrosoftWindows => Some({
+                #[cfg(guest_arch = "aarch64")]
+                let template = secure_boot_templates::microsoft_windows();
+                #[cfg(guest_arch = "x86_64")]
+                let template = if isolation.is_isolated() {
+                    secure_boot_templates::microsoft_windows_confidential()
+                } else {
+                    secure_boot_templates::microsoft_windows()
+                };
+                template
+            }),
+            SecureBootTemplateType::MicrosoftUefiCertificateAuthority => Some({
+                #[cfg(guest_arch = "aarch64")]
+                let template = secure_boot_templates::microsoft_uefi_ca();
+                #[cfg(guest_arch = "x86_64")]
+                let template = if isolation.is_isolated() {
+                    secure_boot_templates::microsoft_uefi_ca_confidential()
+                } else {
+                    secure_boot_templates::microsoft_uefi_ca()
+                };
+                template
+            }),
         };
 
         // check if vmgs includes custom UEFI JSON

--- a/vm/devices/firmware/hyperv_secure_boot_templates/src/lib.rs
+++ b/vm/devices/firmware/hyperv_secure_boot_templates/src/lib.rs
@@ -59,6 +59,8 @@ pub mod aarch64 {
 pub mod x64 {
     include_templates! {
         (microsoft_windows, "x64/MicrosoftWindows_Template.json"),
+        (microsoft_windows_confidential, "x64/MicrosoftWindows_Confidential_Template.json"),
         (microsoft_uefi_ca, "x64/MicrosoftUEFI_Template.json"),
+        (microsoft_uefi_ca_confidential, "x64/MicrosoftUEFI_Confidential_Template.json"),
     }
 }


### PR DESCRIPTION
## openhcl: use confidential secure boot templates for isolated VMs

### Why

The Hyper-V secure boot template drop ships two x64 sets: the standard
`MicrosoftWindows` / `MicrosoftUEFI` templates and `_Confidential` variants of
each. Both confidential JSON files were already vendored in
`hyperv_secure_boot_templates`, but nothing referenced them — the crate only
exposed the standard loaders, so `underhill_core` applied the standard
templates to every VM regardless of isolation.

The two sets are not cosmetic variations. The confidential templates establish
a **2023-only trust anchor set**:

| | standard | confidential |
| --- | --- | --- |
| PK | Hyper-V Firmware PK | same |
| KEK | KEK CA 2011 + KEK 2K CA 2023 | KEK 2K CA 2023 only |
| db (Windows) | Windows Production PCA 2011 + Windows UEFI CA 2023 | Windows UEFI CA 2023 only |
| db (UEFI CA) | UEFI CA 2011 + UEFI CA 2023 + Azure Services Linux Kmod PCA | UEFI CA 2023 only |
| dbx | 445 hashes | 291 hashes (strict subset) |

Because isolated VMs were being provisioned from the standard templates, they
trusted the 2011 CAs and the Azure Services Linux Kmod PCA — a materially
broader boot trust surface than the platform defines for confidential VMs. The
narrower `dbx` follows from this: the 154 omitted revocations all chain to CAs
the confidential template does not trust in the first place, so carrying them
adds variable-store bytes without adding protection.

### What changed

- `hyperv_secure_boot_templates`: register the two existing x64 confidential
  JSON assets in the `include_templates!` macro, adding
  `microsoft_windows_confidential` and `microsoft_uefi_ca_confidential`
  loaders (and the generated parse-validation tests that come with them).
- `underhill_core`: when resolving `SecureBootTemplateType` for a UEFI VM,
  select the confidential variant if `isolation.is_isolated()`.

### Behavior and compatibility

| Configuration | Template |
| --- | --- |
| x64, isolated | confidential |
| x64, non-isolated | standard (unchanged) |
| aarch64 | standard (unchanged) |

aarch64 is deliberately untouched: the drop is x64-only and no confidential
aarch64 templates exist, so the `cfg(guest_arch)` split preserves existing
selection there.

**Compatibility note for reviewers:** newly created isolated VMs will only
validate boot components chaining to the 2023 CAs. A CVM guest image whose
bootloader or shim is signed solely under the 2011 CAs — or, for the UEFI CA
template, one relying on the Azure Services Linux Kmod PCA — will fail secure
boot where it previously passed. That is the intended trust posture for
confidential VMs, but it is a behavioral change and not merely a hardening
no-op.

Existing VMs are unaffected. Secure boot variables are persisted to the UEFI
variable store at creation time and are not re-applied from the template on
later boots.