### PR TITLE
virt_mshv: support nested virtualization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4901,9 +4901,9 @@ dependencies = [
 
 [[package]]
 name = "mshv-bindings"
-version = "0.6.8"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a94fc3871dd23738188e5bc76a1d1a5930ebcaf9308c560a7274aa62b1770594"
+checksum = "9b4b2414499597c6e31b1cd25239f19e8e8c55023b3bf8fcfa44d927cff6a123"
 dependencies = [
  "libc",
  "num_enum",
@@ -4915,9 +4915,9 @@ dependencies = [
 
 [[package]]
 name = "mshv-ioctls"
-version = "0.6.8"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1339723fe3a26baf4041459de20ad923e89d312c3bb25dbf9f60738c22a47f5e"
+checksum = "c30d1b5b76a709e30b46248f52bbb44dde04a659d6d58255c7f06c88d528d210"
 dependencies = [
  "libc",
  "mshv-bindings",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -641,8 +641,8 @@ iced-x86 = { version = "1.17", default-features = false, features = [
 igvm = { git = "https://github.com/microsoft/igvm", rev = "b7e717d40653f8c2382342eb7097dcd3ec0568de" }
 igvm_defs = { git = "https://github.com/microsoft/igvm", rev = "b7e717d40653f8c2382342eb7097dcd3ec0568de", default-features = false }
 kvm-bindings = "0.14.0"
-mshv-bindings = "0.6.8"
-mshv-ioctls = "0.6.8"
+mshv-bindings = "0.7.1"
+mshv-ioctls = "0.7.1"
 uefi = "0.35.0"
 vfio-bindings = "0.4.0"
 x86_64 = { version = "0.15.2", default-features = false }

--- a/Guide/src/reference/emulated/pcie/overview.md
+++ b/Guide/src/reference/emulated/pcie/overview.md
@@ -14,10 +14,11 @@ Root Complex (GenericPcieRootComplex)
 └── Root Port N  (PcieDownstreamPort)  → ...
 ```
 
-The root complex owns the ECAM MMIO region. When the guest reads
-or writes a config space address, the root complex decodes the
-bus/device/function from the ECAM offset and routes the access
-to the correct port. Each port has a Type 1 (bridge)
+The root complex owns the ECAM MMIO region. On x86_64, a segment-zero root
+complex that spans the complete bus range also supports legacy
+configuration access through I/O ports CF8/CFC. Partial and
+multi-root-complex topologies use ECAM so that one legacy handler does
+not hide buses owned by another root complex. Each port has a Type 1 (bridge)
 configuration space with PCIe Express and MSI capabilities.
 
 Ports may optionally be hotplug-capable. Devices behind

--- a/Guide/src/reference/openvmm/management/cli.md
+++ b/Guide/src/reference/openvmm/management/cli.md
@@ -120,12 +120,14 @@ describes the source definitions.
   `--isolation snp`.
 * `--nested-virt`: Expose hardware virtualization (VMX/SVM) to the guest so it
   can run its own hypervisor (Hyper-V, KVM, etc.). Only supported on `x86_64`,
-  and only by backends that support nested virtualization (currently WHP and
-  KVM); requesting it with a backend that does not support it fails early. The
-  host must expose virtualization extensions to the VM running OpenVMM. When
-  enabled, a guest may detect nested virtualization and turn on features such
-  as Virtual Secure Mode (VSM), which can hurt performance and interfere with
-  VMBus devices; nested virt cannot currently be combined with `--hv`/VMBus or
+  and only by backends that support nested virtualization (currently WHP,
+  KVM, and MSHV); requesting it with a backend that does not support it fails
+  early.
+  The host must expose virtualization extensions to the VM running OpenVMM.
+  When enabled, a guest may detect nested virtualization and turn on features
+  such as Virtual Secure Mode (VSM), which can hurt performance and interfere
+  with VMBus devices; nested virt cannot currently be combined with
+  `--hv`/VMBus or
   `--hypervisor whp:user_mode_apic`.
 * `--uefi`: Boot using `mu_msvm` UEFI
 * `--uefi-firmware <FILE>`: Path to the UEFI firmware file (`MSVM.fd`). When `--uefi` is specified, this option is required only if you do not set the environment variable `OPENVMM_UEFI_FIRMWARE` (or the architecture-specific variants `X86_64_OPENVMM_UEFI_FIRMWARE`, or `AARCH64_OPENVMM_UEFI_FIRMWARE`). If omitted, the default is read from `OPENVMM_UEFI_FIRMWARE` first, then falls back to the architecture-specific variables.

--- a/openvmm/openvmm_core/src/worker/dispatch.rs
+++ b/openvmm/openvmm_core/src/worker/dispatch.rs
@@ -2213,24 +2213,35 @@ impl InitializedVm {
                     chipset_builder
                         .arc_mutex_device(device_name)
                         .try_add(|services| {
+                            let mut register_mmio = services.register_mmio();
+                            #[cfg(guest_arch = "x86_64")]
+                            let mut register_pio = services.register_pio();
                             let root_port_definitions = rc
                                 .ports
                                 .iter()
                                 .map(pcie_topology::build_port_definition)
                                 .collect();
-                            GenericPcieRootComplex::builder(
-                                &mut services.register_mmio(),
+                            let builder = GenericPcieRootComplex::builder(
+                                &mut register_mmio,
                                 rc.start_bus..=rc.end_bus,
                                 ranges.ecam_range,
-                            )
-                            .root_ports(
-                                root_port_definitions,
-                                &msi_conn.msi_target(rc_bus_range, 0),
-                            )
-                            .first_port_device_number(root_port_start_device)
-                            .reserved_device_numbers(reserved_device_numbers)
-                            .chbcr_range(chbcr_range)
-                            .build()
+                            );
+                            #[cfg(guest_arch = "x86_64")]
+                            let builder =
+                                if rc.segment == 0 && rc.start_bus == 0 && rc.end_bus == u8::MAX {
+                                    builder.pci_config_io(&mut register_pio)
+                                } else {
+                                    builder
+                                };
+                            builder
+                                .root_ports(
+                                    root_port_definitions,
+                                    &msi_conn.msi_target(rc_bus_range, 0),
+                                )
+                                .first_port_device_number(root_port_start_device)
+                                .reserved_device_numbers(reserved_device_numbers)
+                                .chbcr_range(chbcr_range)
+                                .build()
                         })?;
 
                 // Defer MSI wiring to after IOMMU setup so that

--- a/openvmm/openvmm_entry/src/cli_args.rs
+++ b/openvmm/openvmm_entry/src/cli_args.rs
@@ -1031,7 +1031,7 @@ flags:
     /// own hypervisor.
     ///
     /// Only supported on x86_64, and only by backends that support nested
-    /// virtualization (currently WHP and KVM). Requires host support.
+    /// virtualization (currently WHP, KVM, and MSHV). Requires host support.
     #[clap(long)]
     pub nested_virt: bool,
 

--- a/openvmm/openvmm_entry/src/lib.rs
+++ b/openvmm/openvmm_entry/src/lib.rs
@@ -1231,6 +1231,16 @@ async fn vm_config_from_command_line(
 
     let mut chipset = VmManifestBuilder::new(base_chipset_type(opt), arch);
 
+    if arch == MachineArch::X86_64
+        && pcie_root_complexes.iter().any(|root_complex| {
+            root_complex.segment == 0
+                && root_complex.start_bus == 0
+                && root_complex.end_bus == u8::MAX
+        })
+    {
+        chipset = chipset.with_legacy_pci_config_io();
+    }
+
     if framebuffer.is_some() {
         chipset = chipset.with_framebuffer();
     }

--- a/openvmm/openvmm_entry/src/ttrpc/mod.rs
+++ b/openvmm/openvmm_entry/src/ttrpc/mod.rs
@@ -876,8 +876,24 @@ impl VmService {
             }
         };
 
+        // Build the PCIe topology before the chipset manifest so full-domain
+        // legacy PCI configuration ownership can be coordinated.
+        let pcie = if let Some(pcie) = req_config.pcie.take() {
+            build_pcie_topology(pcie, &registry).await?
+        } else {
+            BuiltPcieTopology::default()
+        };
+
         let mut chipset_builder =
             VmManifestBuilder::new(base_chipset_type, arch).with_serial(ports);
+        if arch == vm_manifest_builder::MachineArch::X86_64
+            && pcie
+                .root_complexes
+                .iter()
+                .any(|rc| rc.segment == 0 && rc.start_bus == 0 && rc.end_bus == u8::MAX)
+        {
+            chipset_builder = chipset_builder.with_legacy_pci_config_io();
+        }
         if let Some((base_template, secure_boot_enabled)) = uefi_config {
             // The UEFI helper device backs the firmware's variable store and
             // runtime services, so it is required for a UEFI boot. The store is
@@ -940,14 +956,6 @@ impl VmService {
             .map(|c| c.processor_count)
             .unwrap_or(1);
         let arch = parse_arch_topology_overrides(req_config.processor_config.as_ref())?;
-
-        // Build the PCIe topology (root complexes, switches, and the devices
-        // attached behind their ports).
-        let pcie = if let Some(pcie) = req_config.pcie.take() {
-            build_pcie_topology(pcie, &registry).await?
-        } else {
-            BuiltPcieTopology::default()
-        };
 
         let mut config = Config {
             // TODO: devices, other stuff

--- a/petri/src/vm/openvmm/start.rs
+++ b/petri/src/vm/openvmm/start.rs
@@ -58,6 +58,17 @@ impl PetriVmConfigOpenVmm {
             rc.iommu = Some(iommu_config.clone());
         }
 
+        if arch == MachineArch::X86_64
+            && config
+                .pcie_root_complexes
+                .iter()
+                .any(|rc| rc.segment == 0 && rc.start_bus == 0 && rc.end_bus == u8::MAX)
+        {
+            config
+                .chipset_devices
+                .retain(|device| device.name != "missing-pci");
+        }
+
         // TODO: OpenHCL needs virt_whp support
         // TODO: PCAT needs vga device support
         // TODO: arm64 is broken?

--- a/vm/devices/pci/pcie/src/root.rs
+++ b/vm/devices/pci/pcie/src/root.rs
@@ -25,6 +25,9 @@ use chipset_device::pci::ByteEnabledDwordWrite;
 use chipset_device::pci::PciConfigAccessType;
 use chipset_device::pci::PciConfigAddress;
 use chipset_device::pci::PciConfigByteEnable;
+use chipset_device::pio::ControlPortIoIntercept;
+use chipset_device::pio::PortIoIntercept;
+use chipset_device::pio::RegisterPortIoIntercept;
 use chipset_device::poll_device::PollDevice;
 use cxl_spec::CxlComponentRegisters;
 use inspect::Inspect;
@@ -79,6 +82,12 @@ pub struct GenericPcieRootComplex {
     end_bus: u8,
     /// Intercept control for the ECAM MMIO region.
     ecam: Box<dyn ControlMmioIntercept>,
+    /// Intercept controls for legacy PCI configuration I/O, when present.
+    #[inspect(skip)]
+    pio: Option<(
+        Box<dyn ControlPortIoIntercept>,
+        Box<dyn ControlPortIoIntercept>,
+    )>,
     /// Intercept control for the CHBCR MMIO region, when present.
     chbcr: Option<Box<dyn ControlMmioIntercept>>,
     /// CXL Component Registers backing CHBCR accesses in CXL mode.
@@ -91,6 +100,8 @@ pub struct GenericPcieRootComplex {
     reserved_device_numbers: u32,
     /// Bus config space accesses handler.
     bus_cfg_handler: PciBusCfgAccessHandler,
+    /// Legacy PCI configuration address register.
+    pio_address: u32,
 }
 
 /// A device occupying a slot on the root complex bus.
@@ -134,6 +145,7 @@ pub struct DownstreamPortInfo {
 /// settings, then call [`build`](GenericPcieRootComplexBuilder::build).
 pub struct GenericPcieRootComplexBuilder<'a> {
     register_mmio: &'a mut dyn RegisterMmioIntercept,
+    register_pio: Option<&'a mut dyn RegisterPortIoIntercept>,
     bus_range: RangeInclusive<u8>,
     ecam_range: MemoryRange,
     root_ports: Option<(Vec<GenericPciePortDefinition>, &'a MsiTarget)>,
@@ -148,6 +160,12 @@ fn device_number_is_reserved(reserved_device_numbers: u32, device: u8) -> bool {
 }
 
 impl<'a> GenericPcieRootComplexBuilder<'a> {
+    /// Enable legacy x86 PCI configuration access through ports CF8/CFC.
+    pub fn pci_config_io(mut self, register_pio: &'a mut dyn RegisterPortIoIntercept) -> Self {
+        self.register_pio = Some(register_pio);
+        self
+    }
+
     /// Add root ports to the complex.
     ///
     /// `msi_target` is the MSI target for all root ports; the caller is
@@ -199,6 +217,7 @@ impl<'a> GenericPcieRootComplexBuilder<'a> {
     pub fn build(self) -> Result<GenericPcieRootComplex, InvalidRootComplexError> {
         let Self {
             register_mmio,
+            register_pio,
             bus_range,
             ecam_range,
             root_ports,
@@ -212,6 +231,14 @@ impl<'a> GenericPcieRootComplexBuilder<'a> {
 
         let mut ecam = register_mmio.new_io_region("ecam", ecam_range.len());
         ecam.map(ecam_range.start());
+
+        let pio = register_pio.map(|register_pio| {
+            let mut address = register_pio.new_io_region("address", 4);
+            let mut data = register_pio.new_io_region("data", 4);
+            address.map(0xcf8);
+            data.map(0xcfc);
+            (address, data)
+        });
 
         // Presence of CHBCR range indicates CXL mode, which needs a component-register
         // backing object even if no capability payload blocks are registered yet.
@@ -286,11 +313,13 @@ impl<'a> GenericPcieRootComplexBuilder<'a> {
             start_bus,
             end_bus,
             ecam,
+            pio,
             chbcr,
             cxl_component_registers,
             devices,
             reserved_device_numbers,
             bus_cfg_handler: PciBusCfgAccessHandler::new(),
+            pio_address: 0,
         })
     }
 }
@@ -310,6 +339,7 @@ impl GenericPcieRootComplex {
 
         GenericPcieRootComplexBuilder {
             register_mmio,
+            register_pio: None,
             bus_range,
             ecam_range,
             root_ports: None,
@@ -541,6 +571,7 @@ impl ChangeDeviceState for GenericPcieRootComplex {
     async fn stop(&mut self) {}
 
     async fn reset(&mut self) {
+        self.pio_address = 0;
         for (_, d) in self.devices.iter_mut() {
             if let BusDevice::RootPort { port, .. } = d {
                 port.port.cfg_space.reset();
@@ -554,8 +585,84 @@ impl ChipsetDevice for GenericPcieRootComplex {
         Some(self)
     }
 
+    fn supports_pio(&mut self) -> Option<&mut dyn PortIoIntercept> {
+        self.pio.is_some().then_some(self)
+    }
+
     fn supports_poll_device(&mut self) -> Option<&mut dyn PollDevice> {
         Some(self)
+    }
+}
+
+impl PortIoIntercept for GenericPcieRootComplex {
+    fn io_read(&mut self, io_port: u16, data: &mut [u8]) -> IoResult {
+        let Some((address_control, data_control)) = &self.pio else {
+            return IoResult::Err(IoError::InvalidRegister);
+        };
+        let byte_enable = match PciConfigByteEnable::from_offset_len(io_port, data.len()) {
+            Ok(byte_enable) => byte_enable,
+            Err(err) => return IoResult::Err(err),
+        };
+        let mut value_u32 = if address_control.offset_of(io_port).is_some() {
+            self.pio_address
+        } else if data_control.offset_of(io_port).is_some() {
+            let Some(address) = self.pio_config_address() else {
+                data.fill(0xff);
+                return IoResult::Ok;
+            };
+            let mut value_u32 = !0;
+            let mut value = ByteEnabledDwordRead::new(&mut value_u32, byte_enable);
+            let mut callback =
+                PciBusCfgAccessCallbackView::new(&self.start_bus, &self.end_bus, &mut self.devices);
+            let result = self
+                .bus_cfg_handler
+                .read(address, value.reborrow(), &mut callback);
+            if !matches!(result, IoResult::Ok) {
+                return result;
+            }
+            value_u32
+        } else {
+            return IoResult::Err(IoError::InvalidRegister);
+        };
+        ByteEnabledDwordRead::new(&mut value_u32, byte_enable).fill_intercept_buffer(data);
+        IoResult::Ok
+    }
+
+    fn io_write(&mut self, io_port: u16, data: &[u8]) -> IoResult {
+        let Some((address_control, data_control)) = &self.pio else {
+            return IoResult::Err(IoError::InvalidRegister);
+        };
+        let byte_enable = match PciConfigByteEnable::from_offset_len(io_port, data.len()) {
+            Ok(byte_enable) => byte_enable,
+            Err(err) => return IoResult::Err(err),
+        };
+        let value = ByteEnabledDwordWrite::from_intercept_buffer(byte_enable, data);
+        if address_control.offset_of(io_port).is_some() {
+            self.pio_address = value.merge(self.pio_address) & 0x80ff_fffc;
+            IoResult::Ok
+        } else if data_control.offset_of(io_port).is_some() {
+            let Some(address) = self.pio_config_address() else {
+                return IoResult::Ok;
+            };
+            let mut callback =
+                PciBusCfgAccessCallbackView::new(&self.start_bus, &self.end_bus, &mut self.devices);
+            self.bus_cfg_handler.write(address, value, &mut callback)
+        } else {
+            IoResult::Err(IoError::InvalidRegister)
+        }
+    }
+}
+
+impl GenericPcieRootComplex {
+    fn pio_config_address(&self) -> Option<PciConfigAddress> {
+        if self.pio_address & (1 << 31) == 0 {
+            return None;
+        }
+        PciConfigAddress::new(
+            (self.pio_address >> 16) as u8,
+            (self.pio_address >> 8) as u8,
+            ((self.pio_address & 0xfc) / 4) as u16,
+        )
     }
 }
 
@@ -898,6 +1005,9 @@ mod save_restore {
             /// Optional CXL component-register state for CHBCR-backed root complexes.
             #[mesh(4)]
             pub cxl_component_registers: Option<CxlComponentRegistersSavedState>,
+            /// Legacy PCI configuration address register.
+            #[mesh(5)]
+            pub pio_address: u32,
         }
     }
 
@@ -926,6 +1036,7 @@ mod save_restore {
                     .as_mut()
                     .map(|regs| regs.save())
                     .transpose()?,
+                pio_address: self.pio_address,
             })
         }
 
@@ -935,7 +1046,10 @@ mod save_restore {
                 end_bus,
                 ports,
                 cxl_component_registers,
+                pio_address,
             } = state;
+
+            self.pio_address = pio_address;
 
             // Validate that bus numbers match
             if start_bus != self.start_bus || end_bus != self.end_bus {
@@ -1155,6 +1269,42 @@ mod tests {
             .root_ports(port_defs, &msi_conn.msi_target(rc_bus_range, 0))
             .build()
             .unwrap()
+    }
+
+    fn instantiate_root_complex_with_pio() -> GenericPcieRootComplex {
+        let port_defs = vec![GenericPciePortDefinition {
+            name: "test-port".into(),
+            devfn: None,
+            hotplug: false,
+            settings: PciePortSettings::default(),
+        }];
+        let mut register_mmio = TestPcieMmioRegistration {};
+        let mut register_pio = TestPciePioRegistration;
+        let ecam = MemoryRange::new(0..ecam_size_from_bus_numbers(0, 1));
+        let rc_bus_range = AssignedBusRange::new();
+        rc_bus_range.set_bus_range(0, 1);
+        let msi_conn = pci_core::msi::MsiConnection::new();
+        GenericPcieRootComplex::builder(&mut register_mmio, 0..=1, ecam)
+            .pci_config_io(&mut register_pio)
+            .root_ports(port_defs, &msi_conn.msi_target(rc_bus_range, 0))
+            .build()
+            .unwrap()
+    }
+
+    #[test]
+    fn test_pio_config_read() {
+        let mut rc = instantiate_root_complex_with_pio();
+        assert!(matches!(
+            rc.io_write(0xcf8, &0x8000_0000u32.to_le_bytes()),
+            IoResult::Ok
+        ));
+
+        let mut value = [0; 4];
+        assert!(matches!(rc.io_read(0xcfc, &mut value), IoResult::Ok));
+        assert_eq!(
+            u32::from_le_bytes(value),
+            (ROOT_PORT_DEVICE_ID as u32) << 16 | VENDOR_ID as u32
+        );
     }
 
     fn instantiate_root_complex_with_chbcr(

--- a/vm/devices/pci/pcie/src/test_helpers.rs
+++ b/vm/devices/pci/pcie/src/test_helpers.rs
@@ -6,6 +6,8 @@ use chipset_device::mmio::ControlMmioIntercept;
 use chipset_device::mmio::RegisterMmioIntercept;
 use chipset_device::pci::ByteEnabledDwordRead;
 use chipset_device::pci::ByteEnabledDwordWrite;
+use chipset_device::pio::ControlPortIoIntercept;
+use chipset_device::pio::RegisterPortIoIntercept;
 use pci_bus::GenericPciBusDevice;
 use std::fmt::Debug;
 
@@ -60,6 +62,47 @@ impl ControlMmioIntercept for TestPcieControlMmioIntercept {
 
     fn region_name(&self) -> &str {
         "???"
+    }
+}
+
+pub struct TestPciePioRegistration;
+
+impl RegisterPortIoIntercept for TestPciePioRegistration {
+    fn new_io_region(&mut self, _debug_name: &str, len: u16) -> Box<dyn ControlPortIoIntercept> {
+        Box::new(TestPcieControlPioIntercept { mapping: None, len })
+    }
+}
+
+struct TestPcieControlPioIntercept {
+    mapping: Option<u16>,
+    len: u16,
+}
+
+impl ControlPortIoIntercept for TestPcieControlPioIntercept {
+    fn map(&mut self, addr: u16) {
+        assert!(self.mapping.replace(addr).is_none());
+    }
+
+    fn unmap(&mut self) {
+        assert!(self.mapping.take().is_some());
+    }
+
+    fn addr(&self) -> Option<u16> {
+        self.mapping
+    }
+
+    fn len(&self) -> u16 {
+        self.len
+    }
+
+    fn offset_of(&self, addr: u16) -> Option<u16> {
+        let base = self.mapping?;
+        let end = base.checked_add(self.len)?;
+        (base..end).contains(&addr).then_some(addr - base)
+    }
+
+    fn region_name(&self) -> &str {
+        "test-pio"
     }
 }
 

--- a/vmm_core/virt_mshv/src/lib.rs
+++ b/vmm_core/virt_mshv/src/lib.rs
@@ -165,29 +165,47 @@ impl<'a> MshvProtoPartition<'a> {
             .create_vcpu(0)
             .map_err(|e| ErrorInner::CreateVcpu(e.into()))?;
 
-        // Install intercepts required by both architectures.
-        vmfd.install_intercept(mshv_install_intercept {
-            access_type_mask: HV_INTERCEPT_ACCESS_MASK_EXECUTE,
-            intercept_type: hvdef::hypercall::HvInterceptType::HvInterceptTypeHypercall.0,
-            intercept_parameter: Default::default(),
-        })
-        .map_err(|e| ErrorInner::InstallIntercept(e.into()))?;
+        // Nested partitions leave HV#1 handling to L0. OpenVMM's intercepts
+        // service its VMBus server, which is unavailable in this mode.
+        if !config.nested_virt {
+            vmfd.install_intercept(mshv_install_intercept {
+                access_type_mask: HV_INTERCEPT_ACCESS_MASK_EXECUTE,
+                intercept_type: hvdef::hypercall::HvInterceptType::HvInterceptTypeHypercall.0,
+                intercept_parameter: Default::default(),
+            })
+            .map_err(|e| {
+                ErrorInner::InstallIntercept(
+                    hvdef::hypercall::HvInterceptType::HvInterceptTypeHypercall,
+                    e.into(),
+                )
+            })?;
 
-        vmfd.install_intercept(mshv_install_intercept {
-            access_type_mask: HV_INTERCEPT_ACCESS_MASK_EXECUTE,
-            intercept_type:
-                hvdef::hypercall::HvInterceptType::HvInterceptTypeUnknownSynicConnection.0,
-            intercept_parameter: Default::default(),
-        })
-        .map_err(|e| ErrorInner::InstallIntercept(e.into()))?;
+            vmfd.install_intercept(mshv_install_intercept {
+                access_type_mask: HV_INTERCEPT_ACCESS_MASK_EXECUTE,
+                intercept_type:
+                    hvdef::hypercall::HvInterceptType::HvInterceptTypeUnknownSynicConnection.0,
+                intercept_parameter: Default::default(),
+            })
+            .map_err(|e| {
+                ErrorInner::InstallIntercept(
+                    hvdef::hypercall::HvInterceptType::HvInterceptTypeUnknownSynicConnection,
+                    e.into(),
+                )
+            })?;
 
-        vmfd.install_intercept(mshv_install_intercept {
-            access_type_mask: HV_INTERCEPT_ACCESS_MASK_EXECUTE,
-            intercept_type:
-                hvdef::hypercall::HvInterceptType::HvInterceptTypeRetargetInterruptWithUnknownDeviceId.0,
-            intercept_parameter: Default::default(),
-        })
-        .map_err(|e| ErrorInner::InstallIntercept(e.into()))?;
+            vmfd.install_intercept(mshv_install_intercept {
+                access_type_mask: HV_INTERCEPT_ACCESS_MASK_EXECUTE,
+                intercept_type:
+                    hvdef::hypercall::HvInterceptType::HvInterceptTypeRetargetInterruptWithUnknownDeviceId.0,
+                intercept_parameter: Default::default(),
+            })
+            .map_err(|e| {
+                ErrorInner::InstallIntercept(
+                    hvdef::hypercall::HvInterceptType::HvInterceptTypeRetargetInterruptWithUnknownDeviceId,
+                    e.into(),
+                )
+            })?;
+        }
 
         // Set up a signal for forcing vcpufd.run() to exit with EINTR.
         static SIGNAL_HANDLER_INIT: Once = Once::new();
@@ -809,8 +827,8 @@ enum ErrorInner {
     },
     #[error("failed to reset state")]
     ResetState(#[source] Box<virt::state::StateError<Error>>),
-    #[error("install intercept failed")]
-    InstallIntercept(#[source] KernelError),
+    #[error("failed to install {0:?} intercept")]
+    InstallIntercept(hvdef::hypercall::HvInterceptType, #[source] KernelError),
     #[cfg(guest_arch = "x86_64")]
     #[error("failed to register cpuid override")]
     RegisterCpuid(#[source] KernelError),
@@ -889,6 +907,13 @@ fn common_synthetic_features() -> hvdef::HvPartitionSyntheticProcessorFeatures {
         .with_access_intr_ctrl_regs(true)
         .with_access_hypercall_regs(true)
         .with_access_vp_index(true)
+        // access_vp_regs enables HvCallGetVpRegisters / HvCallSetVpRegisters
+        // for the guest. cloud-hypervisor sets this unconditionally in
+        // `make_default_synthetic_features_mask`, and it is required for
+        // nested-virt L1 guests to be recognized as parent partitions by
+        // the mshv Linux driver (which gates /dev/mshv on the
+        // create_partitions privilege that L0 mshv derives from this bit).
+        .with_access_vp_regs(true)
         .with_fast_hypercall_output(true)
         .with_direct_synthetic_timers(true)
         .with_extended_processor_masks(true)

--- a/vmm_core/virt_mshv/src/x86_64/mod.rs
+++ b/vmm_core/virt_mshv/src/x86_64/mod.rs
@@ -115,34 +115,53 @@ impl virt::Hypervisor for LinuxMshv {
             vm_topology::processor::x86::ApicMode::X2ApicSupported
                 | vm_topology::processor::x86::ApicMode::X2ApicEnabled
         );
-        let create_args =
-            partition_create_args(snp, x2apic, config.processor_topology.smt_enabled());
+        let create_args = partition_create_args(PartitionCreateOptions {
+            snp,
+            x2apic,
+            smt: config.processor_topology.smt_enabled(),
+            nested: config.nested_virt,
+        });
 
         let vmfd = create_vm_with_retry(&self.mshv, &create_args)?;
 
         // Set synthetic processor features before initialization when the
         // guest interface is configured. SNP partitions require the smaller
         // early-property feature set accepted by the hypervisor.
-        if config.hv_config.is_some() || snp {
-            let synthetic_features = if snp {
-                snp_synthetic_features()
+        if config.hv_config.is_some() || snp || config.nested_virt {
+            let synthetic_features_mask = if snp {
+                u64::from(snp_synthetic_features())
+            } else if config.nested_virt {
+                // Limit the mask to features L0 reports as assignable.
+                self.mshv.make_default_synthetic_features_mask()
             } else {
-                common_synthetic_features()
-                    .with_access_partition_reference_tsc(true)
-                    .with_access_guest_idle_reg(true)
-                    .with_access_frequency_regs(true)
-                    .with_enable_extended_gva_ranges_for_flush_virtual_address_list(true)
+                u64::from(
+                    common_synthetic_features()
+                        .with_access_partition_reference_tsc(true)
+                        .with_access_guest_idle_reg(true)
+                        .with_access_frequency_regs(true)
+                        .with_enable_extended_gva_ranges_for_flush_virtual_address_list(true),
+                )
             };
 
             vmfd.set_partition_property(
                 HvPartitionPropertyCode::SyntheticProcFeatures.0,
-                u64::from(synthetic_features),
+                synthetic_features_mask,
             )
             .map_err(|e| ErrorInner::SetPartitionProperty(e.into()))?;
         }
 
         vmfd.initialize()
             .map_err(|e| ErrorInner::CreateVMInitFailed(e.into()))?;
+
+        // Guest hypervisors probe architectural MSRs that L0 may not virtualize.
+        if config.nested_virt {
+            vmfd.set_partition_property(
+                HvPartitionPropertyCode::UnimplementedMsrAction.0,
+                mshv_bindings::hv_unimplemented_msr_action_HV_UNIMPLEMENTED_MSR_ACTION_IGNORE_WRITE_READ_ZERO
+                    as u64,
+            )
+            .map_err(|e| ErrorInner::SetPartitionProperty(e.into()))?;
+        }
 
         if snp {
             let snp_policy = igvm_snp_config.as_ref().map_or_else(
@@ -206,26 +225,37 @@ impl virt::Hypervisor for LinuxMshv {
         proto.isolation = isolation;
         Ok(proto)
     }
+
+    fn recognizes_nested_virt(&self) -> bool {
+        true
+    }
 }
 
-fn partition_create_args(
+struct PartitionCreateOptions {
     snp: bool,
     x2apic: bool,
     smt: bool,
+    nested: bool,
+}
+
+fn partition_create_args(
+    options: PartitionCreateOptions,
 ) -> mshv_bindings::mshv_create_partition_v2 {
     let mut pt_flags =
         1 << mshv_bindings::MSHV_PT_BIT_LAPIC | 1 << mshv_bindings::MSHV_PT_BIT_GPA_SUPER_PAGES;
 
-    if snp || x2apic {
+    if options.snp || options.x2apic {
         pt_flags |= 1 << mshv_bindings::MSHV_PT_BIT_X2APIC;
     }
-    if smt {
+    if options.smt {
         pt_flags |= 1 << mshv_bindings::MSHV_PT_BIT_SMT_ENABLED_GUEST;
     }
-
+    if options.nested {
+        pt_flags |= 1 << mshv_bindings::MSHV_PT_BIT_NESTED_VIRTUALIZATION;
+    }
     mshv_bindings::mshv_create_partition_v2 {
         pt_flags: pt_flags | 1 << mshv_bindings::MSHV_PT_BIT_CPU_AND_XSAVE_FEATURES,
-        pt_isolation: if snp {
+        pt_isolation: if options.snp {
             mshv_bindings::MSHV_PT_ISOLATION_SNP as u64
         } else {
             mshv_bindings::MSHV_PT_ISOLATION_NONE as u64
@@ -389,7 +419,7 @@ impl MshvProtoPartition<'_> {
             xsaves_state_bv_broken: false,
             dr6_tsx_broken: false,
             nxe_forced_on: false,
-            nested_virt: false,
+            nested_virt: self.config.nested_virt,
         })
     }
 
@@ -1553,7 +1583,12 @@ mod tests {
 
     #[test]
     fn snp_partition_creation_uses_isolation_flags() {
-        let args = partition_create_args(true, false, false);
+        let args = partition_create_args(PartitionCreateOptions {
+            snp: true,
+            x2apic: false,
+            smt: false,
+            nested: false,
+        });
         let pt_isolation = args.pt_isolation;
         let pt_num_cpu_fbanks = args.pt_num_cpu_fbanks;
         let pt_cpu_fbanks = args.pt_cpu_fbanks;
@@ -1586,7 +1621,12 @@ mod tests {
 
     #[test]
     fn ordinary_partition_creation_keeps_feature_banks() {
-        let args = partition_create_args(false, false, true);
+        let args = partition_create_args(PartitionCreateOptions {
+            snp: false,
+            x2apic: false,
+            smt: true,
+            nested: false,
+        });
         let pt_isolation = args.pt_isolation;
         let pt_num_cpu_fbanks = args.pt_num_cpu_fbanks;
 
@@ -1600,6 +1640,10 @@ mod tests {
             0
         );
         assert_eq!(args.pt_flags & 1 << mshv_bindings::MSHV_PT_BIT_X2APIC, 0);
+        assert_eq!(
+            args.pt_flags & 1 << mshv_bindings::MSHV_PT_BIT_NESTED_VIRTUALIZATION,
+            0
+        );
         assert_ne!(
             args.pt_flags & 1 << mshv_bindings::MSHV_PT_BIT_GPA_SUPER_PAGES,
             0
@@ -1607,6 +1651,21 @@ mod tests {
         assert_eq!(
             pt_num_cpu_fbanks,
             mshv_bindings::MSHV_NUM_CPU_FEATURES_BANKS as u16
+        );
+    }
+
+    #[test]
+    fn nested_partition_creation_sets_nested_virtualization_flag() {
+        let args = partition_create_args(PartitionCreateOptions {
+            snp: false,
+            x2apic: false,
+            smt: false,
+            nested: true,
+        });
+
+        assert_ne!(
+            args.pt_flags & 1 << mshv_bindings::MSHV_PT_BIT_NESTED_VIRTUALIZATION,
+            0
         );
     }
 }

--- a/vmm_core/vm_manifest_builder/src/lib.rs
+++ b/vmm_core/vm_manifest_builder/src/lib.rs
@@ -80,6 +80,7 @@ pub struct VmManifestBuilder {
     guest_watchdog: bool,
     psp: bool,
     platform_pm_timer_assist: bool,
+    legacy_pci_config_io: bool,
     uefi: Option<UefiManifest>,
     debugcon: Option<(Resource<SerialBackendHandle>, u16)>,
     vmbus: bool,
@@ -292,6 +293,7 @@ impl VmManifestBuilder {
             guest_watchdog: false,
             psp: false,
             platform_pm_timer_assist: false,
+            legacy_pci_config_io: false,
             uefi: None,
             debugcon: None,
             vmbus,
@@ -402,6 +404,12 @@ impl VmManifestBuilder {
     /// platform-specific resolver registered with the resource resolver.
     pub fn with_platform_pm_timer_assist(mut self) -> Self {
         self.platform_pm_timer_assist = true;
+        self
+    }
+
+    /// Mark legacy PCI configuration I/O as provided by a PCIe root complex.
+    pub fn with_legacy_pci_config_io(mut self) -> Self {
+        self.legacy_pci_config_io = true;
         self
     }
 
@@ -531,6 +539,9 @@ impl VmManifestBuilder {
                         self.serial,
                     )?
                     .attach_missing_arch_ports(self.arch, false);
+                if !self.legacy_pci_config_io {
+                    result.attach_missing_pci_config_ports(self.arch);
+                }
                 if let Some(recv) = self.battery_status_recv {
                     result.attach_battery(self.arch, recv);
                 }
@@ -575,11 +586,13 @@ impl VmManifestBuilder {
                         false,
                         self.serial,
                     )?
-                    .attach_missing_arch_ports(self.arch, false)
+                    .attach_missing_arch_ports(self.arch, false);
+                if !self.legacy_pci_config_io {
                     // Linux probes legacy PCI configuration ports even when
                     // PCIe ECAM is available. Absorb those probes as missing
                     // devices instead of tracing them as unknown PIO.
-                    .attach_missing_pci_config_ports(self.arch);
+                    result.attach_missing_pci_config_ports(self.arch);
+                }
                 if self.guest_watchdog {
                     result.attach_guest_watchdog();
                 }
@@ -615,6 +628,9 @@ impl VmManifestBuilder {
                         self.serial,
                     )?
                     .attach_missing_arch_ports(self.arch, true);
+                if !self.legacy_pci_config_io {
+                    result.attach_missing_pci_config_ports(self.arch);
+                }
                 if let Some(recv) = self.battery_status_recv {
                     result.attach_battery(self.arch, recv);
                 }
@@ -989,13 +1005,6 @@ impl VmChipsetResult {
                         .claim_pio("port61", 0x61..=0x61)
                         .into_resource(),
                 },
-                ChipsetDeviceHandle {
-                    name: "missing-pci".to_owned(),
-                    resource: MissingDevHandle::new()
-                        .claim_pio("address", 0xcf8..=0xcfb)
-                        .claim_pio("data", 0xcfc..=0xcff)
-                        .into_resource(),
-                },
                 // Linux will probe 0x87 during boot to determine if there the DMA
                 // device is present
                 ChipsetDeviceHandle {
@@ -1067,6 +1076,46 @@ mod tests {
         assert_eq!(
             serial_pl011.map(|handle| handle.debugger_mode),
             [true, false]
+        );
+    }
+
+    #[test]
+    fn legacy_pci_config_io_omits_missing_pci_ports() {
+        let manifest =
+            VmManifestBuilder::new(BaseChipsetType::EnlightenedLinuxDirect, MachineArch::X86_64)
+                .build()
+                .unwrap();
+        assert!(
+            manifest
+                .chipset_devices
+                .iter()
+                .any(|device| device.name == "missing-pci")
+        );
+
+        let manifest =
+            VmManifestBuilder::new(BaseChipsetType::EnlightenedLinuxDirect, MachineArch::X86_64)
+                .with_legacy_pci_config_io()
+                .build()
+                .unwrap();
+        assert!(
+            !manifest
+                .chipset_devices
+                .iter()
+                .any(|device| device.name == "missing-pci")
+        );
+    }
+
+    #[test]
+    fn missing_pci_ports_are_kept_without_root_complex_owner() {
+        let manifest =
+            VmManifestBuilder::new(BaseChipsetType::HyperVGen2LinuxDirect, MachineArch::X86_64)
+                .build()
+                .unwrap();
+        assert!(
+            manifest
+                .chipset_devices
+                .iter()
+                .any(|device| device.name == "missing-pci")
         );
     }
 }


### PR DESCRIPTION
Update MSHV bindings to 0.7.1 and configure nested partition features. Add legacy CF8/CFC PCI configuration I/O for the segment-zero PCIe root complex, coordinate manifest fallback ownership, and address related Linux PCIe test and review fixes.

limit legacy I/O to full bus domains

Keep ECAM enabled for every PCIe root complex. Expose legacy CF8/CFC configuration I/O only when one segment-zero root complex owns the full bus range from 0 through 255.

This preserves Azure Linux compatibility for full-domain topologies without hiding buses in partial or multi-root-complex configurations.