### PR TITLE
openvmm: extend rpc interface for virtio-net and virtio-fs devices

### DIFF
--- a/openvmm/openvmm_entry/src/ttrpc/mod.rs
+++ b/openvmm/openvmm_entry/src/ttrpc/mod.rs
@@ -1061,14 +1061,7 @@ impl VmService {
             }
 
             for virtiofs in devices_config.virtiofs_config {
-                let resource = virtio_resources::fs::VirtioFsHandle {
-                    tag: virtiofs.tag,
-                    fs: virtio_resources::fs::VirtioFsBackend::HostFs {
-                        root_path: virtiofs.root_path,
-                        mount_options: String::new(),
-                    },
-                }
-                .into_resource();
+                let resource = build_virtio_fs(virtiofs)?.into_resource();
                 // Use VPCI when possible (currently only on Windows and macOS due
                 // to KVM backend limitations).
                 if cfg!(windows) || cfg!(target_os = "macos") {
@@ -1593,6 +1586,7 @@ fn parse_port_config(port: vmservice::PortConfig) -> anyhow::Result<HostPortConf
         host_port,
         guest_port,
         protocol,
+        host_address,
     } = port;
     let protocol = if protocol == vmservice::IpProtocol::Tcp as i32 {
         HostPortProtocol::Tcp
@@ -1603,7 +1597,16 @@ fn parse_port_config(port: vmservice::PortConfig) -> anyhow::Result<HostPortConf
     };
     Ok(HostPortConfig {
         protocol,
-        host_address: None,
+        host_address: if host_address.is_empty() {
+            None
+        } else {
+            Some(
+                host_address
+                    .parse::<std::net::IpAddr>()
+                    .context("invalid host address")?
+                    .into(),
+            )
+        },
         host_port: HostPort::Fixed(host_port.try_into().context("host port out of range")?),
         guest_port: guest_port.try_into().context("guest port out of range")?,
     })
@@ -2112,34 +2115,46 @@ async fn build_virtio_device(
             virtio_resources::console::VirtioConsoleHandle { backend }.into_resource()
         }
         Kind::VhostUser(vhost_user) => build_vhost_user_device(vhost_user)?,
-        Kind::Fs(vmservice::VirtioFs { tag, root_path }) => {
-            const VIRTIO_FS_TAG_LEN: usize = 36;
-            anyhow::ensure!(!tag.is_empty(), "virtio-fs tag must not be empty");
-            anyhow::ensure!(
-                !tag.contains('\0'),
-                "virtio-fs tag must not contain NUL bytes"
-            );
-            anyhow::ensure!(
-                tag.len() <= VIRTIO_FS_TAG_LEN,
-                "virtio-fs tag exceeds the {VIRTIO_FS_TAG_LEN}-byte protocol limit"
-            );
-            anyhow::ensure!(
-                !root_path.is_empty(),
-                "virtio-fs root path must not be empty"
-            );
-            anyhow::ensure!(
-                !root_path.contains('\0'),
-                "virtio-fs root path must not contain NUL bytes"
-            );
-            virtio_resources::fs::VirtioFsHandle {
-                tag,
-                fs: virtio_resources::fs::VirtioFsBackend::HostFs {
-                    root_path,
-                    mount_options: String::new(),
-                },
-            }
-            .into_resource()
-        }
+        Kind::Fs(config) => build_virtio_fs(config)?.into_resource(),
+    })
+}
+
+fn build_virtio_fs(
+    config: vmservice::VirtioFs,
+) -> anyhow::Result<virtio_resources::fs::VirtioFsHandle> {
+    let vmservice::VirtioFs {
+        tag,
+        root_path,
+        read_only,
+    } = config;
+    const VIRTIO_FS_TAG_LEN: usize = 36;
+    anyhow::ensure!(!tag.is_empty(), "virtio-fs tag must not be empty");
+    anyhow::ensure!(
+        !tag.contains('\0'),
+        "virtio-fs tag must not contain NUL bytes"
+    );
+    anyhow::ensure!(
+        tag.len() <= VIRTIO_FS_TAG_LEN,
+        "virtio-fs tag exceeds the {VIRTIO_FS_TAG_LEN}-byte protocol limit"
+    );
+    anyhow::ensure!(
+        !root_path.is_empty(),
+        "virtio-fs root path must not be empty"
+    );
+    anyhow::ensure!(
+        !root_path.contains('\0'),
+        "virtio-fs root path must not contain NUL bytes"
+    );
+    Ok(virtio_resources::fs::VirtioFsHandle {
+        tag,
+        fs: virtio_resources::fs::VirtioFsBackend::HostFs {
+            root_path,
+            mount_options: if read_only {
+                "ro".to_string()
+            } else {
+                String::new()
+            },
+        },
     })
 }
 

--- a/openvmm/openvmm_ttrpc_vmservice/src/vmservice.proto
+++ b/openvmm/openvmm_ttrpc_vmservice/src/vmservice.proto
@@ -794,6 +794,7 @@ message PortConfig {
     uint32 guest_port = 2;
     // The protocol to forward.
     IpProtocol protocol = 3;
+    string host_address = 4;
 }
 
 message ConsommeBackend {
@@ -813,6 +814,7 @@ message WindowsPCIDevice {
 message VirtioFs {
     string tag = 1;
     string root_path = 2;
+    bool read_only = 3;
 }
 
 message VirtioConsoleConfig {

--- a/vmm_tests/vmm_tests/tests/tests/ttrpc.rs
+++ b/vmm_tests/vmm_tests/tests/tests/ttrpc.rs
@@ -178,7 +178,7 @@ async fn test_ttrpc_interface(
             _ => "",
         };
         let probe_address = if host_address.is_empty() {
-            "127.0.0.1"
+            "0.0.0.0"
         } else {
             host_address
         };
@@ -464,15 +464,20 @@ async fn test_ttrpc_interface(
             "CreateVm should bind the requested host address"
         );
         // An explicit loopback address must not become a wildcard bind.
-        let other_address = TcpListener::bind(("127.0.0.2", host_port));
         if host_address.is_empty() {
+            #[cfg(not(windows))]
             assert_eq!(
-                other_address.unwrap_err().kind(),
+                TcpListener::bind(("127.0.0.2", host_port))
+                    .unwrap_err()
+                    .kind(),
                 std::io::ErrorKind::AddrInUse,
                 "an empty host address should retain the wildcard default"
             );
         } else {
-            drop(other_address.context("port forward unexpectedly bound another address")?);
+            drop(
+                TcpListener::bind(("127.0.0.2", host_port))
+                    .context("port forward unexpectedly bound another address")?,
+            );
         }
 
         let props = query_props().await.unwrap();

--- a/vmm_tests/vmm_tests/tests/tests/ttrpc.rs
+++ b/vmm_tests/vmm_tests/tests/tests/ttrpc.rs
@@ -25,6 +25,7 @@ use petri::ResolvedArtifact;
 use petri::pipette::cmd;
 use petri_artifacts_vmm_test::artifacts;
 use std::io::Write;
+use std::net::TcpListener;
 use std::ops::Deref;
 use std::ops::DerefMut;
 use std::path::Path;
@@ -157,6 +158,7 @@ async fn test_ttrpc_interface(
         std::fs::create_dir_all(&virtiofs_root)?;
         std::fs::create_dir_all(&hotplug_virtiofs_root)?;
         std::fs::create_dir_all(&second_hotplug_virtiofs_root)?;
+        std::fs::write(virtiofs_root.join("content"), b"boot virtio-fs share")?;
         let hvsocket_path = tempdir.path().join(format!("hvsocket-{i}"));
         let pipette_listener = if i == 0 {
             let path = format!(
@@ -170,6 +172,17 @@ async fn test_ttrpc_interface(
         };
 
         let consomme_nic_id = Guid::new_random().to_string();
+        let host_address = match i {
+            0 => "127.0.0.1",
+            1 => "::1",
+            _ => "",
+        };
+        let probe_address = if host_address.is_empty() {
+            "127.0.0.1"
+        } else {
+            host_address
+        };
+        let host_port = TcpListener::bind((probe_address, 0))?.local_addr()?.port();
 
         // On iteration 0, test `connect: true` for both serial and
         // virtio console by pre-creating listeners that the VM will
@@ -399,7 +412,12 @@ async fn test_ttrpc_interface(
                                 backend: Some(vmservice::nic_config::Backend::Consomme(
                                     vmservice::ConsommeBackend {
                                         cidr: String::new(),
-                                        ports: vec![],
+                                        ports: vec![vmservice::PortConfig {
+                                            host_port: host_port.into(),
+                                            guest_port: 80,
+                                            protocol: vmservice::IpProtocol::Tcp as i32,
+                                            host_address: host_address.to_string(),
+                                        }],
                                     },
                                 )),
                                 ..Default::default()
@@ -411,7 +429,7 @@ async fn test_ttrpc_interface(
                             virtiofs_config: vec![vmservice::VirtioFs {
                                 tag: "testfs".to_string(),
                                 root_path: virtiofs_root.to_string_lossy().into(),
-                                read_only: false,
+                                read_only: i == 0,
                             }],
                             // A SCSI controller keeps a request channel
                             // alive for the lifetime of the VM, which used
@@ -438,6 +456,25 @@ async fn test_ttrpc_interface(
             .await
             .unwrap();
 
+        assert_eq!(
+            TcpListener::bind((probe_address, host_port))
+                .unwrap_err()
+                .kind(),
+            std::io::ErrorKind::AddrInUse,
+            "CreateVm should bind the requested host address"
+        );
+        // An explicit loopback address must not become a wildcard bind.
+        let other_address = TcpListener::bind(("127.0.0.2", host_port));
+        if host_address.is_empty() {
+            assert_eq!(
+                other_address.unwrap_err().kind(),
+                std::io::ErrorKind::AddrInUse,
+                "an empty host address should retain the wildcard default"
+            );
+        } else {
+            drop(other_address.context("port forward unexpectedly bound another address")?);
+        }
+
         let props = query_props().await.unwrap();
         assert_eq!(
             props.state,
@@ -449,41 +486,57 @@ async fn test_ttrpc_interface(
             "memory/processor stats should be unset, not zeroed"
         );
 
-        // Invalid protocols exercise Consomme update/remove without binding a port.
+        // Invalid options exercise Consomme update/remove without binding a port.
         for modify_type in [vmservice::ModifyType::Update, vmservice::ModifyType::Remove] {
-            let err = client
-                .call()
-                .start(
-                    vmservice::Vm::ModifyResource,
-                    vmservice::ModifyResourceRequest {
-                        r#type: modify_type as i32,
-                        resource: Some(vmservice::modify_resource_request::Resource::NicConfig(
-                            vmservice::NicConfig {
-                                nic_id: consomme_nic_id.clone(),
-                                mac_address: "00-15-5D-12-12-12".to_string(),
-                                backend: Some(vmservice::nic_config::Backend::Consomme(
-                                    vmservice::ConsommeBackend {
-                                        cidr: String::new(),
-                                        ports: vec![vmservice::PortConfig {
-                                            host_port: 8080,
-                                            guest_port: 80,
-                                            protocol: 99,
-                                            host_address: String::new(),
-                                        }],
+            for (protocol, host_address, expected_error) in [
+                (99, "", "invalid protocol"),
+                (
+                    vmservice::IpProtocol::Tcp as i32,
+                    "not-an-ip-address",
+                    "invalid host address",
+                ),
+                (
+                    vmservice::IpProtocol::Udp as i32,
+                    "127.0.0.1:8080",
+                    "invalid host address",
+                ),
+            ] {
+                let err = client
+                    .call()
+                    .start(
+                        vmservice::Vm::ModifyResource,
+                        vmservice::ModifyResourceRequest {
+                            r#type: modify_type as i32,
+                            resource: Some(
+                                vmservice::modify_resource_request::Resource::NicConfig(
+                                    vmservice::NicConfig {
+                                        nic_id: consomme_nic_id.clone(),
+                                        mac_address: "00-15-5D-12-12-12".to_string(),
+                                        backend: Some(vmservice::nic_config::Backend::Consomme(
+                                            vmservice::ConsommeBackend {
+                                                cidr: String::new(),
+                                                ports: vec![vmservice::PortConfig {
+                                                    host_port: 8080,
+                                                    guest_port: 80,
+                                                    protocol,
+                                                    host_address: host_address.to_string(),
+                                                }],
+                                            },
+                                        )),
+                                        ..Default::default()
                                     },
-                                )),
-                                ..Default::default()
-                            },
-                        )),
-                    },
-                )
-                .await
-                .unwrap_err();
-            assert!(
-                err.message.contains("invalid protocol"),
-                "expected invalid protocol error, got: {}",
-                err.message
-            );
+                                ),
+                            ),
+                        },
+                    )
+                    .await
+                    .unwrap_err();
+                assert!(
+                    err.message.contains(expected_error),
+                    "expected {expected_error}, got: {}",
+                    err.message
+                );
+            }
         }
 
         // On iteration 0, exercise AddPcieDevice/RemovePcieDevice with
@@ -524,7 +577,7 @@ async fn test_ttrpc_interface(
                             vmservice::VirtioFs {
                                 tag: "hotplugfs".to_string(),
                                 root_path: hotplug_virtiofs_root.to_string_lossy().into(),
-                                read_only: false,
+                                read_only: true,
                             },
                         ))),
                     },
@@ -549,7 +602,12 @@ async fn test_ttrpc_interface(
                     .call()
                     .start(
                         vmservice::Vm::AddVpciDevice,
-                        virtio_fs_vpci_request(&instance_id, "vpci-fs", &hotplug_virtiofs_root),
+                        virtio_fs_vpci_request(
+                            &instance_id,
+                            "vpci-fs",
+                            &hotplug_virtiofs_root,
+                            false,
+                        ),
                     )
                     .await
                     .unwrap();
@@ -641,13 +699,20 @@ async fn test_ttrpc_interface(
                     .await?;
                     validate_pcie_config(&agent).await?;
                     #[cfg(windows)]
-                    validate_vpci_virtio_fs_hotplug(
-                        &client,
-                        &agent,
-                        &hotplug_virtiofs_root,
-                        &second_hotplug_virtiofs_root,
-                    )
-                    .await?;
+                    {
+                        mount_virtio_fs(&agent, "testfs", "/mnt/testfs").await?;
+                        validate_virtio_fs_access(&agent, "/mnt/testfs", &virtiofs_root, true)
+                            .await?;
+                        let sh = agent.unix_shell();
+                        cmd!(sh, "umount /mnt/testfs").run().await?;
+                        validate_vpci_virtio_fs_hotplug(
+                            &client,
+                            &agent,
+                            &hotplug_virtiofs_root,
+                            &second_hotplug_virtiofs_root,
+                        )
+                        .await?;
+                    }
 
                     validate_smbios(&agent).await?;
                     agent.power_off().await?;
@@ -1030,6 +1095,7 @@ fn virtio_fs_vpci_request(
     instance_id: &Guid,
     tag: &str,
     root_path: &Path,
+    read_only: bool,
 ) -> vmservice::AddVpciDeviceRequest {
     vmservice::AddVpciDeviceRequest {
         instance_id: instance_id.to_string(),
@@ -1037,7 +1103,7 @@ fn virtio_fs_vpci_request(
             vmservice::VirtioFs {
                 tag: tag.to_string(),
                 root_path: root_path.to_string_lossy().into_owned(),
-                read_only: false,
+                read_only,
             },
         ))),
     }
@@ -1060,7 +1126,7 @@ async fn validate_vpci_virtio_fs_hotplug(
         .call()
         .start(
             vmservice::Vm::AddVpciDevice,
-            virtio_fs_vpci_request(&first_instance_id, "vpci-fs-1", first_root),
+            virtio_fs_vpci_request(&first_instance_id, "vpci-fs-1", first_root, false),
         )
         .await
         .map_err(|err| anyhow::anyhow!(err.message))?;
@@ -1069,7 +1135,7 @@ async fn validate_vpci_virtio_fs_hotplug(
         .call()
         .start(
             vmservice::Vm::AddVpciDevice,
-            virtio_fs_vpci_request(&second_instance_id, "vpci-fs-2", second_root),
+            virtio_fs_vpci_request(&second_instance_id, "vpci-fs-2", second_root, true),
         )
         .await
         .map_err(|err| anyhow::anyhow!(err.message))?;
@@ -1090,6 +1156,8 @@ async fn validate_vpci_virtio_fs_hotplug(
         agent.read_file(format!("{second_mount}/content")).await? == SECOND_CONTENT,
         "second VPCI virtio-fs share returned unexpected contents"
     );
+    validate_virtio_fs_access(agent, first_mount, first_root, false).await?;
+    validate_virtio_fs_access(agent, second_mount, second_root, true).await?;
     let sh = agent.unix_shell();
     cmd!(sh, "umount {second_mount}").run().await?;
     client
@@ -1103,7 +1171,8 @@ async fn validate_vpci_virtio_fs_hotplug(
         .await
         .map_err(|err| anyhow::anyhow!(err.message))?;
     anyhow::ensure!(
-        agent.read_file(format!("{first_mount}/content")).await? == FIRST_CONTENT,
+        agent.read_file(format!("{first_mount}/content")).await?
+            == std::fs::read(first_root.join("content"))?,
         "first share stopped working after removing second share"
     );
 
@@ -1133,6 +1202,53 @@ async fn validate_vpci_virtio_fs_hotplug(
         "unexpected repeated-remove error: {}",
         err.message
     );
+    Ok(())
+}
+
+#[cfg(windows)]
+async fn validate_virtio_fs_access(
+    agent: &pipette_client::PipetteClient,
+    target: &str,
+    root: &Path,
+    read_only: bool,
+) -> anyhow::Result<()> {
+    let original = std::fs::read(root.join("content"))?;
+    anyhow::ensure!(
+        agent.read_file(format!("{target}/content")).await? == original,
+        "virtio-fs share returned unexpected contents"
+    );
+    for name in ["content", "new-file"] {
+        let path = format!("{target}/{name}");
+        if read_only {
+            // Do not mount with -o ro: the host backend must enforce the restriction.
+            let sh = agent.unix_shell();
+            let script = format!("printf modified > {path}");
+            let output = cmd!(sh, "sh -c {script}")
+                .env("LC_ALL", "C")
+                .ignore_status()
+                .output()
+                .await?;
+            anyhow::ensure!(
+                !output.status.success()
+                    && String::from_utf8_lossy(&output.stderr).contains("Read-only file system"),
+                "expected a read-only filesystem error writing {path}, got {}: {}",
+                output.status,
+                String::from_utf8_lossy(&output.stderr)
+            );
+        } else {
+            agent.write_file(&path, &b"modified"[..]).await?;
+            anyhow::ensure!(
+                std::fs::read(root.join(name))? == b"modified",
+                "writable share did not propagate guest writes to {name}"
+            );
+        }
+    }
+    if read_only {
+        anyhow::ensure!(
+            std::fs::read(root.join("content"))? == original && !root.join("new-file").exists(),
+            "guest writes modified the read-only share"
+        );
+    }
     Ok(())
 }
 

--- a/vmm_tests/vmm_tests/tests/tests/ttrpc.rs
+++ b/vmm_tests/vmm_tests/tests/tests/ttrpc.rs
@@ -411,6 +411,7 @@ async fn test_ttrpc_interface(
                             virtiofs_config: vec![vmservice::VirtioFs {
                                 tag: "testfs".to_string(),
                                 root_path: virtiofs_root.to_string_lossy().into(),
+                                read_only: false,
                             }],
                             // A SCSI controller keeps a request channel
                             // alive for the lifetime of the VM, which used
@@ -467,6 +468,7 @@ async fn test_ttrpc_interface(
                                             host_port: 8080,
                                             guest_port: 80,
                                             protocol: 99,
+                                            host_address: String::new(),
                                         }],
                                     },
                                 )),
@@ -522,6 +524,7 @@ async fn test_ttrpc_interface(
                             vmservice::VirtioFs {
                                 tag: "hotplugfs".to_string(),
                                 root_path: hotplug_virtiofs_root.to_string_lossy().into(),
+                                read_only: false,
                             },
                         ))),
                     },
@@ -1034,6 +1037,7 @@ fn virtio_fs_vpci_request(
             vmservice::VirtioFs {
                 tag: tag.to_string(),
                 root_path: root_path.to_string_lossy().into_owned(),
+                read_only: false,
             },
         ))),
     }


### PR DESCRIPTION
Adds the ability to do the following over RPC:
- specify a host address for bind port calls 
- mark virtio-fs shares as readonly
- specify a path for crash dumps to be written to



