### PR TITLE
Restrict Upstream-Only CI Workflows and Jobs

### DIFF
--- a/.github/workflows/openvmm-ci.yaml
+++ b/.github/workflows/openvmm-ci.yaml
@@ -362,7 +362,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    if: github.event.pull_request.draft == false
+    if: github.repository == 'microsoft/openvmm'
     steps:
     - run: |
         set -x
@@ -635,7 +635,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    if: github.event.pull_request.draft == false
+    if: github.repository == 'microsoft/openvmm'
     steps:
     - run: |
         set -x
@@ -1019,7 +1019,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    if: github.event.pull_request.draft == false
+    if: github.repository == 'microsoft/openvmm'
     steps:
     - run: |
         set -x
@@ -1379,7 +1379,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    if: github.event.pull_request.draft == false
+    if: github.repository == 'microsoft/openvmm'
     steps:
     - run: |
         set -x
@@ -1669,7 +1669,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    if: github.event.pull_request.draft == false
+    if: github.repository == 'microsoft/openvmm'
     steps:
     - run: |
         set -x
@@ -2048,7 +2048,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    if: github.event.pull_request.draft == false
+    if: github.repository == 'microsoft/openvmm'
     steps:
     - run: |
         set -x
@@ -2439,7 +2439,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    if: github.event.pull_request.draft == false
+    if: github.repository == 'microsoft/openvmm'
     steps:
     - run: |
         set -x
@@ -2729,7 +2729,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    if: github.event.pull_request.draft == false
+    if: github.repository == 'microsoft/openvmm'
     steps:
     - run: |
         set -x
@@ -3083,7 +3083,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    if: github.event.pull_request.draft == false
+    if: github.repository == 'microsoft/openvmm'
     steps:
     - run: |
         set -x
@@ -3479,7 +3479,7 @@ jobs:
     - job2
     - job3
     - job7
-    if: github.event.pull_request.draft == false
+    if: github.repository == 'microsoft/openvmm'
     steps:
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
@@ -3774,7 +3774,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    if: github.event.pull_request.draft == false
+    if: github.repository == 'microsoft/openvmm'
     steps:
     - run: |
         set -x
@@ -3965,7 +3965,7 @@ jobs:
     - job2
     - job3
     - job7
-    if: github.event.pull_request.draft == false
+    if: github.repository == 'microsoft/openvmm'
     steps:
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
@@ -4260,7 +4260,7 @@ jobs:
     - job2
     - job3
     - job7
-    if: github.event.pull_request.draft == false
+    if: github.repository == 'microsoft/openvmm'
     steps:
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
@@ -4560,7 +4560,7 @@ jobs:
     - job2
     - job3
     - job7
-    if: github.event.pull_request.draft == false
+    if: github.repository == 'microsoft/openvmm'
     steps:
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
@@ -4861,7 +4861,7 @@ jobs:
     - job2
     - job3
     - job7
-    if: github.event.pull_request.draft == false
+    if: github.repository == 'microsoft/openvmm'
     steps:
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
@@ -5160,7 +5160,7 @@ jobs:
     - job2
     - job3
     - job9
-    if: github.event.pull_request.draft == false
+    if: github.repository == 'microsoft/openvmm'
     steps:
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
@@ -5438,7 +5438,7 @@ jobs:
     - job2
     - job3
     - job9
-    if: github.event.pull_request.draft == false
+    if: github.repository == 'microsoft/openvmm'
     steps:
     - run: |
         set -x
@@ -5765,7 +5765,7 @@ jobs:
     - job2
     - job3
     - job5
-    if: github.event.pull_request.draft == false
+    if: github.repository == 'microsoft/openvmm'
     steps:
     - run: |
         set -x
@@ -6087,7 +6087,7 @@ jobs:
     needs:
     - job3
     - job8
-    if: github.event.pull_request.draft == false
+    if: github.repository == 'microsoft/openvmm'
     steps:
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
@@ -6362,7 +6362,7 @@ jobs:
       id-token: write
     needs:
     - job9
-    if: github.event.pull_request.draft == false
+    if: github.repository == 'microsoft/openvmm'
     steps:
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
@@ -6491,7 +6491,7 @@ jobs:
       id-token: write
     needs:
     - job9
-    if: github.event.pull_request.draft == false
+    if: github.repository == 'microsoft/openvmm'
     steps:
     - run: |
         set -x
@@ -6665,7 +6665,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    if: github.event.pull_request.draft == false
+    if: github.repository == 'microsoft/openvmm'
     steps:
     - run: |
         set -x
@@ -7071,7 +7071,7 @@ jobs:
     needs:
     - job6
     - job7
-    if: github.event.pull_request.draft == false
+    if: github.repository == 'microsoft/openvmm'
     steps:
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
@@ -7195,7 +7195,7 @@ jobs:
     needs:
     - job6
     - job7
-    if: github.event.pull_request.draft == false
+    if: github.repository == 'microsoft/openvmm'
     steps:
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
@@ -7704,7 +7704,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    if: github.event.pull_request.draft == false
+    if: github.repository == 'microsoft/openvmm'
     steps:
     - run: |
         set -x
@@ -7939,7 +7939,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    if: github.event.pull_request.draft == false
+    if: github.repository == 'microsoft/openvmm'
     steps:
     - run: |
         set -x
@@ -8259,7 +8259,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    if: github.event.pull_request.draft == false
+    if: github.repository == 'microsoft/openvmm'
     steps:
     - run: |
         set -x
@@ -8498,7 +8498,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    if: github.event.pull_request.draft == false
+    if: github.repository == 'microsoft/openvmm'
     steps:
     - run: |
         set -x
@@ -8826,7 +8826,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    if: github.event.pull_request.draft == false
+    if: github.repository == 'microsoft/openvmm'
     steps:
     - run: |
         set -x
@@ -9314,7 +9314,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    if: github.event.pull_request.draft == false
+    if: github.repository == 'microsoft/openvmm'
     steps:
     - run: |
         set -x

--- a/.github/workflows/openvmm-docs-ci.yaml
+++ b/.github/workflows/openvmm-docs-ci.yaml
@@ -531,7 +531,7 @@ jobs:
     - job0
     - job1
     - job2
-    if: github.event.pull_request.draft == false
+    if: github.repository == 'microsoft/openvmm'
     steps:
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c

--- a/.github/workflows/openvmm-pr-release.yaml
+++ b/.github/workflows/openvmm-pr-release.yaml
@@ -27,11 +27,7 @@ concurrency:
 jobs:
   job0:
     name: quick check [fmt, clippy x64-linux]
-    runs-on:
-    - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3-v7
-    - 1ES.ImageOverride=ubuntu2404-amd64
-    - JobId=job0-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       id-token: write
@@ -415,7 +411,7 @@ jobs:
       id-token: write
     needs:
     - job0
-    if: contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
+    if: github.repository == 'microsoft/openvmm' && contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
     steps:
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
@@ -622,7 +618,7 @@ jobs:
       id-token: write
     needs:
     - job0
-    if: contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
+    if: github.repository == 'microsoft/openvmm' && contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
     steps:
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
@@ -940,7 +936,7 @@ jobs:
       id-token: write
     needs:
     - job0
-    if: contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
+    if: github.repository == 'microsoft/openvmm' && contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
     steps:
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
@@ -1258,7 +1254,7 @@ jobs:
       id-token: write
     needs:
     - job0
-    if: contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
+    if: github.repository == 'microsoft/openvmm' && contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
     steps:
     - run: |
         set -x
@@ -1550,7 +1546,7 @@ jobs:
       id-token: write
     needs:
     - job0
-    if: contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
+    if: github.repository == 'microsoft/openvmm' && contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
     steps:
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
@@ -1855,7 +1851,7 @@ jobs:
       id-token: write
     needs:
     - job0
-    if: contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
+    if: github.repository == 'microsoft/openvmm' && contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
     steps:
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
@@ -2204,7 +2200,7 @@ jobs:
       id-token: write
     needs:
     - job0
-    if: contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
+    if: github.repository == 'microsoft/openvmm' && contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
     steps:
     - run: |
         set -x
@@ -2496,7 +2492,7 @@ jobs:
       id-token: write
     needs:
     - job0
-    if: contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
+    if: github.repository == 'microsoft/openvmm' && contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
     steps:
     - run: |
         set -x
@@ -2853,7 +2849,7 @@ jobs:
       id-token: write
     needs:
     - job0
-    if: contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
+    if: github.repository == 'microsoft/openvmm' && contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
     steps:
     - run: |
         set -x
@@ -3250,7 +3246,7 @@ jobs:
     - job2
     - job3
     - job7
-    if: contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
+    if: github.repository == 'microsoft/openvmm' && contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
     steps:
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
@@ -3547,7 +3543,7 @@ jobs:
       id-token: write
     needs:
     - job0
-    if: contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
+    if: github.repository == 'microsoft/openvmm' && contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
     steps:
     - run: |
         set -x
@@ -3739,7 +3735,7 @@ jobs:
     - job2
     - job3
     - job7
-    if: contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
+    if: github.repository == 'microsoft/openvmm' && contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
     steps:
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
@@ -4035,7 +4031,7 @@ jobs:
     - job2
     - job3
     - job7
-    if: contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
+    if: github.repository == 'microsoft/openvmm' && contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
     steps:
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
@@ -4336,7 +4332,7 @@ jobs:
     - job2
     - job3
     - job7
-    if: contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
+    if: github.repository == 'microsoft/openvmm' && contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
     steps:
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
@@ -4637,7 +4633,7 @@ jobs:
     - job2
     - job3
     - job7
-    if: contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
+    if: github.repository == 'microsoft/openvmm' && contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
     steps:
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
@@ -4937,7 +4933,7 @@ jobs:
     - job2
     - job3
     - job9
-    if: contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
+    if: github.repository == 'microsoft/openvmm' && contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
     steps:
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
@@ -5216,7 +5212,7 @@ jobs:
     - job2
     - job3
     - job9
-    if: contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
+    if: github.repository == 'microsoft/openvmm' && contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
     steps:
     - run: |
         set -x
@@ -5544,7 +5540,7 @@ jobs:
     - job2
     - job3
     - job5
-    if: contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
+    if: github.repository == 'microsoft/openvmm' && contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
     steps:
     - run: |
         set -x
@@ -5867,7 +5863,7 @@ jobs:
     - job0
     - job3
     - job8
-    if: contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
+    if: github.repository == 'microsoft/openvmm' && contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
     steps:
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
@@ -6143,7 +6139,7 @@ jobs:
     needs:
     - job0
     - job9
-    if: contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
+    if: github.repository == 'microsoft/openvmm' && contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
     steps:
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
@@ -6273,7 +6269,7 @@ jobs:
     needs:
     - job0
     - job9
-    if: contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
+    if: github.repository == 'microsoft/openvmm' && contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
     steps:
     - run: |
         set -x
@@ -6449,7 +6445,7 @@ jobs:
       id-token: write
     needs:
     - job0
-    if: contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
+    if: github.repository == 'microsoft/openvmm' && contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
     steps:
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
@@ -6811,7 +6807,7 @@ jobs:
     - job0
     - job6
     - job7
-    if: contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
+    if: github.repository == 'microsoft/openvmm' && contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
     steps:
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
@@ -6936,7 +6932,7 @@ jobs:
     - job0
     - job6
     - job7
-    if: contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
+    if: github.repository == 'microsoft/openvmm' && contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
     steps:
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
@@ -7213,7 +7209,7 @@ jobs:
       id-token: write
     needs:
     - job0
-    if: contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
+    if: github.repository == 'microsoft/openvmm' && contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
     steps:
     - run: |
         set -x
@@ -7450,7 +7446,7 @@ jobs:
       id-token: write
     needs:
     - job0
-    if: contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
+    if: github.repository == 'microsoft/openvmm' && contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
     steps:
     - run: |
         set -x
@@ -7772,7 +7768,7 @@ jobs:
       id-token: write
     needs:
     - job0
-    if: contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
+    if: github.repository == 'microsoft/openvmm' && contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
     steps:
     - run: |
         set -x
@@ -8013,7 +8009,7 @@ jobs:
       id-token: write
     needs:
     - job0
-    if: contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
+    if: github.repository == 'microsoft/openvmm' && contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
     steps:
     - run: |
         set -x
@@ -8343,7 +8339,7 @@ jobs:
       id-token: write
     needs:
     - job0
-    if: contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
+    if: github.repository == 'microsoft/openvmm' && contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
     steps:
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
@@ -8781,7 +8777,7 @@ jobs:
       id-token: write
     needs:
     - job0
-    if: contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
+    if: github.repository == 'microsoft/openvmm' && contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false
     steps:
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c

--- a/.github/workflows/openvmm-pr.yaml
+++ b/.github/workflows/openvmm-pr.yaml
@@ -613,7 +613,7 @@ jobs:
       id-token: write
     needs:
     - job0
-    if: github.event.pull_request.draft == false
+    if: github.repository == 'microsoft/openvmm' && github.event.pull_request.draft == false
     steps:
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
@@ -1138,7 +1138,7 @@ jobs:
       id-token: write
     needs:
     - job0
-    if: github.event.pull_request.draft == false
+    if: github.repository == 'microsoft/openvmm' && github.event.pull_request.draft == false
     steps:
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c

--- a/.github/workflows/openvmm-pr.yaml
+++ b/.github/workflows/openvmm-pr.yaml
@@ -26,11 +26,7 @@ concurrency:
 jobs:
   job0:
     name: quick check [fmt, clippy x64-linux]
-    runs-on:
-    - self-hosted
-    - 1ES.Pool=openvmm-gh-amd-westus3-v7
-    - 1ES.ImageOverride=ubuntu2404-amd64
-    - JobId=job0-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       id-token: write
@@ -414,7 +410,7 @@ jobs:
       id-token: write
     needs:
     - job0
-    if: github.event.pull_request.draft == false
+    if: github.repository == 'microsoft/openvmm' && github.event.pull_request.draft == false
     steps:
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
@@ -828,7 +824,7 @@ jobs:
       id-token: write
     needs:
     - job0
-    if: github.event.pull_request.draft == false
+    if: github.repository == 'microsoft/openvmm' && github.event.pull_request.draft == false
     steps:
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
@@ -1353,7 +1349,7 @@ jobs:
       id-token: write
     needs:
     - job0
-    if: github.event.pull_request.draft == false
+    if: github.repository == 'microsoft/openvmm' && github.event.pull_request.draft == false
     steps:
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
@@ -1671,7 +1667,7 @@ jobs:
       id-token: write
     needs:
     - job0
-    if: github.event.pull_request.draft == false
+    if: github.repository == 'microsoft/openvmm' && github.event.pull_request.draft == false
     steps:
     - run: |
         set -x
@@ -1963,7 +1959,7 @@ jobs:
       id-token: write
     needs:
     - job0
-    if: github.event.pull_request.draft == false
+    if: github.repository == 'microsoft/openvmm' && github.event.pull_request.draft == false
     steps:
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
@@ -2268,7 +2264,7 @@ jobs:
       id-token: write
     needs:
     - job0
-    if: github.event.pull_request.draft == false
+    if: github.repository == 'microsoft/openvmm' && github.event.pull_request.draft == false
     steps:
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
@@ -2617,7 +2613,7 @@ jobs:
       id-token: write
     needs:
     - job0
-    if: github.event.pull_request.draft == false
+    if: github.repository == 'microsoft/openvmm' && github.event.pull_request.draft == false
     steps:
     - run: |
         set -x
@@ -2909,7 +2905,7 @@ jobs:
       id-token: write
     needs:
     - job0
-    if: github.event.pull_request.draft == false
+    if: github.repository == 'microsoft/openvmm' && github.event.pull_request.draft == false
     steps:
     - run: |
         set -x
@@ -3265,7 +3261,7 @@ jobs:
       id-token: write
     needs:
     - job0
-    if: github.event.pull_request.draft == false
+    if: github.repository == 'microsoft/openvmm' && github.event.pull_request.draft == false
     steps:
     - run: |
         set -x
@@ -3453,7 +3449,7 @@ jobs:
       id-token: write
     needs:
     - job0
-    if: github.event.pull_request.draft == false
+    if: github.repository == 'microsoft/openvmm' && github.event.pull_request.draft == false
     steps:
     - run: |
         set -x
@@ -3850,7 +3846,7 @@ jobs:
     - job2
     - job3
     - job7
-    if: github.event.pull_request.draft == false
+    if: github.repository == 'microsoft/openvmm' && github.event.pull_request.draft == false
     steps:
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
@@ -4151,7 +4147,7 @@ jobs:
     - job2
     - job3
     - job7
-    if: github.event.pull_request.draft == false
+    if: github.repository == 'microsoft/openvmm' && github.event.pull_request.draft == false
     steps:
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
@@ -4447,7 +4443,7 @@ jobs:
     - job2
     - job3
     - job7
-    if: github.event.pull_request.draft == false
+    if: github.repository == 'microsoft/openvmm' && github.event.pull_request.draft == false
     steps:
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
@@ -4748,7 +4744,7 @@ jobs:
     - job2
     - job3
     - job7
-    if: github.event.pull_request.draft == false
+    if: github.repository == 'microsoft/openvmm' && github.event.pull_request.draft == false
     steps:
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
@@ -5049,7 +5045,7 @@ jobs:
     - job2
     - job3
     - job7
-    if: github.event.pull_request.draft == false
+    if: github.repository == 'microsoft/openvmm' && github.event.pull_request.draft == false
     steps:
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
@@ -5349,7 +5345,7 @@ jobs:
     - job2
     - job3
     - job9
-    if: github.event.pull_request.draft == false
+    if: github.repository == 'microsoft/openvmm' && github.event.pull_request.draft == false
     steps:
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
@@ -5628,7 +5624,7 @@ jobs:
     - job2
     - job3
     - job9
-    if: github.event.pull_request.draft == false
+    if: github.repository == 'microsoft/openvmm' && github.event.pull_request.draft == false
     steps:
     - run: |
         set -x
@@ -5956,7 +5952,7 @@ jobs:
     - job2
     - job3
     - job5
-    if: github.event.pull_request.draft == false
+    if: github.repository == 'microsoft/openvmm' && github.event.pull_request.draft == false
     steps:
     - run: |
         set -x
@@ -6279,7 +6275,7 @@ jobs:
     - job0
     - job3
     - job8
-    if: github.event.pull_request.draft == false
+    if: github.repository == 'microsoft/openvmm' && github.event.pull_request.draft == false
     steps:
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
@@ -6553,7 +6549,7 @@ jobs:
       id-token: write
     needs:
     - job0
-    if: github.event.pull_request.draft == false
+    if: github.repository == 'microsoft/openvmm' && github.event.pull_request.draft == false
     steps:
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
@@ -7135,7 +7131,7 @@ jobs:
       id-token: write
     needs:
     - job0
-    if: github.event.pull_request.draft == false
+    if: github.repository == 'microsoft/openvmm' && github.event.pull_request.draft == false
     steps:
     - run: |
         set -x
@@ -7372,7 +7368,7 @@ jobs:
       id-token: write
     needs:
     - job0
-    if: github.event.pull_request.draft == false
+    if: github.repository == 'microsoft/openvmm' && github.event.pull_request.draft == false
     steps:
     - run: |
         set -x
@@ -7694,7 +7690,7 @@ jobs:
       id-token: write
     needs:
     - job0
-    if: github.event.pull_request.draft == false
+    if: github.repository == 'microsoft/openvmm' && github.event.pull_request.draft == false
     steps:
     - run: |
         set -x
@@ -7935,7 +7931,7 @@ jobs:
       id-token: write
     needs:
     - job0
-    if: github.event.pull_request.draft == false
+    if: github.repository == 'microsoft/openvmm' && github.event.pull_request.draft == false
     steps:
     - run: |
         set -x
@@ -8265,7 +8261,7 @@ jobs:
       id-token: write
     needs:
     - job0
-    if: github.event.pull_request.draft == false
+    if: github.repository == 'microsoft/openvmm' && github.event.pull_request.draft == false
     steps:
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
@@ -8703,7 +8699,7 @@ jobs:
       id-token: write
     needs:
     - job0
-    if: github.event.pull_request.draft == false
+    if: github.repository == 'microsoft/openvmm' && github.event.pull_request.draft == false
     steps:
     - name: 🌼📦 Download artifacts
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c

--- a/.github/workflows/refresh-mirror.yml
+++ b/.github/workflows/refresh-mirror.yml
@@ -12,6 +12,7 @@ permissions:
 
 jobs:
   QueueBuild:
+    if: github.repository == 'microsoft/openvmm'
     runs-on: ubuntu-latest
     steps:
       - uses: Azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1

--- a/.github/workflows/upload-petri-results.yml
+++ b/.github/workflows/upload-petri-results.yml
@@ -17,12 +17,15 @@ permissions:
 
 jobs:
   upload-logs:
+    # Only the upstream repository has access to the Azure test results storage.
     # Only attempt upload if the workflow run could have actually produced some artifacts
     if: >-
       ${{
-        github.event.workflow_run.conclusion == 'success' ||
-        github.event.workflow_run.conclusion == 'failure' ||
-        github.event.workflow_run.conclusion == 'timed_out'
+        github.repository == 'microsoft/openvmm' && (
+          github.event.workflow_run.conclusion == 'success' ||
+          github.event.workflow_run.conclusion == 'failure' ||
+          github.event.workflow_run.conclusion == 'timed_out'
+        )
       }}
     runs-on: ubuntu-latest
     env:

--- a/flowey/flowey_hvlite/src/pipelines/build_docs.rs
+++ b/flowey/flowey_hvlite/src/pipelines/build_docs.rs
@@ -177,6 +177,7 @@ impl IntoPipeline for BuildDocsCli {
             let job = pipeline
                 .new_job(FlowPlatform::Linux(FlowPlatformLinuxDistro::Ubuntu), FlowArch::X86_64, "publish openvmm.dev")
                 .gh_set_pool(crate::pipelines_shared::gh_pools::linux_x64_gh())
+                .gh_dangerous_override_if("github.repository == 'microsoft/openvmm'")
                 .gh_set_concurrency_group(GhConcurrencyGroup {
                     name: "publish-openvmm.dev".into(),
                     cancel_in_progress: false,

--- a/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
+++ b/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
@@ -1189,6 +1189,9 @@ impl IntoPipeline for CheckinGatesCli {
                         format!("verify openhcl binary size [{}]", arch_tag),
                     )
                     .gh_set_pool_with_fork_gate(gh_pools::linux_x64_gh(), config)
+                    .gh_dangerous_override_if(
+                        "github.repository == 'microsoft/openvmm' && github.event.pull_request.draft == false",
+                    )
                     .side_effect(|done| {
                         flowey_lib_hvlite::_jobs::check_openvmm_hcl_size::Request {
                             target: CommonTriple::Common {

--- a/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
+++ b/flowey/flowey_hvlite/src/pipelines/checkin_gates.rs
@@ -52,6 +52,37 @@ enum PipelineConfig {
     PrRelease,
 }
 
+trait CheckinGatesJobExt {
+    fn gh_set_pool_with_fork_gate(self, pool: GhRunner, config: PipelineConfig) -> Self;
+}
+
+impl CheckinGatesJobExt for PipelineJob<'_> {
+    fn gh_set_pool_with_fork_gate(self, pool: GhRunner, config: PipelineConfig) -> Self {
+        let is_upstream_only =
+            matches!(pool, GhRunner::SelfHosted(_) | GhRunner::RunnerGroup { .. });
+        let job = self.gh_set_pool(pool);
+
+        let condition = match (config, is_upstream_only) {
+            (PipelineConfig::Pr, true) => Some(
+                "github.repository == 'microsoft/openvmm' && github.event.pull_request.draft == false",
+            ),
+            (PipelineConfig::Ci, true) => Some("github.repository == 'microsoft/openvmm'"),
+            (PipelineConfig::PrRelease, true) => Some(
+                "github.repository == 'microsoft/openvmm' && contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false",
+            ),
+            (PipelineConfig::PrRelease, false) => Some(
+                "contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false",
+            ),
+            _ => None,
+        };
+
+        match condition {
+            Some(condition) => job.gh_dangerous_override_if(condition),
+            None => job,
+        }
+    }
+}
+
 /// A unified pipeline defining all checkin gates required to land a commit in
 /// the OpenVMM repo.
 #[derive(clap::Args)]
@@ -158,8 +189,7 @@ impl IntoPipeline for CheckinGatesCli {
         )?;
 
         pipeline.inject_all_jobs_with(move |job| {
-            let mut job = job
-                .dep_on(&cfg_common_params)
+            job.dep_on(&cfg_common_params)
                 .dep_on(|_| flowey_lib_hvlite::_jobs::cfg_versions::Request::Init)
                 .dep_on(
                     |_| flowey_lib_hvlite::_jobs::cfg_hvlite_reposource::Params {
@@ -173,16 +203,7 @@ impl IntoPipeline for CheckinGatesCli {
                 .gh_grant_permissions::<flowey_lib_common::gh_task_azure_login::Node>([(
                     GhPermission::IdToken,
                     GhPermissionValue::Write,
-                )]);
-
-            // For the release pipeline, only run if the "release-ci-required" label is present and PR is not draft
-            if matches!(config, PipelineConfig::PrRelease) {
-                job = job.gh_dangerous_override_if(
-                    "contains(github.event.pull_request.labels.*.name, 'release-ci-required') && github.event.pull_request.draft == false",
-                );
-            }
-
-            job
+                )])
         });
 
         let openhcl_musl_target = |arch: CommonArch| -> Triple {
@@ -232,7 +253,8 @@ impl IntoPipeline for CheckinGatesCli {
 
         // Quick check gate
         //
-        // Combined fmt + clippy on one self-hosted linux machine.
+        // Combined fmt + clippy on one GitHub-hosted linux machine so that it
+        // can bootstrap the remaining fork-capable jobs.
         // Catches the most common failures quickly before fanning out expensive jobs.
         let quick_check_job = if matches!(config, PipelineConfig::Pr | PipelineConfig::PrRelease) {
             let job = pipeline
@@ -241,7 +263,7 @@ impl IntoPipeline for CheckinGatesCli {
                     FlowArch::X86_64,
                     "quick check [fmt, clippy x64-linux]",
                 )
-                .gh_set_pool(gh_pools::default_linux())
+                .gh_set_pool_with_fork_gate(gh_pools::linux_x64_gh(), config)
                 .ado_set_pool(ado_pools::default_linux())
                 // 1. xtask fmt (linux)
                 .side_effect(|done| flowey_lib_hvlite::_jobs::check_xtask_fmt::Request {
@@ -271,7 +293,7 @@ impl IntoPipeline for CheckinGatesCli {
                     FlowArch::X86_64,
                     "xtask fmt (windows)",
                 )
-                .gh_set_pool(gh_pools::windows_x64_gh())
+                .gh_set_pool_with_fork_gate(gh_pools::windows_x64_gh(), config)
                 .ado_set_pool(ado_pools::default_windows())
                 .side_effect(|done| flowey_lib_hvlite::_jobs::check_xtask_fmt::Request {
                     target: CommonTriple::X86_64_WINDOWS_MSVC,
@@ -290,7 +312,7 @@ impl IntoPipeline for CheckinGatesCli {
                         FlowArch::X86_64,
                         "xtask fmt (linux)",
                     )
-                    .gh_set_pool(gh_pools::linux_x64_gh())
+                    .gh_set_pool_with_fork_gate(gh_pools::linux_x64_gh(), config)
                     .ado_set_pool(ado_pools::default_linux())
                     .side_effect(|done| flowey_lib_hvlite::_jobs::check_xtask_fmt::Request {
                         target: CommonTriple::X86_64_LINUX_GNU,
@@ -349,7 +371,7 @@ impl IntoPipeline for CheckinGatesCli {
                 FlowArch::X86_64,
                 "build artifacts (shared VMM tests) [windows]",
             )
-            .gh_set_pool(gh_pools::default_windows())
+            .gh_set_pool_with_fork_gate(gh_pools::default_windows(), config)
             .ado_set_pool(ado_pools::default_windows());
         for (arch, pub_pipette_windows) in shared_win_pipette_artifacts {
             shared_win_job = shared_win_job.publish(pub_pipette_windows, |pipette| {
@@ -450,7 +472,7 @@ impl IntoPipeline for CheckinGatesCli {
                 FlowArch::X86_64,
                 "build artifacts (shared VMM tests) [linux]",
             )
-            .gh_set_pool(gh_pools::linux_intel_v6_1es())
+            .gh_set_pool_with_fork_gate(gh_pools::linux_intel_v6_1es(), config)
             .ado_set_pool(ado_pools::default_linux());
         for (
             arch,
@@ -602,7 +624,7 @@ impl IntoPipeline for CheckinGatesCli {
                     FlowArch::X86_64,
                     format!("build artifacts (not for VMM tests) [{arch_tag}-windows]"),
                 )
-                .gh_set_pool(gh_pools::default_windows())
+                .gh_set_pool_with_fork_gate(gh_pools::default_windows(), config)
                 .ado_set_pool(ado_pools::default_windows())
                 .publish(pub_hypestv, |hypestv| {
                     flowey_lib_hvlite::build_hypestv::Request {
@@ -678,7 +700,7 @@ impl IntoPipeline for CheckinGatesCli {
                     FlowArch::X86_64,
                     format!("build artifacts (for VMM tests) [{arch_tag}-windows]"),
                 )
-                .gh_set_pool(gh_pools::default_windows())
+                .gh_set_pool_with_fork_gate(gh_pools::default_windows(), config)
                 .ado_set_pool(ado_pools::default_windows())
                 .publish(pub_openvmm, |openvmm| {
                     flowey_lib_hvlite::build_openvmm::Request {
@@ -856,7 +878,7 @@ impl IntoPipeline for CheckinGatesCli {
                     FlowArch::X86_64,
                     format!("build artifacts (for VMM tests) [{arch_tag}-linux]"),
                 )
-                .gh_set_pool(gh_pools::default_linux())
+                .gh_set_pool_with_fork_gate(gh_pools::default_linux(), config)
                 .ado_set_pool(ado_pools::default_linux())
                 .publish(pub_openvmm, |openvmm| {
                     flowey_lib_hvlite::build_openvmm::Request {
@@ -1111,7 +1133,7 @@ impl IntoPipeline for CheckinGatesCli {
                     FlowArch::X86_64,
                     build_openhcl_job_tag(arch_tag, mi_secure),
                 )
-                .gh_set_pool(gh_pools::default_linux())
+                .gh_set_pool_with_fork_gate(gh_pools::default_linux(), config)
                 .ado_set_pool(ado_pools::default_linux())
                 .dep_on(|ctx| {
                     let publish_baseline_artifact = pub_openhcl_baseline
@@ -1166,7 +1188,7 @@ impl IntoPipeline for CheckinGatesCli {
                         FlowArch::X86_64,
                         format!("verify openhcl binary size [{}]", arch_tag),
                     )
-                    .gh_set_pool(gh_pools::linux_x64_gh())
+                    .gh_set_pool_with_fork_gate(gh_pools::linux_x64_gh(), config)
                     .side_effect(|done| {
                         flowey_lib_hvlite::_jobs::check_openvmm_hcl_size::Request {
                             target: CommonTriple::Common {
@@ -1324,7 +1346,7 @@ impl IntoPipeline for CheckinGatesCli {
 
             let mut clippy_unit_test_job = pipeline
                 .new_job(platform, arch, job_name)
-                .gh_set_pool(gh_pool);
+                .gh_set_pool_with_fork_gate(gh_pool, config);
 
             if let Some(pool) = ado_pool {
                 clippy_unit_test_job = clippy_unit_test_job.ado_set_pool(pool);
@@ -1752,7 +1774,7 @@ impl IntoPipeline for CheckinGatesCli {
 
             let mut vmm_tests_run_job = pipeline
                 .new_job(platform, arch, format!("run vmm-tests [{label}]"))
-                .gh_set_pool(gh_pool);
+                .gh_set_pool_with_fork_gate(gh_pool, config);
 
             if let Some(pool) = ado_pool {
                 vmm_tests_run_job = vmm_tests_run_job.ado_set_pool(pool);
@@ -1858,7 +1880,7 @@ impl IntoPipeline for CheckinGatesCli {
                         FlowArch::X86_64,
                         format!("run vmm-perf [{label}]"),
                     )
-                    .gh_set_pool(pool)
+                    .gh_set_pool_with_fork_gate(pool, config)
                     .with_timeout_in_minutes(120)
                     .dep_on(|_| flowey_lib_hvlite::_jobs::cfg_versions::Request::Init)
                     .dep_on(
@@ -1889,7 +1911,7 @@ impl IntoPipeline for CheckinGatesCli {
                         FlowArch::X86_64,
                         "test flowey local backend",
                     )
-                    .gh_set_pool(gh_pools::linux_x64_gh())
+                    .gh_set_pool_with_fork_gate(gh_pools::linux_x64_gh(), config)
                     .side_effect(|done| {
                         flowey_lib_hvlite::_jobs::test_local_flowey_build_igvm::Request {
                             base_recipe: OpenhclIgvmRecipe::X64,
@@ -1909,7 +1931,7 @@ impl IntoPipeline for CheckinGatesCli {
                     FlowArch::X86_64,
                     "build openvmm [distribution config, x64-linux-gnu]",
                 )
-                .gh_set_pool(gh_pools::linux_x64_gh())
+                .gh_set_pool_with_fork_gate(gh_pools::linux_x64_gh(), config)
                 .ado_set_pool(ado_pools::default_linux())
                 .side_effect(|done| {
                     flowey_lib_hvlite::_jobs::check_distro_build_from_checkout::Request { done }
@@ -1945,7 +1967,7 @@ impl IntoPipeline for CheckinGatesCli {
                     FlowArch::X86_64,
                     "openvmm checkin gates",
                 )
-                .gh_set_pool(gh_pools::linux_x64_gh())
+                .gh_set_pool_with_fork_gate(gh_pools::linux_x64_gh(), config)
                 // always run this job, regardless whether or not any previous jobs failed
                 .gh_dangerous_override_if("always() && github.event.pull_request.draft == false")
                 .gh_dangerous_global_env_var("ANY_JOBS_FAILED", "${{ contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'failure') }}")
@@ -1973,7 +1995,7 @@ impl IntoPipeline for CheckinGatesCli {
                     GhPermission::Contents,
                     GhPermissionValue::Write,
                 )])
-                .gh_set_pool(gh_pools::linux_x64_gh())
+                .gh_set_pool_with_fork_gate(gh_pools::linux_x64_gh(), config)
                 .dep_on(
                     |ctx| flowey_lib_hvlite::_jobs::publish_vmgstool_gh_release::Request {
                         vmgstools: vmgstools


### PR DESCRIPTION
## Description

Fork CI currently schedules jobs that require Microsoft-owned runners, credentials, services, or upstream artifacts. This can leave checks queued, fail workflows, and block otherwise runnable validation.


This change:

- Runs the quick-check gate on GitHub-hosted Linux.
- Restricts self-hosted checkin jobs to `microsoft/openvmm`.
- Skips documentation publishing, VSO mirror refresh, OpenHCL baseline size checks, and Petri result uploads in forks.
- Preserves existing draft PR and release-label conditions.
- Regenerates the affected Flowey workflows.

## Validation

- `cargo check -p flowey_hvlite`
- `cargo clippy --all-targets -p flowey_hvlite`
- `cargo doc --no-deps -p flowey_hvlite`
- `cargo nextest run --profile agent -p flowey_hvlite --no-tests pass`
- `cargo xtask fmt --fix`
- `cargo xflowey regen`