### PR TITLE
Restrict CI Jobs to The Upstream Repository

### DIFF
--- a/.github/workflows/openvmm-docs-ci.yaml
+++ b/.github/workflows/openvmm-docs-ci.yaml
@@ -531,7 +531,7 @@ jobs:
     - job0
     - job1
     - job2
-    if: github.event.pull_request.draft == false
+    if: github.repository == 'microsoft/openvmm'
     steps:
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c

--- a/.github/workflows/refresh-mirror.yml
+++ b/.github/workflows/refresh-mirror.yml
@@ -12,6 +12,7 @@ permissions:
 
 jobs:
   QueueBuild:
+    if: github.repository == 'microsoft/openvmm'
     runs-on: ubuntu-latest
     steps:
       - uses: Azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1

--- a/flowey/flowey_hvlite/src/pipelines/build_docs.rs
+++ b/flowey/flowey_hvlite/src/pipelines/build_docs.rs
@@ -177,6 +177,7 @@ impl IntoPipeline for BuildDocsCli {
             let job = pipeline
                 .new_job(FlowPlatform::Linux(FlowPlatformLinuxDistro::Ubuntu), FlowArch::X86_64, "publish openvmm.dev")
                 .gh_set_pool(crate::pipelines_shared::gh_pools::linux_x64_gh())
+                .gh_dangerous_override_if("github.repository == 'microsoft/openvmm'")
                 .gh_set_concurrency_group(GhConcurrencyGroup {
                     name: "publish-openvmm.dev".into(),
                     cancel_in_progress: true,


### PR DESCRIPTION
Publishing docs to openvmm.dev and refreshing the VSO mirror both rely on secrets and permissions that only exist on microsoft/openvmm. On forks these jobs either fail or run needlessly, so gate them on the repository name.

- build_docs.rs: override the "publish openvmm.dev" job condition with `github.repository == 'microsoft/openvmm'` via gh_dangerous_override_if, replacing the previous draft-PR check.
- openvmm-docs-ci.yaml: regenerated to reflect the flowey change.
- refresh-mirror.yml: gate the QueueBuild job on the same condition.