### PR TITLE
snp: openhcl_boot: remove vtl0 memory ranges under 2MB

### DIFF
--- a/openhcl/openhcl_boot/src/host_params/dt/mod.rs
+++ b/openhcl/openhcl_boot/src/host_params/dt/mod.rs
@@ -10,6 +10,7 @@ use crate::cmdline::SidecarOptions;
 use crate::host_params::COMMAND_LINE_SIZE;
 use crate::host_params::MAX_CPU_COUNT;
 use crate::host_params::MAX_ENTROPY_SIZE;
+use crate::host_params::MAX_HOST_PARTITION_RAM_RANGES;
 use crate::host_params::MAX_NUMA_NODES;
 use crate::host_params::MAX_PARTITION_RAM_RANGES;
 use crate::host_params::MAX_VTL2_RAM_RANGES;
@@ -70,6 +71,236 @@ pub enum DtError {
     /// Host provided MMIO range is insufficient to cover VTL2.
     #[error("host provided MMIO range is insufficient to cover VTL2")]
     NotEnoughVtl2Mmio,
+}
+
+// This must match the minimum eager registration granularity used by
+// underhill_mem for SNP VTL0 RAM.
+const SNP_VTL0_MEMORY_ALIGNMENT: u64 = 2 * 1024 * 1024;
+const MAX_IGNORED_VTL0_RAM_RANGES: usize = 2 * (MAX_PARTITION_RAM_RANGES + MAX_VTL2_RAM_RANGES);
+
+fn compatible_memory_entries(left: &MemoryEntry, right: &MemoryEntry) -> bool {
+    left.mem_type == right.mem_type && left.vnode == right.vnode
+}
+
+fn coalesce_vtl2_ram(vtl2_ram: &mut ArrayVec<MemoryEntry, MAX_VTL2_RAM_RANGES>) {
+    vtl2_ram.sort_unstable_by_key(|entry| entry.range.start());
+
+    let mut index = 1;
+    while index < vtl2_ram.len() {
+        let previous = vtl2_ram[index - 1];
+        let current = vtl2_ram[index];
+        if previous.range.end() == current.range.start()
+            && compatible_memory_entries(&previous, &current)
+        {
+            vtl2_ram[index - 1].range =
+                MemoryRange::new(previous.range.start()..current.range.end());
+            vtl2_ram.remove(index);
+        } else {
+            index += 1;
+        }
+    }
+}
+
+fn add_reclaimed_vtl2_ram(
+    vtl2_ram: &mut ArrayVec<MemoryEntry, MAX_VTL2_RAM_RANGES>,
+    entry: MemoryEntry,
+) -> bool {
+    let insert_index =
+        vtl2_ram.partition_point(|existing| existing.range.start() < entry.range.start());
+
+    if insert_index > 0 {
+        let previous = vtl2_ram[insert_index - 1];
+        if previous.range.end() == entry.range.start()
+            && compatible_memory_entries(&previous, &entry)
+        {
+            let mut end = entry.range.end();
+            if insert_index < vtl2_ram.len() {
+                let next = vtl2_ram[insert_index];
+                if end == next.range.start() && compatible_memory_entries(&entry, &next) {
+                    end = next.range.end();
+                    vtl2_ram.remove(insert_index);
+                }
+            }
+            vtl2_ram[insert_index - 1].range = MemoryRange::new(previous.range.start()..end);
+            return true;
+        }
+    }
+
+    if insert_index < vtl2_ram.len() {
+        let next = vtl2_ram[insert_index];
+        if entry.range.end() == next.range.start() && compatible_memory_entries(&entry, &next) {
+            vtl2_ram[insert_index].range = MemoryRange::new(entry.range.start()..next.range.end());
+            return true;
+        }
+    }
+
+    if vtl2_ram.len() == vtl2_ram.capacity() {
+        return false;
+    }
+
+    vtl2_ram.insert(insert_index, entry);
+    true
+}
+
+fn reclaim_vtl0_edge(
+    vtl2_ram: &mut ArrayVec<MemoryEntry, MAX_VTL2_RAM_RANGES>,
+    vtl0_fragments: &[MemoryEntry],
+    edge: MemoryRange,
+    edge_is_reserved: &impl Fn(MemoryRange) -> bool,
+    ignored_vtl0_ram: &mut ArrayVec<MemoryRange, MAX_IGNORED_VTL0_RAM_RANGES>,
+) {
+    if edge_is_reserved(edge) {
+        log::warn!("unaligned VTL0 edge {edge:#x?} overlaps required imported memory");
+        return;
+    }
+
+    for fragment in vtl0_fragments {
+        let start = fragment.range.start().max(edge.start());
+        let end = fragment.range.end().min(edge.end());
+        if start < end {
+            let entry = MemoryEntry {
+                range: MemoryRange::new(start..end),
+                mem_type: fragment.mem_type,
+                vnode: fragment.vnode,
+            };
+            if add_reclaimed_vtl2_ram(vtl2_ram, entry) {
+                log::warn!(
+                    "converting unaligned VTL0 edge {:#x?} on vnode {} with memory type {:?} to VTL2 RAM",
+                    entry.range,
+                    entry.vnode,
+                    entry.mem_type
+                );
+            } else {
+                log::warn!(
+                    "discarding unaligned VTL0 edge {:#x?} on vnode {} with memory type {:?}: \
+                     the VTL2 RAM range list is full",
+                    entry.range,
+                    entry.vnode,
+                    entry.mem_type
+                );
+                ignored_vtl0_ram
+                    .try_push(entry.range)
+                    .expect("ignored VTL0 edge count is bounded by partition memory ranges");
+            }
+        }
+    }
+}
+
+fn reclaim_unaligned_vtl0_edges(
+    partition_memory: &[MemoryEntry],
+    vtl2_ram: &mut ArrayVec<MemoryEntry, MAX_VTL2_RAM_RANGES>,
+    edge_is_reserved: impl Fn(MemoryRange) -> bool,
+    ignored_vtl0_ram: &mut ArrayVec<MemoryRange, MAX_IGNORED_VTL0_RAM_RANGES>,
+) {
+    coalesce_vtl2_ram(vtl2_ram);
+
+    let mut vtl0_ram = off_stack!(
+        ArrayVec<MemoryEntry, { MAX_PARTITION_RAM_RANGES + MAX_VTL2_RAM_RANGES }>,
+        ArrayVec::new_const()
+    );
+    vtl0_ram.clear();
+    for (range, result) in walk_ranges(
+        partition_memory.iter().map(|entry| (entry.range, *entry)),
+        vtl2_ram.iter().map(|entry| (entry.range, ())),
+    ) {
+        match result {
+            memory_range::RangeWalkResult::Left(entry) => vtl0_ram
+                .try_push(MemoryEntry {
+                    range,
+                    mem_type: entry.mem_type,
+                    vnode: entry.vnode,
+                })
+                .expect("partition memory range count is bounded"),
+            memory_range::RangeWalkResult::Neither
+            | memory_range::RangeWalkResult::Right(_)
+            | memory_range::RangeWalkResult::Both(_, _) => {}
+        }
+    }
+
+    let mut span_start_index = 0;
+    while span_start_index < vtl0_ram.len() {
+        let mut span_end_index = span_start_index + 1;
+        // Registration only cares about contiguous GPA spans, so NUMA and
+        // memory-type boundaries inside a span do not create additional edges.
+        while span_end_index < vtl0_ram.len()
+            && vtl0_ram[span_end_index - 1].range.end() == vtl0_ram[span_end_index].range.start()
+        {
+            span_end_index += 1;
+        }
+
+        let span = MemoryRange::new(
+            vtl0_ram[span_start_index].range.start()..vtl0_ram[span_end_index - 1].range.end(),
+        );
+        let aligned_start = span
+            .start()
+            .checked_add(SNP_VTL0_MEMORY_ALIGNMENT - 1)
+            .map(|address| address & !(SNP_VTL0_MEMORY_ALIGNMENT - 1));
+        let aligned_end = span.end() & !(SNP_VTL0_MEMORY_ALIGNMENT - 1);
+        let fragments = &vtl0_ram[span_start_index..span_end_index];
+
+        match aligned_start {
+            Some(aligned_start) if aligned_start < aligned_end => {
+                if span.start() < aligned_start {
+                    reclaim_vtl0_edge(
+                        vtl2_ram,
+                        fragments,
+                        MemoryRange::new(span.start()..aligned_start),
+                        &edge_is_reserved,
+                        ignored_vtl0_ram,
+                    );
+                }
+                if aligned_end < span.end() {
+                    reclaim_vtl0_edge(
+                        vtl2_ram,
+                        fragments,
+                        MemoryRange::new(aligned_end..span.end()),
+                        &edge_is_reserved,
+                        ignored_vtl0_ram,
+                    );
+                }
+            }
+            _ => reclaim_vtl0_edge(
+                vtl2_ram,
+                fragments,
+                span,
+                &edge_is_reserved,
+                ignored_vtl0_ram,
+            ),
+        }
+
+        span_start_index = span_end_index;
+    }
+}
+
+fn remove_ignored_vtl0_ram(
+    partition_memory: &[MemoryEntry],
+    ignored_vtl0_ram: &[MemoryRange],
+) -> OffStackRef<'static, ArrayVec<MemoryEntry, MAX_PARTITION_RAM_RANGES>> {
+    let mut usable_memory = off_stack!(
+        ArrayVec<MemoryEntry, MAX_PARTITION_RAM_RANGES>,
+        ArrayVec::new_const()
+    );
+    usable_memory.clear();
+
+    for (range, result) in walk_ranges(
+        partition_memory.iter().map(|entry| (entry.range, *entry)),
+        ignored_vtl0_ram.iter().map(|range| (*range, ())),
+    ) {
+        match result {
+            memory_range::RangeWalkResult::Left(entry) => usable_memory.push(MemoryEntry {
+                range,
+                mem_type: entry.mem_type,
+                vnode: entry.vnode,
+            }),
+            memory_range::RangeWalkResult::Both(_, _) => {}
+            memory_range::RangeWalkResult::Right(_) => {
+                panic!("ignored VTL0 range {range:#x?} is outside partition RAM")
+            }
+            memory_range::RangeWalkResult::Neither => {}
+        }
+    }
+
+    usable_memory
 }
 
 /// Allocate the private pool across NUMA nodes.
@@ -485,8 +716,12 @@ fn init_heap(params: &ShimParams) {
     }
 }
 
-type ParsedDt =
-    ParsedDeviceTree<MAX_PARTITION_RAM_RANGES, MAX_CPU_COUNT, COMMAND_LINE_SIZE, MAX_ENTROPY_SIZE>;
+type ParsedDt = ParsedDeviceTree<
+    MAX_HOST_PARTITION_RAM_RANGES,
+    MAX_CPU_COUNT,
+    COMMAND_LINE_SIZE,
+    MAX_ENTROPY_SIZE,
+>;
 
 /// Add common ranges to [`AddressSpaceManagerBuilder`] regardless if creating
 /// topology from the host or from saved state.
@@ -516,6 +751,9 @@ fn add_common_ranges<'a, I: Iterator<Item = MemoryRange>>(
 #[derive(Debug, PartialEq, Eq)]
 struct PartitionTopology {
     vtl2_ram: &'static [MemoryEntry],
+    /// Replacement partition map when ranges were removed or restored from
+    /// persisted state. `None` means the parsed host map can be used directly.
+    partition_ram_override: Option<&'static [MemoryEntry]>,
     vtl0_mmio: ArrayVec<MemoryRange, 2>,
     vtl2_mmio: ArrayVec<MemoryRange, 2>,
     memory_allocation_mode: MemoryAllocationMode,
@@ -551,6 +789,9 @@ fn topology_from_host_dt(
 
     let mut vtl2_ram =
         off_stack!(ArrayVec<MemoryEntry, MAX_VTL2_RAM_RANGES>, ArrayVec::new_const());
+    let mut ignored_vtl0_ram =
+        off_stack!(ArrayVec<MemoryRange, MAX_IGNORED_VTL0_RAM_RANGES>, ArrayVec::new_const());
+    ignored_vtl0_ram.clear();
 
     // TODO: Decide if isolated guests always use VTL2 allocation mode.
 
@@ -572,6 +813,23 @@ fn topology_from_host_dt(
                 .expect("vtl2 ram should only be 64 big");
         }
     }
+
+    if params.isolation_type == IsolationType::Snp {
+        reclaim_unaligned_vtl0_edges(
+            &parsed.memory,
+            &mut vtl2_ram,
+            |edge| {
+                params
+                    .imported_regions()
+                    .any(|(range, _)| range.start() < edge.end() && edge.start() < range.end())
+            },
+            &mut ignored_vtl0_ram,
+        );
+    }
+    let partition_ram_override = (!ignored_vtl0_ram.is_empty())
+        .then(|| remove_ignored_vtl0_ram(&parsed.memory, &ignored_vtl0_ram))
+        .map(OffStackRef::leak)
+        .map(|memory| memory.as_slice());
 
     // The host is responsible for allocating MMIO ranges for non-isolated
     // guests when it also provides the ram VTL2 should use.
@@ -736,6 +994,7 @@ fn topology_from_host_dt(
 
     Ok(PartitionTopology {
         vtl2_ram: OffStackRef::<'_, ArrayVec<MemoryEntry, MAX_VTL2_RAM_RANGES>>::leak(vtl2_ram),
+        partition_ram_override,
         vtl0_mmio,
         vtl2_mmio,
         memory_allocation_mode,
@@ -818,6 +1077,22 @@ fn topology_from_persisted_state(
 
     let mut vtl2_ram =
         off_stack!(ArrayVec<MemoryEntry, MAX_VTL2_RAM_RANGES>, ArrayVec::new_const());
+    let mut restored_partition_ram =
+        off_stack!(ArrayVec<MemoryEntry, MAX_PARTITION_RAM_RANGES>, ArrayVec::new_const());
+    restored_partition_ram.clear();
+    restored_partition_ram.extend(
+        memory_range::merge_adjacent_ranges(partition_memory.iter().filter_map(|entry| {
+            entry
+                .vtl_type
+                .ram()
+                .then_some((entry.range, (entry.igvm_type.clone().into(), entry.vnode)))
+        }))
+        .map(|(range, (mem_type, vnode))| MemoryEntry {
+            range,
+            mem_type,
+            vnode,
+        }),
+    );
 
     // Determine which ranges are memory ranges used by VTL2.
     let previous_vtl2_ram = partition_memory.iter().filter_map(|entry| {
@@ -853,10 +1128,28 @@ fn topology_from_persisted_state(
     // FUTURE: When VTL2 itself did allocation, we should verify that all ranges
     // are still within the provided memory map.
     if matches!(memory_allocation_mode, MemoryAllocationMode::Host) {
-        let host_vtl2_ram = parse_host_vtl2_ram(params, &parsed.memory);
+        let mut host_vtl2_ram =
+            off_stack!(ArrayVec<MemoryEntry, MAX_VTL2_RAM_RANGES>, ArrayVec::new_const());
+        host_vtl2_ram
+            .try_extend_from_slice(parse_host_vtl2_ram(params, &parsed.memory).as_ref())
+            .expect("vtl2 ram should only be 64 big");
+        if params.isolation_type == IsolationType::Snp {
+            let mut ignored_vtl0_ram = off_stack!(ArrayVec<MemoryRange, MAX_IGNORED_VTL0_RAM_RANGES>, ArrayVec::new_const());
+            ignored_vtl0_ram.clear();
+            reclaim_unaligned_vtl0_edges(
+                &parsed.memory,
+                &mut host_vtl2_ram,
+                |edge| {
+                    params
+                        .imported_regions()
+                        .any(|(range, _)| range.start() < edge.end() && edge.start() < range.end())
+                },
+                &mut ignored_vtl0_ram,
+            );
+        }
         assert_eq!(
             vtl2_ram.as_slice(),
-            host_vtl2_ram.as_ref(),
+            host_vtl2_ram.as_slice(),
             "vtl2 ram from persisted state does not match host provided ram"
         );
     }
@@ -947,6 +1240,7 @@ fn topology_from_persisted_state(
     Ok(PersistedPartitionTopology {
         topology: PartitionTopology {
             vtl2_ram: OffStackRef::<'_, ArrayVec<MemoryEntry, MAX_VTL2_RAM_RANGES>>::leak(vtl2_ram),
+            partition_ram_override: Some(OffStackRef::leak(restored_partition_ram)),
             vtl0_mmio,
             vtl2_mmio,
             memory_allocation_mode,
@@ -1132,7 +1426,13 @@ impl PartitionInfo {
         vtl2_ram.clear();
         vtl2_ram.extend(topology.vtl2_ram.iter().copied());
         partition_ram.clear();
-        partition_ram.extend(parsed.memory.iter().copied());
+        partition_ram.extend(
+            topology
+                .partition_ram_override
+                .unwrap_or(&parsed.memory)
+                .iter()
+                .copied(),
+        );
         *memory_allocation_mode = topology.memory_allocation_mode;
 
         // Set vmbus fields. The connection ID comes from the host, but mmio
@@ -1171,5 +1471,140 @@ impl PartitionInfo {
         *boot_options = options;
 
         Ok(storage)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entry(
+        range: core::ops::Range<u64>,
+        mem_type: MemoryMapEntryType,
+        vnode: u32,
+    ) -> MemoryEntry {
+        MemoryEntry {
+            range: MemoryRange::new(range),
+            mem_type,
+            vnode,
+        }
+    }
+
+    #[test]
+    fn reclaims_unaligned_vtl0_edges() {
+        let memory = [
+            entry(
+                0x10_0000..0x30_0000,
+                MemoryMapEntryType::VTL2_PROTECTABLE,
+                1,
+            ),
+            entry(0x30_0000..0x70_0000, MemoryMapEntryType::MEMORY, 2),
+            entry(
+                0x1000_0000..0x1030_0000,
+                MemoryMapEntryType::VTL2_PROTECTABLE,
+                3,
+            ),
+            entry(
+                0x1030_0000..0x1060_0000,
+                MemoryMapEntryType::VTL2_PROTECTABLE,
+                4,
+            ),
+            entry(
+                0x2001_0000..0x2010_0000,
+                MemoryMapEntryType::VTL2_PROTECTABLE,
+                5,
+            ),
+            entry(
+                0xc000_0000..0xe000_0000,
+                MemoryMapEntryType::VTL2_PROTECTABLE,
+                0,
+            ),
+        ];
+        let mut vtl2_ram = ArrayVec::new();
+        vtl2_ram.push(entry(
+            0xd815_0000..0xe000_0000,
+            MemoryMapEntryType::VTL2_PROTECTABLE,
+            0,
+        ));
+
+        let imported_range = MemoryRange::new(0x2001_0000..0x2002_0000);
+        let mut ignored_vtl0_ram = ArrayVec::new();
+        reclaim_unaligned_vtl0_edges(
+            &memory,
+            &mut vtl2_ram,
+            |edge| imported_range.start() < edge.end() && edge.start() < imported_range.end(),
+            &mut ignored_vtl0_ram,
+        );
+
+        assert_eq!(
+            vtl2_ram.as_slice(),
+            &[
+                entry(
+                    0x10_0000..0x20_0000,
+                    MemoryMapEntryType::VTL2_PROTECTABLE,
+                    1
+                ),
+                entry(0x60_0000..0x70_0000, MemoryMapEntryType::MEMORY, 2),
+                entry(
+                    0xd800_0000..0xe000_0000,
+                    MemoryMapEntryType::VTL2_PROTECTABLE,
+                    0
+                ),
+            ]
+        );
+        assert!(ignored_vtl0_ram.is_empty());
+
+        let discarded = MemoryRange::new(0x30_0000..0x40_0000);
+        let usable_memory = remove_ignored_vtl0_ram(&memory[..2], &[discarded]);
+        assert_eq!(
+            usable_memory.as_slice(),
+            &[
+                entry(
+                    0x10_0000..0x30_0000,
+                    MemoryMapEntryType::VTL2_PROTECTABLE,
+                    1,
+                ),
+                entry(0x40_0000..0x70_0000, MemoryMapEntryType::MEMORY, 2),
+            ]
+        );
+    }
+
+    #[test]
+    fn full_range_list_only_accepts_mergeable_edges() {
+        let mut vtl2_ram = ArrayVec::new();
+        for index in 0..MAX_VTL2_RAM_RANGES {
+            let start = 0x10_0000 + index as u64 * 0x40_0000;
+            vtl2_ram.push(entry(
+                start..start + 0x10_0000,
+                MemoryMapEntryType::VTL2_PROTECTABLE,
+                0,
+            ));
+        }
+        let original_second = vtl2_ram[1];
+        let unreclaimed_edge = entry(
+            original_second.range.start() - 0x10_0000..original_second.range.start(),
+            MemoryMapEntryType::MEMORY,
+            1,
+        );
+
+        assert!(add_reclaimed_vtl2_ram(
+            &mut vtl2_ram,
+            entry(0..0x10_0000, MemoryMapEntryType::VTL2_PROTECTABLE, 0,),
+        ));
+        assert!(!add_reclaimed_vtl2_ram(&mut vtl2_ram, unreclaimed_edge,));
+
+        assert_eq!(vtl2_ram.len(), MAX_VTL2_RAM_RANGES);
+        assert_eq!(vtl2_ram[0].range, MemoryRange::new(0..0x20_0000));
+        assert_eq!(vtl2_ram[1], original_second);
+
+        let mut ignored_vtl0_ram = ArrayVec::new();
+        reclaim_vtl0_edge(
+            &mut vtl2_ram,
+            &[unreclaimed_edge],
+            unreclaimed_edge.range,
+            &|_| false,
+            &mut ignored_vtl0_ram,
+        );
+        assert_eq!(ignored_vtl0_ram.as_slice(), &[unreclaimed_edge.range]);
     }
 }

--- a/openhcl/openhcl_boot/src/host_params/mod.rs
+++ b/openhcl/openhcl_boot/src/host_params/mod.rs
@@ -28,14 +28,19 @@ pub const MAX_NUMA_NODES: usize = 64;
 
 pub const COMMAND_LINE_SIZE: usize = 0x2000;
 
-/// Each ram range reported by the host for VTL2 is split per NUMA node.
+/// Maximum number of VTL2 RAM ranges.
 ///
-/// Today, Hyper-V has a max limit of 64 NUMA nodes, so we should only ever see
-/// 64 ram ranges.
+/// The primary ranges are bounded by Hyper-V's limit of 64 NUMA nodes.
+/// Additional alignment padding is merged into those ranges when possible and
+/// otherwise reclaimed only while capacity remains.
 pub const MAX_VTL2_RAM_RANGES: usize = 64;
 
-/// The maximum number of ram ranges that can be read from the host.
-const MAX_PARTITION_RAM_RANGES: usize = 1024;
+/// The maximum number of RAM ranges that can be read from the host.
+const MAX_HOST_PARTITION_RAM_RANGES: usize = 1024;
+
+/// The maximum number of partition RAM ranges after removing unusable VTL0
+/// edges. Each VTL2 range can introduce two additional boundaries.
+const MAX_PARTITION_RAM_RANGES: usize = MAX_HOST_PARTITION_RAM_RANGES + 2 * MAX_VTL2_RAM_RANGES;
 
 /// Maximum size of the host-provided entropy
 pub const MAX_ENTROPY_SIZE: usize = 256;
@@ -48,7 +53,8 @@ pub struct PartitionInfo {
     ///
     /// This vec is guaranteed to be sorted, and non-overlapping.
     pub vtl2_ram: ArrayVec<MemoryEntry, MAX_VTL2_RAM_RANGES>,
-    /// The full memory map provided by the host.
+    /// The host memory map after removing RAM that cannot be assigned safely
+    /// to either VTL.
     pub partition_ram: ArrayVec<MemoryEntry, MAX_PARTITION_RAM_RANGES>,
     /// The partiton's isolation type.
     pub isolation: IsolationType,

--- a/openhcl/underhill_core/src/worker.rs
+++ b/openhcl/underhill_core/src/worker.rs
@@ -1192,57 +1192,88 @@ fn build_vtl0_memory_layout(
     vtl0_memory_map: Vec<(MemoryRangeWithNode, MemoryMapEntryType)>,
     chipset_mmio: &ChipsetMmioRanges,
     mut shared_pool_size: u64,
+    shared_pool_alignment: u64,
 ) -> anyhow::Result<BuiltVtl0MemoryLayout> {
     let mmio: Vec<MemoryRange> = [chipset_mmio.low, chipset_mmio.high]
         .into_iter()
         .filter(|r| !r.is_empty())
         .collect();
-    // Allocate shared_pool memory starting from the last (top of memory)
-    // continuing downward until the size is covered.
-    //
-    // Note that we must only allocate from memory entries that are actually
-    // ram, not reserved or pmem. Keep track of the ranges that are skipped to
-    // re-add to the memory map later.
-    let mut filtered_vtl0_memory_map = vtl0_memory_map.clone();
-    let mut skipped = Vec::new();
-    let mut shared_pool = Vec::new();
-    while shared_pool_size != 0 {
-        let (last, last_typ) = filtered_vtl0_memory_map.last_mut().with_context(|| {
-            format!(
-                "unable to allocate shared_pool of size {shared_pool_size} from VTL0 memory map"
-            )
-        })?;
+    assert!(shared_pool_alignment.is_power_of_two());
+    assert!(shared_pool_size.is_multiple_of(shared_pool_alignment));
 
-        if *last_typ != MemoryMapEntryType::MEMORY {
-            skipped.push(filtered_vtl0_memory_map.pop().expect("is element"));
+    // Select aligned subranges from normal RAM runs, starting at high
+    // addresses. Aligning both sides of every carve preserves the registration
+    // alignment of the VTL0 spans on either side, even when an adjacent
+    // reserved entry ends at an unaligned address.
+    let mut shared_pool_ranges = Vec::new();
+    let mut run_end_index = vtl0_memory_map.len();
+    while run_end_index != 0 {
+        let last_index = run_end_index - 1;
+        if !matches!(
+            vtl0_memory_map[last_index].1,
+            MemoryMapEntryType::MEMORY | MemoryMapEntryType::VTL2_PROTECTABLE
+        ) {
+            run_end_index = last_index;
             continue;
         }
 
-        if last.range.len() > shared_pool_size {
-            // Split this memory range, with the top being given to the shared
-            // pool and the remainder back to VTL0.
-            let shared_start = last.range.end() - shared_pool_size;
-            let vtl0 = MemoryRangeWithNode {
-                range: MemoryRange::new(last.range.start()..shared_start),
-                vnode: last.vnode,
-            };
-
-            shared_pool.push(MemoryRangeWithNode {
-                range: MemoryRange::new(shared_start..last.range.end()),
-                vnode: last.vnode,
-            });
-            *last = vtl0;
-            break;
-        } else {
-            shared_pool_size -= last.range.len();
-            shared_pool.push(last.clone());
-            filtered_vtl0_memory_map.pop();
+        let mut run_start_index = last_index;
+        while run_start_index != 0
+            && vtl0_memory_map[run_start_index - 1].0.range.end()
+                == vtl0_memory_map[run_start_index].0.range.start()
+            && matches!(
+                vtl0_memory_map[run_start_index - 1].1,
+                MemoryMapEntryType::MEMORY | MemoryMapEntryType::VTL2_PROTECTABLE
+            )
+        {
+            run_start_index -= 1;
         }
+
+        let run_start = vtl0_memory_map[run_start_index].0.range.start();
+        let run_end = vtl0_memory_map[last_index].0.range.end();
+        let aligned_start = (run_start + shared_pool_alignment - 1) & !(shared_pool_alignment - 1);
+        let aligned_end = run_end & !(shared_pool_alignment - 1);
+        if aligned_start < aligned_end {
+            let allocation_size = shared_pool_size.min(aligned_end - aligned_start);
+            shared_pool_ranges.push(MemoryRange::new(aligned_end - allocation_size..aligned_end));
+            shared_pool_size -= allocation_size;
+            if shared_pool_size == 0 {
+                break;
+            }
+        }
+
+        run_end_index = run_start_index;
     }
 
-    // Skipped entries are added in reverse order to maintain the sorted list.
-    for entry in skipped.into_iter().rev() {
-        filtered_vtl0_memory_map.push(entry);
+    anyhow::ensure!(
+        shared_pool_size == 0,
+        "unable to allocate shared_pool of size {shared_pool_size} from aligned VTL0 memory spans"
+    );
+    shared_pool_ranges.sort_unstable_by_key(|range| range.start());
+
+    let mut filtered_vtl0_memory_map = Vec::new();
+    let mut shared_pool = Vec::new();
+    for (entry, typ) in &vtl0_memory_map {
+        filtered_vtl0_memory_map.extend(
+            memory_range::subtract_ranges([entry.range], shared_pool_ranges.iter().copied()).map(
+                |range| {
+                    (
+                        MemoryRangeWithNode {
+                            range,
+                            vnode: entry.vnode,
+                        },
+                        *typ,
+                    )
+                },
+            ),
+        );
+        shared_pool.extend(
+            memory_range::overlapping_ranges([entry.range], shared_pool_ranges.iter().copied())
+                .map(|range| MemoryRangeWithNode {
+                    range,
+                    vnode: entry.vnode,
+                }),
+        );
     }
 
     // TODO: SGX ranges get reported as memory here. Correct or not? Probably should remove?
@@ -1299,6 +1330,118 @@ fn build_vtl0_memory_layout(
         shared_pool,
         complete_memory_layout,
     })
+}
+
+#[cfg(test)]
+mod memory_layout_tests {
+    use super::*;
+
+    #[test]
+    fn shared_pool_uses_vtl2_protectable_ram_at_top_of_memory() {
+        let vtl0_memory_map = vec![
+            (
+                MemoryRangeWithNode {
+                    range: MemoryRange::new(0..0x60_0000),
+                    vnode: 0,
+                },
+                MemoryMapEntryType::MEMORY,
+            ),
+            (
+                MemoryRangeWithNode {
+                    range: MemoryRange::new(0x60_0000..0xa0_0000),
+                    vnode: 0,
+                },
+                MemoryMapEntryType::VTL2_PROTECTABLE,
+            ),
+        ];
+        let chipset_mmio = ChipsetMmioRanges {
+            low: MemoryRange::EMPTY,
+            high: MemoryRange::EMPTY,
+        };
+
+        let built =
+            build_vtl0_memory_layout(vtl0_memory_map, &chipset_mmio, 0x20_0000, 0x20_0000).unwrap();
+
+        assert_eq!(
+            built.vtl0_memory_map,
+            vec![
+                (
+                    MemoryRangeWithNode {
+                        range: MemoryRange::new(0..0x60_0000),
+                        vnode: 0,
+                    },
+                    MemoryMapEntryType::MEMORY,
+                ),
+                (
+                    MemoryRangeWithNode {
+                        range: MemoryRange::new(0x60_0000..0x80_0000),
+                        vnode: 0,
+                    },
+                    MemoryMapEntryType::VTL2_PROTECTABLE,
+                ),
+            ]
+        );
+        assert_eq!(
+            built.shared_pool,
+            vec![MemoryRangeWithNode {
+                range: MemoryRange::new(0x80_0000..0xa0_0000),
+                vnode: 0,
+            }]
+        );
+    }
+
+    #[test]
+    fn shared_pool_preserves_alignment_around_reserved_memory() {
+        let vtl0_memory_map = vec![
+            (
+                MemoryRangeWithNode {
+                    range: MemoryRange::new(0..0x80_0000),
+                    vnode: 0,
+                },
+                MemoryMapEntryType::MEMORY,
+            ),
+            (
+                MemoryRangeWithNode {
+                    range: MemoryRange::new(0x1000_0000..0x10d0_0000),
+                    vnode: 1,
+                },
+                MemoryMapEntryType::MEMORY,
+            ),
+            (
+                MemoryRangeWithNode {
+                    range: MemoryRange::new(0x10d0_0000..0x1100_0000),
+                    vnode: 1,
+                },
+                MemoryMapEntryType::PLATFORM_RESERVED,
+            ),
+        ];
+        let chipset_mmio = ChipsetMmioRanges {
+            low: MemoryRange::EMPTY,
+            high: MemoryRange::EMPTY,
+        };
+
+        let built =
+            build_vtl0_memory_layout(vtl0_memory_map, &chipset_mmio, 0x20_0000, 0x20_0000).unwrap();
+
+        assert_eq!(
+            built.shared_pool,
+            vec![MemoryRangeWithNode {
+                range: MemoryRange::new(0x10a0_0000..0x10c0_0000),
+                vnode: 1,
+            }]
+        );
+        assert!(
+            memory_range::merge_adjacent_ranges(
+                built
+                    .vtl0_memory_layout
+                    .ram()
+                    .iter()
+                    .map(|entry| (entry.range, ()))
+            )
+            .all(|(range, ())| range.start().is_multiple_of(0x20_0000)
+                && range.end().is_multiple_of(0x20_0000))
+        );
+    }
 }
 
 fn round_up_to_2mb(bytes: u64) -> u64 {
@@ -1778,7 +1921,16 @@ async fn new_underhill_vm(
         vtl0_memory_layout: mem_layout,
         shared_pool,
         complete_memory_layout,
-    } = build_vtl0_memory_layout(vtl0_memory_map, &chipset_mmio, shared_pool_size)?;
+    } = build_vtl0_memory_layout(
+        vtl0_memory_map,
+        &chipset_mmio,
+        shared_pool_size,
+        if isolation == virt::IsolationType::Snp {
+            2 * 1024 * 1024
+        } else {
+            hvdef::HV_PAGE_SIZE
+        },
+    )?;
 
     // Determine if x2apic is supported so that the topology matches
     // reality.

--- a/openhcl/underhill_mem/src/init.rs
+++ b/openhcl/underhill_mem/src/init.rs
@@ -347,14 +347,16 @@ pub async fn init(params: &Init<'_>) -> anyhow::Result<MemoryMappings> {
         });
 
         if params.isolation == IsolationType::Snp {
-            // Register all VTL0 memory, starting with contiguous 1 GB ranges, and then 2 MB ranges for any remaining edges.
+            // Register all complete 1 GB VTL0 ranges first, then all complete
+            // 2 MB ranges. Any remaining sub-2 MB edges are unusable by the
+            // kernel registration interface and are intentionally skipped.
             let _span = tracing::info_span!("register_vtl0_memory", CVM_ALLOWED).entered();
             vtl0_mapping
                 .register_all_aligned_memory(SNP_PUD_REGISTRATION_GRANULARITY, true)
                 .context("failed to eagerly register SNP VTL0 memory")?;
             vtl0_mapping
-                .register_all_aligned_memory(SNP_PMD_REGISTRATION_GRANULARITY, false)
-                .context("failed to register SNP VTL0 memory edges")?;
+                .register_all_aligned_memory(SNP_PMD_REGISTRATION_GRANULARITY, true)
+                .context("failed to register aligned SNP VTL0 memory")?;
         }
         let vtl0_mapping = Arc::new(vtl0_mapping);
 


### PR DESCRIPTION
For VTL0 memory ranges that don't fit into 2MB aligned ranges, attempt to convert them to VTL2. Otherwise just drop them. Log warnings in either case.